### PR TITLE
[Fix] Default regex to ignore User-Agent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ if (isNode) {
 }
 
 export const defaultOptions: IUnmockInternalOptions = {
-  ignore: {headers: "\w*User-Agent\w*"},
+  ignore: {headers: "\\w*User-Agent\\w*"},
   logger: isNode ?
     new (__non_webpack_require__("./logger/winston-logger").default)() :
     new (require("./logger/browser-logger").default)(),


### PR DESCRIPTION
The default ignore for User-Agent was using a single backslash, effectively escaping `w` in `\w`. When `JSON.stringify`ed, it translated to a simple `w`, and so the cloud would receive the following pattern to ignore: `w*User-Agentw*`.
That works fine for the specific `User-Agent` header (matches with 0 `w` before and after), but not for any other headers containing `User-Agent` in the name.