### PR TITLE
Add x-unmock-client-user-agent header

### DIFF
--- a/src/jsdom.ts
+++ b/src/jsdom.ts
@@ -1,6 +1,6 @@
 import { IUnmockInternalOptions } from "./unmock-options";
 import { buildPath, endReporter, hostIsWhitelisted,
-  UNMOCK_USER_AGENT_HEADER, unmockUserAgentHeaders } from "./util";
+  UNMOCK_UA_HEADER_NAME, unmockUAHeaderValue } from "./util";
 
 const UNMOCK_AUTH = "___u__n_m_o_c_k_a_u_t__h_";
 const XMLHttpRequestOpen = XMLHttpRequest.prototype.open;
@@ -120,7 +120,7 @@ export const initialize = (
     if (token) {
       this.setRequestHeader(UNMOCK_AUTH, `Bearer ${token}`);
     }
-    this.setRequestHeader(UNMOCK_USER_AGENT_HEADER, JSON.stringify(unmockUserAgentHeaders()));
+    this.setRequestHeader(UNMOCK_UA_HEADER_NAME, JSON.stringify(unmockUAHeaderValue()));
     return res;
   };
 };

--- a/src/jsdom.ts
+++ b/src/jsdom.ts
@@ -1,6 +1,6 @@
-import debug from "debug";
 import { IUnmockInternalOptions } from "./unmock-options";
-import { buildPath, endReporter, hostIsWhitelisted } from "./util";
+import { buildPath, endReporter, hostIsWhitelisted,
+  UNMOCK_USER_AGENT_HEADER, unmockClientUserAgentHeaders } from "./util";
 
 const UNMOCK_AUTH = "___u__n_m_o_c_k_a_u_t__h_";
 const XMLHttpRequestOpen = XMLHttpRequest.prototype.open;
@@ -120,6 +120,7 @@ export const initialize = (
     if (token) {
       this.setRequestHeader(UNMOCK_AUTH, `Bearer ${token}`);
     }
+    this.setRequestHeader(UNMOCK_USER_AGENT_HEADER, JSON.stringify(unmockClientUserAgentHeaders()));
     return res;
   };
 };

--- a/src/jsdom.ts
+++ b/src/jsdom.ts
@@ -1,6 +1,6 @@
 import { IUnmockInternalOptions } from "./unmock-options";
 import { buildPath, endReporter, hostIsWhitelisted,
-  UNMOCK_USER_AGENT_HEADER, unmockClientUserAgentHeaders } from "./util";
+  UNMOCK_USER_AGENT_HEADER, unmockUserAgentHeaders } from "./util";
 
 const UNMOCK_AUTH = "___u__n_m_o_c_k_a_u_t__h_";
 const XMLHttpRequestOpen = XMLHttpRequest.prototype.open;
@@ -120,7 +120,7 @@ export const initialize = (
     if (token) {
       this.setRequestHeader(UNMOCK_AUTH, `Bearer ${token}`);
     }
-    this.setRequestHeader(UNMOCK_USER_AGENT_HEADER, JSON.stringify(unmockClientUserAgentHeaders()));
+    this.setRequestHeader(UNMOCK_USER_AGENT_HEADER, JSON.stringify(unmockUserAgentHeaders()));
     return res;
   };
 };

--- a/src/node.ts
+++ b/src/node.ts
@@ -4,7 +4,7 @@ import https from "https";
 import { URL } from "url";
 import { IUnmockInternalOptions } from "./unmock-options";
 import { buildPath, endReporter, hostIsWhitelisted,
-  UNMOCK_USER_AGENT_HEADER, unmockUserAgentHeaders } from "./util";
+  UNMOCK_UA_HEADER_NAME, unmockUAHeaderValue } from "./util";
 
 const httpreq = fr.http.request;
 const httpreqmod = http.request;
@@ -127,7 +127,7 @@ const mHttp = (
       if (token) {
         output.setHeader("Authorization", `Bearer ${token}`);
       }
-      output.setHeader(UNMOCK_USER_AGENT_HEADER, JSON.stringify(unmockUserAgentHeaders()));
+      output.setHeader(UNMOCK_UA_HEADER_NAME, JSON.stringify(unmockUAHeaderValue()));
       const protoWrite = output.write;
       output.write = (d: Buffer, q?: any, z?: any) => {
         data = d;

--- a/src/node.ts
+++ b/src/node.ts
@@ -3,7 +3,8 @@ import http, { ClientRequest, IncomingMessage, RequestOptions } from "http";
 import https from "https";
 import { URL } from "url";
 import { IUnmockInternalOptions } from "./unmock-options";
-import { buildPath, endReporter, hostIsWhitelisted } from "./util";
+import { buildPath, endReporter, hostIsWhitelisted,
+  UNMOCK_USER_AGENT_HEADER, unmockUserAgentHeaders } from "./util";
 
 const httpreq = fr.http.request;
 const httpreqmod = http.request;
@@ -126,6 +127,7 @@ const mHttp = (
       if (token) {
         output.setHeader("Authorization", `Bearer ${token}`);
       }
+      output.setHeader(UNMOCK_USER_AGENT_HEADER, JSON.stringify(unmockUserAgentHeaders()));
       const protoWrite = output.write;
       output.write = (d: Buffer, q?: any, z?: any) => {
         data = d;

--- a/src/util.ts
+++ b/src/util.ts
@@ -61,3 +61,9 @@ export const endReporter = (
     }
   }
 };
+
+export const unmockUserAgentHeaders = () => {
+  return { lang: isNode ? "node" : "jsdom" };
+};
+
+export const UNMOCK_USER_AGENT_HEADER = "X-Unmock-Client-User-Agent";

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,8 +62,8 @@ export const endReporter = (
   }
 };
 
-export const unmockUserAgentHeaders = () => {
+export const unmockUAHeaderValue = () => {
   return { lang: isNode ? "node" : "jsdom" };
 };
 
-export const UNMOCK_USER_AGENT_HEADER = "X-Unmock-Client-User-Agent";
+export const UNMOCK_UA_HEADER_NAME = "X-Unmock-Client-User-Agent";


### PR DESCRIPTION
- Add `X-Unmock-Client-User-Agent ` header to outgoing requests so we know where requests are coming from
- Could probably add much more data to the object but thought it would suffice to start from simple
- Should not require server changes as `*User-Agent*` is ignored by default (probably should be ignored in server-side always anyway?)