### PR TITLE
[Feat] Updates the persistence layer to save metadata, and save response in one file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "unmock",
+  "displayName": "unmock-js",
   "version": "0.0.39",
   "main": "dist/index.js",
   "bin": {
@@ -40,6 +41,7 @@
   "dependencies": {
     "@types/detect-node": "^2.0.0",
     "@types/ini": "^1.3.30",
+    "@types/js-yaml": "^3.12.0",
     "@types/mkdirp": "^0.5.2",
     "axios": "^0.18.0",
     "cli-spinner": "^0.2.8",
@@ -47,6 +49,7 @@
     "detect-node": "^2.0.4",
     "follow-redirects": "^1.5.9",
     "ini": "^1.3.5",
+    "js-yaml": "^3.13.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.3.0",
     "ora": "^3.0.0",

--- a/src/jsdom.ts
+++ b/src/jsdom.ts
@@ -96,7 +96,13 @@ export const initialize = (
               save,
               selfcall,
               story.story,
-              token !== undefined);
+              token !== undefined,
+              {
+                requestHeaders: headerz,
+                requestHost: ro.host || ro.hostname,
+                requestMethod: method,
+                requestPath: ro.pathname,
+              });
           }
         }
         if (typeof onreadystatechange === "function") {

--- a/src/node.ts
+++ b/src/node.ts
@@ -85,7 +85,7 @@ const mHttp = (
       }
       // content being written or end of call!
       const resp = (res: IncomingMessage) => {
-        const protoOn = res.on  ;
+        const protoOn = res.on;
         res.on = (s: string, f: any) => {
           if (s === "data") {
             return protoOn.apply(res, [s, (d: any) => {

--- a/src/node.ts
+++ b/src/node.ts
@@ -27,19 +27,20 @@ export const initialize = (story: {story: string[]}, token: string | undefined, 
 const mHttp = (
   story: {story: string[]},
   token: string | undefined,
-  { logger, persistence, unmockHost, unmockPort, signature, save, ignore, whitelist }: IUnmockInternalOptions, cb: {
-    (
-        options: string | http.RequestOptions | URL,
-        callback?: ((res: http.IncomingMessage) => void) | undefined): http.ClientRequest;
-    (
-        url: string | URL,
-        options: http.RequestOptions,
-        callback?: ((res: http.IncomingMessage) => void) | undefined): http.ClientRequest;
+  { logger, persistence, unmockHost, unmockPort, signature, save, ignore, whitelist }: IUnmockInternalOptions,
+  cb: {
+    // tslint:disable-next-line:max-line-length
+    (options: string | http.RequestOptions | URL, callback?: ((res: http.IncomingMessage) => void) | undefined): http.ClientRequest;
+    // tslint:disable-next-line:max-line-length
+    (url: string | URL, options: http.RequestOptions, callback?: ((res: http.IncomingMessage) => void) | undefined): http.ClientRequest;
   }) => {
-  return (
-    first: RequestOptions | string | URL,
-    second: RequestOptions | ((res: IncomingMessage) => void) | undefined,
-    third?: (res: IncomingMessage) => void): ClientRequest => {
+    // Return a function that will work for the overloaded methods
+    // parameters will correspond to either of the following signatures:
+    // request(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
+    // request(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+  return (first: RequestOptions | string | URL,
+          second: RequestOptions | ((res: IncomingMessage) => void) | undefined,
+          third?: (res: IncomingMessage) => void): ClientRequest => {
       let data: {} | null = null;
       let selfcall = false;
       const responseData: Buffer[] = [];
@@ -82,8 +83,9 @@ const mHttp = (
         // self call, we ignore
         selfcall = true;
       }
+      // content being written or end of call!
       const resp = (res: IncomingMessage) => {
-        const protoOn = res.on;
+        const protoOn = res.on  ;
         res.on = (s: string, f: any) => {
           if (s === "data") {
             return protoOn.apply(res, [s, (d: any) => {
@@ -107,7 +109,13 @@ const mHttp = (
                 save,
                 selfcall,
                 story.story,
-                token !== undefined);
+                token !== undefined,
+                {
+                  requestHeaders: ro.headers,
+                  requestHost: ro.hostname || ro.host || "",
+                  requestMethod: ro.method || "",
+                  requestPath: ro.path || "",
+                });
               // https://github.com/nodejs/node/blob/master/lib/_http_client.js
               // the original res.on('end') has a closure that refers to this
               // as far as i can understand, 'this' is supposed to refer to res

--- a/src/persistence/fs-persistence.ts
+++ b/src/persistence/fs-persistence.ts
@@ -29,7 +29,7 @@ export default class FSPersistence implements IPersistence {
     // Now add the new data as needed
     const newData = {...existingData, ...data};
     // And save...
-    fs.writeFileSync(target, yml.safeDump(newData, { indent: 2 }), "utf-8");
+    fs.writeFileSync(target, yml.safeDump(newData, { indent: 2 }));
   }
 
   public saveHeaders(hash: string, headers: {[key: string]: string}) {

--- a/src/persistence/fs-persistence.ts
+++ b/src/persistence/fs-persistence.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as ini from "ini";
 import * as yml from "js-yaml";
 import * as mkdirp from "mkdirp";
+import * as os from "os";
 import * as path from "path";
 import { IPersistence } from "./persistence";
 
@@ -11,6 +12,7 @@ const CONFIG_FILE = "credentials";
 const TOKEN_PATH = path.join(UNMOCK_DIR, TOKEN_FILE);
 const CONFIG_PATH = path.join(UNMOCK_DIR, CONFIG_FILE);
 const SAVE_PATH = path.join(UNMOCK_DIR, "save");
+const SECONDARY_CONFIG_PATH = path.join(os.homedir(), UNMOCK_DIR, CONFIG_FILE);
 const RESPONSE_FILE = "response.json";
 const METADATA_FILE = "metadata.unmock.yml";
 const DATA_KEY = "body";
@@ -70,10 +72,14 @@ export default class FSPersistence implements IPersistence {
     if (this.token) {
       return this.token;
     }
-    if (!fs.existsSync(CONFIG_PATH)) {
-      return;
+    let configPath = CONFIG_PATH;
+    if (!fs.existsSync(configPath)) {
+      configPath = SECONDARY_CONFIG_PATH;
+      if (!fs.existsSync(configPath)) {
+        return;
+      }
     }
-    const config = ini.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+    const config = ini.parse(fs.readFileSync(configPath, "utf-8"));
     return config.unmock.token;
   }
 

--- a/src/persistence/fs-persistence.ts
+++ b/src/persistence/fs-persistence.ts
@@ -27,13 +27,9 @@ export default class FSPersistence implements IPersistence {
     // First attempt to load existing data
     const existingData = fs.existsSync(target) ? yml.safeLoad(fs.readFileSync(target, "utf-8")) : {};
     // Now add the new data as needed
-    for (const key of Object.keys(data)) {
-      existingData[key] = data[key];
-    }
+    const newData = {...existingData, ...data};
     // And save...
-    fs.writeFileSync(target, yml.safeDump(existingData, {
-      indent: 2,
-    }), "utf-8");
+    fs.writeFileSync(target, yml.safeDump(newData, { indent: 2 }), "utf-8");
   }
 
   public saveHeaders(hash: string, headers: {[key: string]: string}) {

--- a/src/persistence/fs-persistence.ts
+++ b/src/persistence/fs-persistence.ts
@@ -22,12 +22,10 @@ export default class FSPersistence implements IPersistence {
 
   public saveHeaders(hash: string, headers: {[key: string]: string}) {
     this.saveContents(hash, HEADER_KEY, headers);
-    // fs.writeFileSync(path.join(this.outdir(hash), RESPONSE_FILE), JSON.stringify(headers, null, 2));
   }
 
   public saveBody(hash: string, body: string) {
     this.saveContents(hash, DATA_KEY, body || "");
-    // fs.writeFileSync(path.join(this.outdir(hash), RESPONSE_FILE), JSON.stringify(JSON.parse(body || ""), null, 2));
   }
 
   public saveAuth(auth: string) {

--- a/src/persistence/fs-persistence.ts
+++ b/src/persistence/fs-persistence.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as ini from "ini";
+import * as yml from "js-yaml";
 import * as mkdirp from "mkdirp";
 import * as path from "path";
 import { IPersistence } from "./persistence";
@@ -11,6 +12,7 @@ const TOKEN_PATH = path.join(UNMOCK_DIR, TOKEN_FILE);
 const CONFIG_PATH = path.join(UNMOCK_DIR, CONFIG_FILE);
 const SAVE_PATH = path.join(UNMOCK_DIR, "save");
 const RESPONSE_FILE = "response.json";
+const METADATA_FILE = "metadata.unmock.yml";
 const DATA_KEY = "body";
 const HEADER_KEY = "headers";
 
@@ -18,6 +20,20 @@ export default class FSPersistence implements IPersistence {
   private token: string | undefined;
 
   constructor(private savePath = SAVE_PATH) {
+  }
+
+  public saveMetadata(hash: string, data: {[key: string]: string}) {
+    const target = this.outdir(hash, METADATA_FILE);
+    // First attempt to load existing data
+    const existingData = fs.existsSync(target) ? yml.safeLoad(fs.readFileSync(target, "utf-8")) : {};
+    // Now add the new data as needed
+    for (const key of Object.keys(data)) {
+      existingData[key] = data[key];
+    }
+    // And save...
+    fs.writeFileSync(target, yml.safeDump(existingData, {
+      indent: 2,
+    }), "utf-8");
   }
 
   public saveHeaders(hash: string, headers: {[key: string]: string}) {

--- a/src/persistence/fs-persistence.ts
+++ b/src/persistence/fs-persistence.ts
@@ -74,8 +74,7 @@ export default class FSPersistence implements IPersistence {
   }
 
   private loadContents(hash: string, key: string) {
-    const target = this.outdir(hash, RESPONSE_FILE);
-    const contents = fs.existsSync(target) ? JSON.parse(fs.readFileSync(target, "utf-8")) : {};
+    const contents = this.loadContentOrEmpty(hash);
     if (contents.hasOwnProperty(key)) {
       return contents[key];
     }
@@ -84,8 +83,13 @@ export default class FSPersistence implements IPersistence {
 
   private saveContents(hash: string, key: string, data: any) {
     const target = this.outdir(hash, RESPONSE_FILE);
-    const contents = fs.existsSync(target) ? JSON.parse(fs.readFileSync(target, "utf-8")) : {};
+    const contents = this.loadContentOrEmpty(hash);
     contents[key] = data;
     fs.writeFileSync(target, JSON.stringify(contents, null, 2));
+  }
+
+  private loadContentOrEmpty(hash: string) {
+    const target = this.outdir(hash, RESPONSE_FILE);
+    return fs.existsSync(target) ? JSON.parse(fs.readFileSync(target, "utf-8")) : {};
   }
 }

--- a/src/persistence/local-storage-persistence.ts
+++ b/src/persistence/local-storage-persistence.ts
@@ -23,13 +23,9 @@ export default class LocalStoragePersistence implements IPersistence {
     // First attempt to load existing data
     const existingData = window.localStorage[target] ? yml.safeLoad(window.localStorage[target]) : {};
     // Now add the new data as needed
-    for (const key of Object.keys(data)) {
-      existingData[key] = data[key];
-    }
+    const newData = {...existingData, ...data};
     // And save...
-    window.localStorage[target] = yml.safeDump(existingData, {
-      indent: 2,
-    });
+    window.localStorage[target] = yml.safeDump(newData, { indent: 2 });
   }
 
   public saveHeaders(hash: string, headers: {[key: string]: string}) {

--- a/src/persistence/local-storage-persistence.ts
+++ b/src/persistence/local-storage-persistence.ts
@@ -1,42 +1,77 @@
+import * as path from "path";
 import { IPersistence } from "./persistence";
 
-const UNMOCK = ".unmock";
-const AUTH = ".token";
-const TOKEN = ".access-token";
-const TOKEN_KEY = `${UNMOCK}/${TOKEN}`;
-const AUTH_KEY = `${UNMOCK}/${AUTH}`;
+// Uses directory structure for keys in window local storage
+const UNMOCK_KEY = ".unmock";
+const TOKEN_KEY = ".token";
+const TOKEN_FULL_KEY = path.join(UNMOCK_KEY, TOKEN_KEY);
+const SAVE_PATH = path.join(UNMOCK_KEY, "save");
+const RESPONSE_FILE = "response.json";
+const DATA_KEY = "body";
+const HEADER_KEY = "headers";
 
 export default class LocalStoragePersistence implements IPersistence {
   private token: string | undefined;
+
+  constructor(private savePath = SAVE_PATH) {
+  }
+
   public saveHeaders(hash: string, headers: {[key: string]: string}) {
-    window.localStorage[`${this.outdir(hash)}/response-header.json`] = JSON.stringify(headers, null, 2);
+    this.saveContents(hash, HEADER_KEY, headers);
   }
+
   public saveBody(hash: string, body: string) {
-    window.localStorage[`${this.outdir(hash)}/response.json`] = JSON.stringify(JSON.parse(body || ""), null, 2);
+    this.saveContents(hash, DATA_KEY, body || "");
   }
+
   public saveAuth(auth: string) {
-    window.localStorage[AUTH_KEY] = auth;
+    window.localStorage[TOKEN_FULL_KEY] = auth;
   }
+
   public saveToken(token: string) {
-    // we never save the token to the browser
-    // only ever in memory
+    // we never save the token to the browser only ever in memory
     this.token = token;
   }
+
   public loadHeaders(hash: string) {
-    const out = window.localStorage[`${this.outdir(hash)}/response-header.json`];
-    return out ? JSON.parse(out) : {};
+    return this.loadContents(hash, HEADER_KEY);
   }
+
   public loadBody(hash: string) {
-    return window.localStorage[`${this.outdir(hash)}/response.json`];
+    return this.loadContents(hash, DATA_KEY);
   }
+
   public loadAuth() {
-    return window.localStorage[AUTH_KEY];
+    return window.localStorage[TOKEN_FULL_KEY];
   }
+
   public loadToken() {
     return this.token;
   }
-  private outdir(hash: string) {
-    const outdir = `.unmock/save/${hash}`;
-    return outdir;
+
+  private outdir(hash: string, ...args: string[]) {
+    const outdir = path.normalize(path.join(this.savePath, hash));
+    return path.join(outdir, ...args);
+  }
+
+  private loadContents(hash: string, key: string) {
+    const contents = this.loadContentsOrEmpty(hash);
+    if (contents.hasOwnProperty(key)) {
+      return contents[key];
+    }
+    return {};
+  }
+
+  private saveContents(hash: string, key: string, data: any) {
+    const contents = this.loadContentsOrEmpty(hash);
+    const target = this.outdir(hash, RESPONSE_FILE);
+    contents[key] = data;
+    window.localStorage[target] = JSON.stringify(contents, null, 2);
+  }
+
+  private loadContentsOrEmpty(hash: string) {
+    const target = this.outdir(hash, RESPONSE_FILE);
+    const contents = window.localStorage[target];
+    return contents ? JSON.parse(contents) : {};
   }
 }

--- a/src/persistence/persistence.ts
+++ b/src/persistence/persistence.ts
@@ -3,6 +3,7 @@ export interface IPersistence {
   saveBody: (hash: string, body: string) => void;
   saveAuth: (auth: string) => void;
   saveToken: (token: string) => void;
+  saveMetadata: (hash: string, data: {[key: string]: string}) => void;
   loadHeaders: (hash: string) => {[key: string]: string} | void;
   loadBody: (hash: string) => string | void;
   loadAuth: () => string | void;

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,12 +1,6 @@
 import axios from "axios";
 import { IUnmockInternalOptions } from "./unmock-options";
 
-const UNMOCK_DIR = ".unmock";
-const TOKEN_FILE = ".token";
-const CONFIG_FILE = "credentials";
-const TOKEN_PATH = `${UNMOCK_DIR}/${TOKEN_FILE}`;
-const CONFIG_PATH = `${UNMOCK_DIR}/${CONFIG_FILE}`;
-
 const makeHeader = (token: string) => ({
   headers: {
     Authorization: `Bearer ${token}`,

--- a/src/util.ts
+++ b/src/util.ts
@@ -66,11 +66,7 @@ export const endReporter = (
         if (originalRequest !== undefined) {
           persistence.saveMetadata(hash, originalRequest);
         }
-        const clientData = require("../package.json");
-        persistence.saveMetadata(hash, {
-          unmockClient: clientData.displayName,
-          unmockClientVersion: clientData.version,
-        });
+        persistence.saveMetadata(hash, unmockUAHeaderValue());
         if (body) {
           persistence.saveBody(hash, body);
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,9 +19,6 @@ export const hostIsWhitelisted =
       ((host && whitelist.indexOf(host) !== -1)
         || (hostname && whitelist.indexOf(hostname) !== -1));
 
-// TODO: buildPath and endReporter have to be made easier and simpler to use...
-//        --> perhaps part of UnmockOptions as it is in unmock-python?
-
 export const buildPath =
   (
     headerz: any,

--- a/test/jsdom.test.ts
+++ b/test/jsdom.test.ts
@@ -6,12 +6,13 @@ import axios from "axios";
 import { kcomnu, unmock } from "../dist";
 
 beforeEach(async () => {
-    require("dotenv").config();
-    await unmock({
-        token: process.env.UNMOCK_TOKEN,
-        unmockHost: process.env.UNMOCK_HOST,
-        unmockPort: process.env.UNMOCK_PORT,
-    });
+  require("dotenv").config();
+  await unmock({
+      save: true,
+      token: process.env.UNMOCK_TOKEN,
+      unmockHost: process.env.UNMOCK_HOST,
+      unmockPort: process.env.UNMOCK_PORT,
+  });
 });
 afterEach(async () => await kcomnu());
 

--- a/test/no-story.test.ts
+++ b/test/no-story.test.ts
@@ -9,6 +9,7 @@ beforeEach(async () => {
     require("dotenv").config();
     await unmock({
         ignore: "story",
+        save: true,
         token: process.env.UNMOCK_TOKEN,
         unmockHost: process.env.UNMOCK_HOST,
         unmockPort: process.env.UNMOCK_PORT,

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -6,12 +6,13 @@ import axios from "axios";
 import { kcomnu, unmock } from "../dist";
 
 beforeEach(async () => {
-    require("dotenv").config();
-    await unmock({
-        token: process.env.UNMOCK_TOKEN,
-        unmockHost: process.env.UNMOCK_HOST,
-        unmockPort: process.env.UNMOCK_PORT,
-    });
+  require("dotenv").config();
+  await unmock({
+    save: true,
+    token: process.env.UNMOCK_TOKEN,
+    unmockHost: process.env.UNMOCK_HOST,
+    unmockPort: process.env.UNMOCK_PORT,
+  });
 });
 afterEach(async () => await kcomnu());
 

--- a/test/whitelist.test.ts
+++ b/test/whitelist.test.ts
@@ -9,6 +9,7 @@ import { kcomnu, unmock } from "../dist";
 beforeEach(async () => {
     require("dotenv").config();
     await unmock({
+        save: true,
         token: process.env.UNMOCK_TOKEN,
         unmockHost: process.env.UNMOCK_HOST,
         unmockPort: process.env.UNMOCK_PORT,

--- a/test/with-credentials.test.ts
+++ b/test/with-credentials.test.ts
@@ -9,15 +9,14 @@ import { kcomnu, unmock } from "../dist";
 
 beforeEach(async () => {
   require("dotenv").config();
-  const CREDENTIALS = `[unmock]
-token=${process.env.UNMOCK_TOKEN}
-`;
+  const CREDENTIALS = `[unmock]\ntoken=${process.env.UNMOCK_TOKEN}\n`;
   rimraf.sync(".unmock");
   fs.mkdirSync(".unmock");
   fs.writeFileSync(".unmock/credentials", CREDENTIALS);
   await unmock({
-      unmockHost: process.env.UNMOCK_HOST,
-      unmockPort: process.env.UNMOCK_PORT,
+    save: true,
+    unmockHost: process.env.UNMOCK_HOST,
+    unmockPort: process.env.UNMOCK_PORT,
   });
 });
 

--- a/test/with-credentials.test.ts
+++ b/test/with-credentials.test.ts
@@ -4,14 +4,15 @@
 
 import axios from "axios";
 import fs from "fs";
+import * as mkdirp from "mkdirp";
 import * as rimraf from "rimraf";
 import { kcomnu, unmock } from "../dist";
 
 beforeEach(async () => {
   require("dotenv").config();
   const CREDENTIALS = `[unmock]\ntoken=${process.env.UNMOCK_TOKEN}\n`;
-  rimraf.sync(".unmock");
-  fs.mkdirSync(".unmock");
+  rimraf.sync(".unmock/!(save)");
+  mkdirp.sync(".unmock");
   fs.writeFileSync(".unmock/credentials", CREDENTIALS);
   await unmock({
     save: true,

--- a/test/without-credentials-with-signature.test.ts
+++ b/test/without-credentials-with-signature.test.ts
@@ -8,9 +8,10 @@ import { kcomnu, unmock } from "../dist";
 beforeEach(async () => {
   require("dotenv").config();
   await unmock({
-      signature: process.env.UNMOCK_SIGNATURE,
-      unmockHost: process.env.UNMOCK_HOST,
-      unmockPort: process.env.UNMOCK_PORT,
+    save: true,
+    signature: process.env.UNMOCK_SIGNATURE,
+    unmockHost: process.env.UNMOCK_HOST,
+    unmockPort: process.env.UNMOCK_PORT,
   });
 });
 

--- a/test/without-credentials-without-signature.test.ts
+++ b/test/without-credentials-without-signature.test.ts
@@ -8,8 +8,9 @@ import { kcomnu, unmock } from "../dist";
 beforeEach(async () => {
   require("dotenv").config();
   await unmock({
-      unmockHost: process.env.UNMOCK_HOST,
-      unmockPort: process.env.UNMOCK_PORT,
+    save: true,
+    unmockHost: process.env.UNMOCK_HOST,
+    unmockPort: process.env.UNMOCK_PORT,
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.9.tgz#c16b55186ee73ae65e001fbee69d392c51337ad1"
   integrity sha512-wNMwXSUcwyYajtbayfPp55tSayuDVU6PfY5gzvRSj80UvxdXEJOVPnUVajaOp7NgXLm+1e2ZDLULmpsU9vDvQw==
 
+"@types/js-yaml@^3.12.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.0.tgz#3494ce97358e2675e24e97a747ec23478eeaf8b6"
+  integrity sha512-UGEe/6RsNAxgWdknhzFZbCxuYc5I7b/YEKlfKbo+76SM8CJzGs7XKCj7zyugXViRbKYpXhSXhCYVQZL5tmDbpQ==
+
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
@@ -2457,6 +2462,14 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
+js-yaml@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
+  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@^3.7.0:
   version "3.12.0"


### PR DESCRIPTION
- Saves response in `response.json` with headers under `headers` key and response body under `body` key.
- Saves an `unmock.metadata.yml` file that writes basic data about the original request and basic information about the client being used.
- Simplifies some of the read/write action in the persistence layers.
- Adds a `save: true` to tests for manual checking of returned mocks.

:arrow_right: 
- [x] Once approved, implement the same in `unmock-python`
- [ ] Future PR: simplify the `utils` library