### PR TITLE
Fix "X-Unmock-Client-User-Agent" header

### DIFF
--- a/packages/unmock-jsdom/src/backend/index.ts
+++ b/packages/unmock-jsdom/src/backend/index.ts
@@ -228,7 +228,10 @@ export default class JSDomBackend implements IBackend {
       if (token) {
         this.setRequestHeader(UNMOCK_AUTH, `Bearer ${token}`);
       }
-      this.setRequestHeader(UNMOCK_UA_HEADER_NAME, JSON.stringify("jsdom"));
+      this.setRequestHeader(
+        UNMOCK_UA_HEADER_NAME,
+        JSON.stringify({ lang: "jsdom" }),
+      );
       return res;
     };
   }

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -37,11 +37,18 @@ const mHttp = (
 ) => {
   const { host, ...rawHeaders } = req.headers;
   const reqHost = (host || "").split(":")[0];
-  const { actions, signature, ignore, persistence, unmockHost, unmockPort } = opts;
+  const {
+    actions,
+    signature,
+    ignore,
+    persistence,
+    unmockHost,
+    unmockPort,
+  } = opts;
   const { method, url } = req;
 
   const unmockHeaders = {
-    [UNMOCK_UA_HEADER_NAME]: "node",
+    [UNMOCK_UA_HEADER_NAME]: JSON.stringify({ lang: "node" }),
     ...(token ? makeAuthHeader(token).headers : {}),
   };
   const outgoingData: Buffer[] = [];


### PR DESCRIPTION
Header should be an object with `lang` field. Could also have some extra information soon that the Python version [has](https://github.com/unmock/unmock-python/pull/40/files#diff-e1a3c2a9fa94d09fcb2f0f9624a86903R19).