### PR TITLE
Handle headers in request and response

### DIFF
--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -33,13 +33,13 @@ export interface IUnmockOptions {
   useInProduction?: boolean;
 }
 
-// Similar to `HttpIncomingHeaders` in Node.js
+// Similar to `IncomingHttpHeaders` in @types/node
 export interface IIncomingHeaders {
   [header: string]: string | string[] | undefined;
 }
 
-// Similar to `HttpOutgoingHeaders` in Node.js, allows numbers as they are
-// converted to strings internally
+// Similar to `OutgoingHttpHeaders` in @types/node
+// Allows numbers as they are converted to strings internally
 export interface IOutgoingHeaders {
   [header: string]: string | string[] | number | undefined;
 }

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -33,13 +33,20 @@ export interface IUnmockOptions {
   useInProduction?: boolean;
 }
 
-interface IHeaders {
-  [key: string]: string;
+// Similar to `HttpIncomingHeaders` in Node.js
+export interface IIncomingHeaders {
+  [header: string]: string | string[] | undefined;
+}
+
+// Similar to `HttpOutgoingHeaders` in Node.js, allows numbers as they are
+// converted to strings internally
+export interface IOutgoingHeaders {
+  [header: string]: string | string[] | number | undefined;
 }
 
 export interface ISerializedRequest {
   body?: string;
-  headers?: IHeaders;
+  headers?: IIncomingHeaders;
   host: string;
   method: string;
   path: string;
@@ -52,7 +59,7 @@ export type IMockRequest = {
 
 export interface ISerializedResponse {
   body?: string;
-  headers?: IHeaders;
+  headers?: IOutgoingHeaders;
   statusCode: number;
 }
 

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -33,13 +33,18 @@ export interface IUnmockOptions {
   useInProduction?: boolean;
 }
 
-// Similar to `IncomingHttpHeaders` in @types/node
+/**
+ * Analogous to `IncomingHttpHeaders` in @types/node.
+ * Header names are expected to be _lowercased_.
+ */
 export interface IIncomingHeaders {
   [header: string]: string | string[] | undefined;
 }
 
-// Similar to `OutgoingHttpHeaders` in @types/node
-// Allows numbers as they are converted to strings internally
+/**
+ * Analogous to `OutgoingHttpHeaders` in @types/node.
+ * Allows numbers as they are converted to strings internally.
+ */
 export interface IOutgoingHeaders {
   [header: string]: string | string[] | number | undefined;
 }

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -28,7 +28,11 @@ describe("Node.js interceptor", () => {
     const responseBody = "something here";
     const mock: IMock = {
       request: {},
-      response: { statusCode: 200, body: responseBody },
+      response: {
+        body: responseBody,
+        headers: { "x-awesome": 300 },
+        statusCode: 200,
+      },
     };
     let nodeInterceptor: NodeBackend;
     beforeEach(() => {
@@ -45,6 +49,7 @@ describe("Node.js interceptor", () => {
       const data = response.data;
       expect(data).toBeDefined();
       expect(data).toBe(responseBody);
+      expect(response.headers["x-awesome"]).toBe("300");
     });
   });
 });

--- a/packages/unmock-node/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-node/src/__tests__/serialize/index.test.ts
@@ -1,4 +1,4 @@
-import http, { IncomingMessage } from "http";
+import http, { IncomingMessage, request } from "http";
 import https from "https";
 import Mitm from "mitm";
 import { serializeRequest } from "../../serialize";
@@ -64,6 +64,13 @@ describe("Request serializer", () => {
       expect(serializedRequest.method.toLowerCase()).toBe("post");
       expect(serializedRequest.body).toBe(`{"message":"${message}"}`);
       expect(serializedRequest.protocol).toBe("https");
+      const requestHeaders = serializedRequest.headers;
+      if (requestHeaders === undefined) {
+        throw new Error("Request headers undefined");
+      }
+      expect(requestHeaders["content-type"]).toBe("application/json");
+      expect(requestHeaders["content-length"]).toBe("25");
+      expect(requestHeaders["host"]).toBeUndefined();
       done();
     });
 

--- a/packages/unmock-node/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-node/src/__tests__/serialize/index.test.ts
@@ -70,7 +70,7 @@ describe("Request serializer", () => {
       }
       expect(requestHeaders["content-type"]).toBe("application/json");
       expect(requestHeaders["content-length"]).toBe("25");
-      expect(requestHeaders["host"]).toBeUndefined();
+      expect(requestHeaders.host).toBe("example.org");
       done();
     });
 

--- a/packages/unmock-node/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-node/src/__tests__/serialize/index.test.ts
@@ -1,4 +1,4 @@
-import http, { IncomingMessage, request } from "http";
+import http, { IncomingMessage } from "http";
 import https from "https";
 import Mitm from "mitm";
 import { serializeRequest } from "../../serialize";

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -16,8 +16,15 @@ const respondFromSerializedResponse = (
   serializedResponse: ISerializedResponse,
   res: ServerResponse,
 ) => {
-  // TODO Headers
   res.statusCode = serializedResponse.statusCode;
+
+  const responseHeaders = serializedResponse.headers;
+  if (responseHeaders) {
+    Object.keys(responseHeaders).forEach((headerKey: string) => {
+      res.setHeader(headerKey, responseHeaders[headerKey]);
+    });
+  }
+
   res.write(serializedResponse.body || "");
   res.end();
 };

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -20,8 +20,10 @@ const respondFromSerializedResponse = (
 
   const responseHeaders = serializedResponse.headers;
   if (responseHeaders) {
-    Object.keys(responseHeaders).forEach((headerKey: string) => {
-      res.setHeader(headerKey, responseHeaders[headerKey]);
+    Object.entries(responseHeaders).forEach(([k, v]) => {
+      if (v) {
+        res.setHeader(k, v);
+      }
     });
   }
 

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -16,19 +16,8 @@ const respondFromSerializedResponse = (
   serializedResponse: ISerializedResponse,
   res: ServerResponse,
 ) => {
-  res.statusCode = serializedResponse.statusCode;
-
-  const responseHeaders = serializedResponse.headers;
-  if (responseHeaders) {
-    Object.entries(responseHeaders).forEach(([k, v]) => {
-      if (v) {
-        res.setHeader(k, v);
-      }
-    });
-  }
-
-  res.write(serializedResponse.body || "");
-  res.end();
+  res.writeHead(serializedResponse.statusCode, serializedResponse.headers):
+  res.end(serializedResponse.body);
 };
 
 async function handleRequestAndResponse(

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -46,10 +46,12 @@ async function handleRequestAndResponse(
     }
     respondFromSerializedResponse(serializedResponse, res);
   } catch (err) {
-    // TODO Emit an error in the corresponding client request
-    res.statusCode = constants.STATUS_CODE_FOR_ERROR;
-    res.write(err.message);
-    res.end();
+    // TODO Emit an error in the corresponding client request instead?
+    const errorResponse: ISerializedResponse = {
+      body: err.message,
+      statusCode: constants.STATUS_CODE_FOR_ERROR,
+    };
+    respondFromSerializedResponse(errorResponse, res);
   }
 }
 

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -16,7 +16,7 @@ const respondFromSerializedResponse = (
   serializedResponse: ISerializedResponse,
   res: ServerResponse,
 ) => {
-  res.writeHead(serializedResponse.statusCode, serializedResponse.headers):
+  res.writeHead(serializedResponse.statusCode, serializedResponse.headers);
   res.end(serializedResponse.body);
 };
 

--- a/packages/unmock-node/src/serialize/index.ts
+++ b/packages/unmock-node/src/serialize/index.ts
@@ -1,6 +1,6 @@
 import * as http from "http";
 import * as readable from "readable-stream";
-import { ISerializedRequest } from "unmock-core";
+import { IIncomingHeaders, ISerializedRequest } from "unmock-core";
 import url from "url";
 
 /**
@@ -36,9 +36,11 @@ function extractVars(
   method: string;
   host: string;
   path: string;
-  headers: { [key: string]: string };
+  headers: IIncomingHeaders;
 } {
-  const { host: hostWithPort, ...headers } = interceptedRequest.headers;
+  const headers = interceptedRequest.headers;
+
+  const hostWithPort = headers.host;
 
   if (!hostWithPort) {
     throw new Error("No host");
@@ -61,7 +63,7 @@ function extractVars(
   }
 
   return {
-    headers: headers as { [key: string]: string },
+    headers,
     host,
     method,
     path,
@@ -75,7 +77,7 @@ function extractVars(
 export const serializeRequest = async (
   interceptedRequest: http.IncomingMessage,
 ): Promise<ISerializedRequest> => {
-  const { method, path, host, headers } = extractVars(interceptedRequest);
+  const { headers, host, method, path } = extractVars(interceptedRequest);
 
   const isEncrypted = (interceptedRequest.connection as any).encrypted;
   const protocol = isEncrypted ? "https" : "http";


### PR DESCRIPTION
- Add headers to `ISerializedRequest`. In unmock 0.0, `host` header was dropped from the serialized request, but I don't think there's any reason to do that here
- Add headers to the returned response with `res.setHeader`
- Add separate interfaces for incoming and outgoing headers, as they have different types in Node.js: outgoing headers allow numbers, as `res.setHeader(k, v)` allows that, and I don't see why the serialized response would not allow a number.
- Also permit more types to headers: `string[]`, `undefined` as Node.js allows this, unmock 0.0 did a type-cast to `{ [key: string]: string }` but I think that should be avoided unless required somewhere later on
