### PR TITLE
Simplify ServiceStore instantiation

### DIFF
--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -3,12 +3,17 @@ import { Service } from "../service/service";
 
 describe("Fluent API and Service instantiation tests", () => {
   // define some service populators that match IOASMappingGenerator type
-  const PetStoreWithoutPaths = { petstore: new Service({}, "petstore") };
+  const PetStoreWithoutPaths = {
+    petstore: new Service({ schema: {}, name: "petstore" }),
+  };
   const PetStoreWithEmptyPaths = {
-    petstore: new Service({ paths: {} }, "petstore"),
+    petstore: new Service({ schema: { paths: {} }, name: "petstore" }),
   };
   const PetStoreWithPseudoPaths = {
-    petstore: new Service({ paths: { "/pets": { get: {} } } }, "petstore"),
+    petstore: new Service({
+      schema: { paths: { "/pets": { get: {} } } },
+      name: "petstore",
+    }),
   };
 
   test("Store without paths", () => {
@@ -97,8 +102,8 @@ describe("Test paths matching on serviceStore", () => {
   ) => {
     const path = `/pets/{petId}${additionalPathElement.join("/")}`;
     return {
-      petstore: new Service(
-        {
+      petstore: new Service({
+        schema: {
           paths: {
             [path]: {
               get: {
@@ -113,8 +118,8 @@ describe("Test paths matching on serviceStore", () => {
             },
           },
         },
-        "petstore",
-      ),
+        name: "petstore",
+      }),
     };
   };
 

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -1,42 +1,45 @@
-import { serviceStoreFactory } from "../service";
+import { stateStoreFactory } from "../service";
+import { Service } from "../service/service";
 
 describe("Fluent API and Service instantiation tests", () => {
   // define some service populators that match IOASMappingGenerator type
-  const NoPathsServicePopulator = () => ({ petstore: {} });
-  const EmptyPathsServicePopulator = () => ({ petstore: { paths: {} } });
-  const PetsPathsServicePopulator = () => ({
-    petstore: { paths: { "/pets": { get: {} } } },
-  });
+  const PetStoreWithoutPaths = { petstore: new Service({}, "petstore") };
+  const PetStoreWithEmptyPaths = {
+    petstore: new Service({ paths: {} }, "petstore"),
+  };
+  const PetStoreWithPseudoPaths = {
+    petstore: new Service({ paths: { "/pets": { get: {} } } }, "petstore"),
+  };
 
   test("Store without paths", () => {
-    const store = serviceStoreFactory(NoPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithoutPaths);
     expect(store.noservice).toThrow("Can't find specification");
     expect(store.petstore).toThrow("has no defined paths");
   });
 
   test("Store with empty paths", () => {
-    const store = serviceStoreFactory(EmptyPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithEmptyPaths);
     expect(store.petstore).toThrow("has no defined paths");
     expect(store.petstore.get).toThrow("has no defined paths");
   });
 
   test("Store with non-empty paths with non-matching method", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     expect(store.petstore.post).toThrow("Can't find any endpoints with method");
   });
 
   test("Store with basic call", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     store.petstore(); // Should pass
   });
 
   test("Store with REST method call", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     store.petstore.get(); // Should pass
   });
 
   test("Chaining multiple states without REST methods", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     store
       .petstore()
       .petstore()
@@ -44,7 +47,7 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   test("Chaining multiple states with REST methods", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     store.petstore
       .get()
       .petstore.get()
@@ -52,7 +55,7 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   test("Chaining multiple methods for a service", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     store.petstore
       .get()
       .get()
@@ -62,13 +65,13 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   test("Specifying endpoint without rest method", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     store.petstore("/pets"); // should pass
     expect(() => store.petstore("/pet")).toThrow("Can't find endpoint");
   });
 
   test("Specifying endpoint with rest method", () => {
-    const store = serviceStoreFactory(PetsPathsServicePopulator);
+    const store = stateStoreFactory(PetStoreWithPseudoPaths);
     store.petstore.get("/pets"); // should pass
     expect(() => store.petstore.post("/pets")).toThrow("Can't find response");
     expect(() => store.petstore.get("/pet")).toThrow("Can't find endpoint");
@@ -88,52 +91,53 @@ describe("Test paths matching on serviceStore", () => {
       },
     ],
   };
-  const DynamicPathsServicePopulator = (
+  const DynamicPathsService = (
     params: any,
     ...additionalPathElement: string[]
-  ) => () => {
+  ) => {
     const path = `/pets/{petId}${additionalPathElement.join("/")}`;
     return {
-      petstore: {
-        paths: {
-          [path]: {
-            get: {
-              summary: "Info for a specific pet",
-              operationId: "showPetById",
-              tags: ["pets"],
-              ...params,
-              responses: {
-                200: {},
+      petstore: new Service(
+        {
+          paths: {
+            [path]: {
+              get: {
+                summary: "Info for a specific pet",
+                operationId: "showPetById",
+                tags: ["pets"],
+                ...params,
+                responses: {
+                  200: {},
+                },
               },
             },
           },
         },
-      },
+        "petstore",
+      ),
     };
   };
 
   test("Paths are converted to regexp", () => {
-    const store = serviceStoreFactory(
-      DynamicPathsServicePopulator(petStoreParameters),
-    );
+    const store = stateStoreFactory(DynamicPathsService(petStoreParameters));
     store.petstore("/pets/2"); // Should pass
     expect(() => store.petstore("/pet/2")).toThrow("Can't find endpoint");
     expect(() => store.petstore("/pets/")).toThrow("Can't find endpoint");
   });
 
   test("Creation fails with missing parameters", () => {
-    expect(() => serviceStoreFactory(DynamicPathsServicePopulator({}))).toThrow(
+    expect(() => stateStoreFactory(DynamicPathsService({}))).toThrow(
       "no description for path parameters!",
     );
     expect(() =>
-      serviceStoreFactory(DynamicPathsServicePopulator({ parameters: {} })),
+      stateStoreFactory(DynamicPathsService({ parameters: {} })),
     ).toThrow("no description for path parameters!");
   });
 
   test("Creation fails with partial missing parameters", () => {
     expect(() =>
-      serviceStoreFactory(
-        DynamicPathsServicePopulator(petStoreParameters, "/{boom}", "{foo}"),
+      stateStoreFactory(
+        DynamicPathsService(petStoreParameters, "/{boom}", "{foo}"),
       ),
     ).toThrow("following path parameters have not been described");
   });

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ENDPOINT, DEFAULT_REST_METHOD } from "./constants";
 import {
   HTTPMethod,
-  IOASMappingGenerator,
+  IServiceMapping,
   isRESTMethod,
   IUnmockServiceState,
 } from "./interfaces";
@@ -18,7 +18,7 @@ const saveStateProxy = (store: ServiceStore, serviceName: string) => (
     state = endpoint;
     endpoint = DEFAULT_ENDPOINT;
   }
-  store.__saveState({ endpoint, method, serviceName, state });
+  store.saveState({ endpoint, method, serviceName, state });
   return new Proxy(store, StateHandler(serviceName));
 };
 
@@ -67,5 +67,6 @@ const StateHandler = (prevServiceName?: string) => {
   };
 };
 
-export const serviceStoreFactory = (servicePopulator: IOASMappingGenerator) =>
-  new Proxy(new ServiceStore(servicePopulator), StateHandler());
+// Returns as any to allow for type-free DSL-like access to services and states
+export const stateStoreFactory = (services: IServiceMapping): any =>
+  new Proxy(new ServiceStore(services), StateHandler());

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -55,7 +55,6 @@ export interface IService {
    * @param input Describes the new state that matches a method and endpoint.
    */
   updateState(input: IStateInput): boolean;
-  [serviceName: string]: any;
 }
 
 // Type aliases for brevity
@@ -65,4 +64,8 @@ export interface IStateInput {
   method: HTTPMethod;
   endpoint: string;
   newState: IUnmockServiceState;
+}
+export interface IServiceInput {
+  schema: OASSchema;
+  name: string;
 }

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -1,5 +1,3 @@
-export type IOASMappingGenerator = () => IServiceMapping;
-
 const RESTMethodTypes = [
   "get",
   "head",
@@ -16,7 +14,7 @@ export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
   RESTMethodTypes.toString().includes(maybeMethod.toLowerCase());
 
 export interface IServiceMapping {
-  [serviceName: string]: OASSchema;
+  [serviceName: string]: IService;
 }
 
 export interface IUnmockServiceState {
@@ -57,6 +55,7 @@ export interface IService {
    * @param input Describes the new state that matches a method and endpoint.
    */
   updateState(input: IStateInput): boolean;
+  [serviceName: string]: any;
 }
 
 // Type aliases for brevity

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -7,6 +7,7 @@ import {
 import {
   HTTPMethod,
   IService,
+  IServiceInput,
   IStateInput,
   IUnmockServiceState,
   OASSchema,
@@ -33,10 +34,14 @@ export class Service implements IService {
   // @ts-ignore // ignored because it's currently only being read and not written
   private state: IUnmockServiceState = {};
   private hasPaths: boolean = false;
+  private oasSchema: OASSchema;
+  private name: string;
 
-  constructor(private oasSchema: OASSchema, private name: string) {
+  constructor(opts: IServiceInput) {
+    this.oasSchema = opts.schema;
+    this.name = opts.name;
     // Update the paths in the first level to regex if needed
-    if (oasSchema === undefined || oasSchema.paths === undefined) {
+    if (this.schema === undefined || this.schema.paths === undefined) {
       return; // empty schema or does not contain paths
     }
     this.updateSchemaPaths();

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -1,23 +1,14 @@
 import {
   HTTPMethod,
-  IOASMappingGenerator,
   IServiceMapping,
   isRESTMethod,
   IUnmockServiceState,
 } from "./interfaces";
-import { Service } from "./service";
 
 export class ServiceStore {
-  private serviceMapping: IServiceMapping = {};
+  constructor(private serviceMapping: IServiceMapping) {}
 
-  constructor(servicePopulator: IOASMappingGenerator) {
-    const services = servicePopulator();
-    Object.keys(services).forEach(k => {
-      this.serviceMapping[k] = new Service(services[k], k);
-    });
-  }
-
-  public __saveState({
+  public saveState({
     serviceName: service,
     method,
     endpoint,


### PR DESCRIPTION
- `ServiceStore` constructor accepts a mapping between a service name and a class implementing `IService`.
- `Service` constructor accepts an object instead of multiple parameters
- [x] Update tests to reflect changes