### PR TITLE
ServiceStore constructor to accept array

### DIFF
--- a/packages/unmock-core/src/__tests__/service.util.test.ts
+++ b/packages/unmock-core/src/__tests__/service.util.test.ts
@@ -8,11 +8,11 @@ import {
 
 describe("Tests getAtLevel", () => {
   const schema = {
+    "/pet/{petId}": { get: { 200: {}, default: {} } },
     "/pets": {
-      get: { "200": {}, default: {} },
-      post: { "201": {}, default: {} },
+      get: { 200: {}, default: {} },
+      post: { 201: {}, default: {} },
     },
-    "/pet/{petId}": { get: { "200": {}, default: {} } },
   };
   it("tests different levels without filter", () => {
     expect(getAtLevel(schema, 0).length).toBe(2); // Only 2 items at first level
@@ -64,7 +64,10 @@ describe("Tests getPathParametersFromPath", () => {
 
   it("Tests with empty path", () => {
     expect(getPathParametersFromPath("").length).toBe(0);
+    // Check with undefined and null even though the type is meant to be concretely string
+    // @ts-ignore
     expect(getPathParametersFromPath(undefined).length).toBe(0);
+    // @ts-ignore
     expect(getPathParametersFromPath(null).length).toBe(0);
   });
 });

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -9,8 +9,8 @@ describe("Fluent API and Service instantiation tests", () => {
   ];
   const PetStoreWithPseudoPaths = [
     new Service({
-      schema: { paths: { "/pets": { get: {} } } },
       name: "petstore",
+      schema: { paths: { "/pets": { get: {} } } },
     }),
   ];
 

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -3,18 +3,16 @@ import { Service } from "../service/service";
 
 describe("Fluent API and Service instantiation tests", () => {
   // define some service populators that match IOASMappingGenerator type
-  const PetStoreWithoutPaths = {
-    petstore: new Service({ schema: {}, name: "petstore" }),
-  };
-  const PetStoreWithEmptyPaths = {
-    petstore: new Service({ schema: { paths: {} }, name: "petstore" }),
-  };
-  const PetStoreWithPseudoPaths = {
-    petstore: new Service({
+  const PetStoreWithoutPaths = [new Service({ schema: {}, name: "petstore" })];
+  const PetStoreWithEmptyPaths = [
+    new Service({ schema: { paths: {} }, name: "petstore" }),
+  ];
+  const PetStoreWithPseudoPaths = [
+    new Service({
       schema: { paths: { "/pets": { get: {} } } },
       name: "petstore",
     }),
-  };
+  ];
 
   test("Store without paths", () => {
     const store = stateStoreFactory(PetStoreWithoutPaths);
@@ -101,8 +99,8 @@ describe("Test paths matching on serviceStore", () => {
     ...additionalPathElement: string[]
   ) => {
     const path = `/pets/{petId}${additionalPathElement.join("/")}`;
-    return {
-      petstore: new Service({
+    return [
+      new Service({
         schema: {
           paths: {
             [path]: {
@@ -120,7 +118,7 @@ describe("Test paths matching on serviceStore", () => {
         },
         name: "petstore",
       }),
-    };
+    ];
   };
 
   test("Paths are converted to regexp", () => {

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ENDPOINT, DEFAULT_REST_METHOD } from "./constants";
 import {
   HTTPMethod,
-  IServiceMapping,
+  IService,
   isRESTMethod,
   IUnmockServiceState,
 } from "./interfaces";
@@ -68,5 +68,5 @@ const StateHandler = (prevServiceName?: string) => {
 };
 
 // Returns as any to allow for type-free DSL-like access to services and states
-export const stateStoreFactory = (services: IServiceMapping): any =>
+export const stateStoreFactory = (services: IService[]): any =>
   new Proxy(new ServiceStore(services), StateHandler());

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -27,11 +27,11 @@ export interface IService {
   /**
    * Name for the service.
    */
-  name: string;
+  readonly name: string;
   /**
    * Holds the OpenAPI Schema object (refered to as OAS).
    */
-  schema: OASSchema;
+  readonly schema: OASSchema;
   /**
    * Whether the OAS has a defined "paths" object or not.
    */

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -26,16 +26,18 @@ import {
 // TODO: Is there room here for xstate, in the future?
 
 export class Service implements IService {
-  // Maintains a state for service
-  // First level kv pairs: paths -> methods
-  // Second level kv pairs: methods -> status codes
-  // Third level kv pairs: status codes -> response template overrides
-  // Fourth and beyond: template-specific.
   public readonly name: string;
-  // @ts-ignore // ignored because it's currently only being read and not written
-  private state: IUnmockServiceState = {};
   private hasPaths: boolean = false;
   private readonly oasSchema: OASSchema;
+  /**
+   * Maintains a state for service
+   * First level kv pairs: paths -> methods
+   * Second level kv pairs: methods -> status codes
+   * Third level kv pairs: status codes -> response template overrides
+   * Fourth and beyond: template-specific.
+   */
+  // @ts-ignore // ignored because it's currently only being read and not written
+  private state: IUnmockServiceState = {};
 
   constructor(opts: IServiceInput) {
     this.oasSchema = opts.schema;

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -1,12 +1,19 @@
 import {
   HTTPMethod,
+  IService,
   IServiceMapping,
   isRESTMethod,
   IUnmockServiceState,
 } from "./interfaces";
 
 export class ServiceStore {
-  constructor(private serviceMapping: IServiceMapping) {}
+  private serviceMapping: IServiceMapping = {};
+
+  constructor(services: IService[]) {
+    services.forEach(service => {
+      this.serviceMapping[service.name] = service;
+    });
+  }
 
   public saveState({
     serviceName: service,


### PR DESCRIPTION
- `ServiceStore` constructor to accept an array of `IService` and creates an easier-access mapping in construction.
- Updates tests to reflect changes.
- Adds more `readonly` and changes some objects to avoid `sort` errors (could we maybe just drop this in the linter? any opinions?)