### PR TITLE
Make Schema object immutable in Service

### DIFF
--- a/packages/unmock-core/src/service/constants.ts
+++ b/packages/unmock-core/src/service/constants.ts
@@ -3,4 +3,3 @@ import XRegExp from "xregexp";
 export const DEFAULT_ENDPOINT = "**";
 export const OAS_PATH_PARAM_REGEXP = XRegExp("{([^}]+)}");
 export const OAS_PATH_PARAMS_KW = "path";
-export const UNMOCK_PATH_REGEX_KW = "x-unmock-path-regex";

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -22,6 +22,10 @@ export interface IServiceMapping {
   [serviceName: string]: IService;
 }
 
+export interface IEndpointToRegexMapping {
+  [endpoint: string]: RegExp;
+}
+
 export interface IStateInput {
   method: HTTPMethod;
   endpoint: string;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -28,10 +28,6 @@ export interface IServiceMapping {
   [serviceName: string]: IService;
 }
 
-export interface IEndpointToRegexMapping {
-  [endpoint: string]: RegExp;
-}
-
 export interface IStateInput {
   method: HTTPMethod;
   endpoint: string;
@@ -40,11 +36,6 @@ export interface IStateInput {
 export interface IServiceInput {
   schema: OpenAPIObject;
   name: string;
-}
-
-export interface IOASMatcher {
-  matchToOperationObject(sreq: ISerializedRequest): MatcherResponse;
-  findEndpoint(reqPath: string): string | undefined;
 }
 
 export type MatcherResponse = any | undefined;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -1,7 +1,13 @@
 import { OpenAPIObject } from "loas3/dist/src/generated/full";
 import { ISerializedRequest } from "../interfaces";
 
-export { OpenAPIObject, Paths, Schema } from "loas3/dist/src/generated/full";
+export {
+  OpenAPIObject,
+  Paths,
+  Schema,
+  Parameter,
+  PathItem,
+} from "loas3/dist/src/generated/full";
 
 const RESTMethodTypes = [
   "get",
@@ -36,6 +42,11 @@ export interface IServiceInput {
   name: string;
 }
 
+export interface IOASMatcher {
+  matchToOperationObject(sreq: ISerializedRequest): MatcherResponse;
+  findEndpoint(reqPath: string): string | undefined;
+}
+
 export type MatcherResponse = any | undefined;
 
 export interface IService {
@@ -51,15 +62,6 @@ export interface IService {
    * Whether the OAS has a defined "paths" object or not.
    */
   hasDefinedPaths: boolean;
-  /**
-   * Given an endpoint, checks if it is well defined in the service.
-   * This is used to check and verify dynamic paths (i.e. use path parameters)
-   * @param endpoint The endpoint to find in the OAS
-   * @returns Either the correct path (with parameters if needed),
-   *          or undefined if the path is not found.
-   * @example findEndpoint("/pets/2") will return "/pets/{petId}"
-   */
-  findEndpoint(endpoint: string): string | undefined;
   /**
    * Verifies the given request for method and endpoint are valid.
    * Should throw if anything goes wrong.

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -43,7 +43,7 @@ export class OASMatcher implements IOASMatcher {
     schema: OpenAPIObject,
   ): IEndpointToRegexMapping {
     const mapping: IEndpointToRegexMapping = {};
-    const paths: { [path: string]: any } | undefined = schema.paths;
+    const paths = schema.paths;
     if (paths === undefined || paths.length === 0) {
       return mapping;
     }
@@ -114,7 +114,7 @@ export class OASMatcher implements IOASMatcher {
      * If it fails, iterates over all endpoint until a match is found.
      * Matching path key is returned so that future matching, reference, etc can be done as needed.
      */
-    const paths: { [path: string]: any } | undefined = this.schema.paths;
+    const paths = this.schema.paths;
 
     if (paths === undefined || paths.length === 0) {
       return undefined;
@@ -123,7 +123,7 @@ export class OASMatcher implements IOASMatcher {
     const directMatch = paths[reqPath];
     if (directMatch !== undefined) {
       debugLog(`Found direct path match for ${reqPath}`);
-      return directMatch;
+      return reqPath;
     }
 
     const definedPaths = Object.keys(paths);

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -1,13 +1,7 @@
 import debug from "debug";
 import XRegExp from "xregexp";
 import { ISerializedRequest } from "../interfaces";
-import {
-  IEndpointToRegexMapping,
-  IOASMatcher,
-  MatcherResponse,
-  OpenAPIObject,
-  PathItem,
-} from "./interfaces";
+import { MatcherResponse, OpenAPIObject, PathItem } from "./interfaces";
 import {
   buildPathRegexStringFromParameters,
   getPathParametersFromPath,
@@ -16,9 +10,11 @@ import {
 
 const debugLog = debug("unmock:matcher");
 
-// Just for readability until we have types
+interface IEndpointToRegexMapping {
+  [endpoint: string]: RegExp;
+}
 
-export class OASMatcher implements IOASMatcher {
+export class OASMatcher {
   /**
    * Strip server path prefix from request path, keeping the leading slash.
    * Examples:
@@ -68,7 +64,7 @@ export class OASMatcher implements IOASMatcher {
   }
 
   private readonly schema: OpenAPIObject;
-  private readonly endpointToRegexMapping: IEndpointToRegexMapping = {};
+  private readonly endpointToRegexMapping: IEndpointToRegexMapping;
 
   constructor({ schema }: { schema: OpenAPIObject }) {
     this.schema = schema;

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -56,7 +56,10 @@ export class Service implements IService {
       this.schema !== undefined &&
       this.schema.paths !== undefined &&
       Object.keys(this.schema.paths).length > 0;
-    this.matcher = new OASMatcher({ schema: this.schema });
+    this.matcher = new OASMatcher({
+      endpointToRegexMapping: this.endpointToRegexp,
+      schema: this.schema,
+    });
   }
 
   get schema(): OpenAPIObject {

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -1,3 +1,4 @@
+import { ISerializedRequest } from "../interfaces";
 import { DEFAULT_ENDPOINT } from "./constants";
 import {
   HTTPMethod,
@@ -8,11 +9,8 @@ import {
   OpenAPIObject,
   UnmockServiceState,
 } from "./interfaces";
-import { getAtLevel } from "./util";
-
 import { OASMatcher } from "./matcher";
-
-import { ISerializedRequest } from "../interfaces";
+import { getAtLevel } from "./util";
 
 /**
  * Implements the state management for a service

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -1,8 +1,6 @@
-import XRegExp from "xregexp";
 import { DEFAULT_ENDPOINT } from "./constants";
 import {
   HTTPMethod,
-  IEndpointToRegexMapping,
   IService,
   IServiceInput,
   IStateInput,
@@ -10,12 +8,7 @@ import {
   OpenAPIObject,
   UnmockServiceState,
 } from "./interfaces";
-import {
-  buildPathRegexStringFromParameters,
-  getAtLevel,
-  getPathParametersFromPath,
-  getPathParametersFromSchema,
-} from "./util";
+import { getAtLevel } from "./util";
 
 import { OASMatcher } from "./matcher";
 
@@ -32,7 +25,6 @@ export class Service implements IService {
   private hasPaths: boolean = false;
   private readonly oasSchema: OpenAPIObject;
   private readonly matcher: OASMatcher;
-  private endpointToRegexp: IEndpointToRegexMapping = {};
   /**
    * Maintains a state for service
    * First level kv pairs: paths -> methods
@@ -50,17 +42,7 @@ export class Service implements IService {
       this.schema !== undefined &&
       this.schema.paths !== undefined &&
       Object.keys(this.schema.paths).length > 0;
-
-    if (this.hasDefinedPaths) {
-      this.buildSchemaRegExps();
-      this.matcher = new OASMatcher({
-        endpointToRegexMapping: this.endpointToRegexp,
-        schema: this.schema,
-      });
-    } else {
-      // empty schema or does not contain paths
-      this.matcher = new OASMatcher({ schema: this.schema });
-    }
+    this.matcher = new OASMatcher({ schema: this.schema });
   }
 
   get schema(): OpenAPIObject {
@@ -75,29 +57,6 @@ export class Service implements IService {
     return this.matcher.matchToOperationObject(sreq);
   }
 
-  public findEndpoint(endpoint: string): string | undefined {
-    // Finds the endpoint key that matches given endpoint string
-    // First attempts a direct match by dictionary look-up
-    // If it fails, iterates over all endpoint until a match is found.
-    // Matching path key is returned so that future matching, reference, etc can be done as needed.
-    if (!this.hasDefinedPaths) {
-      return;
-    }
-    if (this.schema.paths[endpoint] !== undefined) {
-      return endpoint;
-    }
-    for (const schemaEndpoint of Object.keys(this.schema.paths)) {
-      const endpointRegex = this.endpointToRegexp[schemaEndpoint];
-      if (endpointRegex === undefined) {
-        continue;
-      }
-      if (endpointRegex.test(endpoint)) {
-        return schemaEndpoint;
-      }
-    }
-    return;
-  }
-
   public verifyRequest(method: HTTPMethod, endpoint: string) {
     // Throws if method + endpoint are invalid for this service
     if (!this.hasDefinedPaths) {
@@ -106,7 +65,7 @@ export class Service implements IService {
 
     if (endpoint !== DEFAULT_ENDPOINT) {
       const servicePaths = this.schema.paths;
-      const schemaEndpoint = this.findEndpoint(endpoint);
+      const schemaEndpoint = this.matcher.findEndpoint(endpoint);
       if (schemaEndpoint === undefined) {
         // This endpoint does not exist, no need to retain state
         throw new Error(
@@ -151,28 +110,5 @@ export class Service implements IService {
 
     this.state = newState; // For PR purposes, we just save the state as is.
     return true;
-  }
-
-  private buildSchemaRegExps() {
-    Object.keys(this.schema.paths).forEach((path: string) => {
-      const pathParameters = getPathParametersFromPath(path);
-      let newPath: string = "";
-      if (pathParameters.length === 0) {
-        newPath = path; // Simply convert to direct regexp pattern
-      } else {
-        const schemaParameters = getPathParametersFromSchema(
-          this.schema.paths,
-          path,
-        );
-        newPath = buildPathRegexStringFromParameters(
-          path,
-          schemaParameters,
-          pathParameters,
-        );
-      }
-
-      const newPathRegex = XRegExp(`^${newPath}$`, "g");
-      this.endpointToRegexp[path] = newPathRegex;
-    });
   }
 }

--- a/packages/unmock-core/src/service/util.ts
+++ b/packages/unmock-core/src/service/util.ts
@@ -1,6 +1,6 @@
 import XRegExp from "xregexp";
 import { OAS_PATH_PARAM_REGEXP, OAS_PATH_PARAMS_KW } from "./constants";
-import { Paths } from "./interfaces";
+import { Parameter, Paths } from "./interfaces";
 
 export const getPathParametersFromPath = (path: string): string[] => {
   const pathParameters: string[] = [];
@@ -13,7 +13,7 @@ export const getPathParametersFromPath = (path: string): string[] => {
 export const getPathParametersFromSchema = (
   schema: Paths,
   path: string,
-): any[] => {
+): Parameter[] => {
   if (!path.includes("{") || schema[path] === undefined) {
     // No parameters in this path... Why bother looking?
     return [];
@@ -22,7 +22,7 @@ export const getPathParametersFromSchema = (
     schema[path],
     2,
     (_: string, v: any) => v.in === OAS_PATH_PARAMS_KW,
-  );
+  ) as Parameter[];
   if (
     schemaPathParameters.length === 0 ||
     Object.keys(schemaPathParameters[0]).length === 0
@@ -36,7 +36,7 @@ export const getPathParametersFromSchema = (
 
 export const buildPathRegexStringFromParameters = (
   path: string,
-  schemaParameters: any[],
+  schemaParameters: Parameter[],
   pathParameters: string[],
 ): string => {
   if (


### PR DESCRIPTION
- Removes `UNMOCK_PATH_REGEX_KW` and its insertion to schema `PathItem` object
- Use a mapping from endpoint (string) to regex to find matches
- Moves endpoint matching to `OASMatcher` (reduces code duplication and keeps scope) -> `Service` will now either delegate to `OASMatcher` or maintain & verify state, etc, abstracting `OASMatcher` from `ServiceStore`.
- Adds more types to `OASMatcher`.
- Adds `IOASMatcher` interface.