### PR TITLE
Bootstrapping for 0.1.0

### DIFF
--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -31,18 +31,8 @@ export function responseCreatorFactory({
     parser.parse(serviceDef),
   );
   const serviceStore = new ServiceStore(services);
-  return (sreq: ISerializedRequest) => {
-    const responseTemplateOrUndefined = serviceStore.match(sreq);
-
-    if (responseTemplateOrUndefined === undefined) {
-      return undefined;
-    }
-
-    const responseTemplate = responseTemplateOrUndefined;
-
-    const sres = generateMockFromTemplate(responseTemplate);
-    return sres;
-  };
+  return (sreq: ISerializedRequest) =>
+    generateMockFromTemplate(serviceStore.match(sreq));
 }
 
 const setupJSFUnmockProperties = (_: UnmockServiceState) => {
@@ -59,8 +49,11 @@ const setupJSFUnmockProperties = (_: UnmockServiceState) => {
 };
 
 const generateMockFromTemplate = (
-  responseTemplate: Operation,
-): ISerializedResponse => {
+  responseTemplate: Operation | undefined,
+): ISerializedResponse | undefined => {
+  if (responseTemplate === undefined) {
+    return undefined;
+  }
   // 1. Take in state from DSL
   // TODO: Link with Matcher/Service
   const state = { $code: 200 };

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -1,6 +1,7 @@
 /**
  * Implements the logic for generating a response from a service file
  */
+import { Operation } from "loas3/dist/src/generated/full";
 import {
   CreateResponse,
   ISerializedRequest,
@@ -58,7 +59,7 @@ const setupJSFUnmockProperties = (_: UnmockServiceState) => {
 };
 
 const generateMockFromTemplate = (
-  responseTemplate: any,
+  responseTemplate: Operation,
 ): ISerializedResponse => {
   // 1. Take in state from DSL
   // TODO: Link with Matcher/Service

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -3,23 +3,46 @@
  */
 import {
   CreateResponse,
-  GeneratedMock,
-  IMock,
   ISerializedRequest,
-  RequestToSpec,
+  ISerializedResponse,
+  IServiceDef,
+  IServiceDefLoader,
 } from "./interfaces";
+
+import { IService } from "./service/interfaces";
+
 import { Schema, UnmockServiceState } from "./service/interfaces";
 
 // json-schema-faker doesn't have typed definitions?
 // @ts-ignore
 import jsf from "json-schema-faker";
+import { ServiceParser } from "./service/parser";
+import { ServiceStore } from "./service/serviceStore";
 
-export const responseCreatorFactory = (): CreateResponse => {
-  return (__: ISerializedRequest) => ({
-    body: "Nothing here yet",
-    statusCode: 200,
-  });
-};
+export function responseCreatorFactory({
+  serviceDefLoader,
+}: {
+  serviceDefLoader: IServiceDefLoader;
+}): CreateResponse {
+  const serviceDefs: IServiceDef[] = serviceDefLoader.loadSync();
+  const parser = new ServiceParser();
+  const services: IService[] = serviceDefs.map(serviceDef =>
+    parser.parse(serviceDef),
+  );
+  const serviceStore = new ServiceStore(services);
+  return (sreq: ISerializedRequest) => {
+    const responseTemplateOrUndefined = serviceStore.match(sreq);
+
+    if (responseTemplateOrUndefined === undefined) {
+      return undefined;
+    }
+
+    const responseTemplate = responseTemplateOrUndefined;
+
+    const sres = generateMockFromTemplate(responseTemplate);
+    return sres;
+  };
+}
 
 const setupJSFUnmockProperties = (_: UnmockServiceState) => {
   // TODO: use the state parameter to update values as needed
@@ -34,17 +57,7 @@ const setupJSFUnmockProperties = (_: UnmockServiceState) => {
   });
 };
 
-const genMockFromSerializedRequest = (getSpecFromRequest: RequestToSpec) => (
-  sreq: ISerializedRequest,
-): IMock => {
-  const { host } = sreq;
-  // 1. Use sreq to find the proper specification and, as needed, convert
-  //    from short-hand notation to verbose OAS (Mike)
-  // TODO: Link with matcher
-  const spec = getSpecFromRequest(sreq);
-  if (spec === undefined) {
-    throw new Error(`Can't find matching service for '${host}'`);
-  }
+const generateMockFromTemplate = (spec: any): ISerializedResponse => {
   // 2. Use sreq to fetch the relevant path in the OAS spec
   // const operation = getPathSchemaFromSpec(spec, method, path);
   // 3. Fetch state from DSL
@@ -55,7 +68,7 @@ const genMockFromSerializedRequest = (getSpecFromRequest: RequestToSpec) => (
   //    handle x-unmock-* within the schemas, modify it according to these
   //    properties + the state -> we can work with jsf out of the box
   // TODO: link with Matcher
-  const responseTemplate = {};
+  const responseTemplate = spec;
 
   // Setup the unmock properties for jsf parsing
   setupJSFUnmockProperties(state);
@@ -65,17 +78,8 @@ const genMockFromSerializedRequest = (getSpecFromRequest: RequestToSpec) => (
 
   // 5. Generate as needed
   return {
-    request: sreq,
-    response: {
-      body: jsf.generate(resolvedTemplate).schema,
-      // TODO: headers
-      statusCode: state.$code, // TODO: what if `$code` response doesn't exist?
-    },
+    body: jsf.generate(resolvedTemplate).schema,
+    // TODO: headers
+    statusCode: state.$code, // TODO: what if `$code` response doesn't exist?
   };
-};
-
-export const mockGeneratorFactory = (
-  getSpecFromRequest: RequestToSpec,
-): ((sreq: ISerializedRequest) => GeneratedMock) => {
-  return genMockFromSerializedRequest(getSpecFromRequest);
 };

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -57,18 +57,16 @@ const setupJSFUnmockProperties = (_: UnmockServiceState) => {
   });
 };
 
-const generateMockFromTemplate = (spec: any): ISerializedResponse => {
-  // 2. Use sreq to fetch the relevant path in the OAS spec
-  // const operation = getPathSchemaFromSpec(spec, method, path);
-  // 3. Fetch state from DSL
+const generateMockFromTemplate = (
+  responseTemplate: any,
+): ISerializedResponse => {
+  // 1. Take in state from DSL
   // TODO: Link with Matcher/Service
   const state = { $code: 200 };
   // const responseCode = String(state.$code || "default");
-  // 4. At this point, we assume there are no references, and we only need to
+  // 2. At this point, we assume there are no references, and we only need to
   //    handle x-unmock-* within the schemas, modify it according to these
   //    properties + the state -> we can work with jsf out of the box
-  // TODO: link with Matcher
-  const responseTemplate = spec;
 
   // Setup the unmock properties for jsf parsing
   setupJSFUnmockProperties(state);

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -19,6 +19,7 @@ describe("Node.js interceptor", () => {
     test("gets successful response", async () => {
       const response = await axios("http://petstore.swagger.io/v1/pets");
       expect(response.status).toBe(200);
+      expect(response.data).toBeDefined();
     });
   });
 });

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -1,13 +1,15 @@
 import axios from "axios";
-import { IMock, UnmockOptions } from "unmock-core";
+import path from "path";
+import { UnmockOptions } from "unmock-core";
 import NodeBackend from "../../backend";
-import * as constants from "../../backend/constants";
+
+const servicesDirectory = path.join(__dirname, "..", "loaders", "resources");
 
 describe("Node.js interceptor", () => {
-  describe("with nothing in place yet", () => {
+  describe("with petstore in place", () => {
     let nodeInterceptor: NodeBackend;
     beforeEach(() => {
-      nodeInterceptor = new NodeBackend();
+      nodeInterceptor = new NodeBackend({ servicesDirectory });
       const unmockOptions = new UnmockOptions();
       nodeInterceptor.initialize(unmockOptions);
     });
@@ -15,7 +17,7 @@ describe("Node.js interceptor", () => {
       nodeInterceptor.reset();
     });
     test("gets successful response", async () => {
-      const response = await axios("http://example.org");
+      const response = await axios("http://petstore.swagger.io/v1/pets");
       expect(response.status).toBe(200);
     });
   });


### PR DESCRIPTION
- Add response creator factory, using `IServiceDefLoader` as the only dependency (for now)
- Change the mock generator to accept a template and return a serialized response, this will need adding the corresponding state when ready