### PR TITLE
Service state validation

### DIFF
--- a/packages/unmock-core/src/__tests__/service.util.test.ts
+++ b/packages/unmock-core/src/__tests__/service.util.test.ts
@@ -1,10 +1,13 @@
 import XRegExp from "xregexp";
-import { Parameter } from "../service/interfaces";
+import { Operation, Parameter, Response } from "../service/interfaces";
 import {
   buildPathRegexStringFromParameters,
+  findPathInObject,
   getAtLevel,
   getPathParametersFromPath,
   getPathParametersFromSchema,
+  getValidResponsesForOperationWithState,
+  verifyResponseWithState,
 } from "../service/util";
 
 describe("Tests getAtLevel", () => {
@@ -171,5 +174,37 @@ describe("Tests buildPathRegexStringFromParameters", () => {
         ["petId"],
       ),
     ).toThrow("following path parameters have not been described");
+  });
+});
+
+describe("Tests findPathInObject", () => {
+  const response: Response = {
+    content: {
+      "application/json": {
+        Pet: {
+          id: {
+            type: "integer",
+            format: "int64",
+          },
+          name: {
+            type: "string",
+          },
+          tag: { type: "string" },
+        },
+      },
+    },
+  };
+  it("with empty path", () => {
+    console.log(
+      verifyResponseWithState(response.content["application/json"], {
+        Pet: { id: "5", name: "bar" },
+      }),
+    );
+    console.log(
+      getValidResponsesForOperationWithState(
+        { responses: { 200: { ...response } } },
+        { Pet: { id: "5", name: "bar" }, $code: 200 },
+      ),
+    );
   });
 });

--- a/packages/unmock-core/src/__tests__/service.util.test.ts
+++ b/packages/unmock-core/src/__tests__/service.util.test.ts
@@ -1,13 +1,10 @@
 import XRegExp from "xregexp";
-import { Operation, Parameter, Response } from "../service/interfaces";
+import { Parameter } from "../service/interfaces";
 import {
   buildPathRegexStringFromParameters,
-  findPathInObject,
   getAtLevel,
   getPathParametersFromPath,
   getPathParametersFromSchema,
-  getValidResponsesForOperationWithState,
-  verifyResponseWithState,
 } from "../service/util";
 
 describe("Tests getAtLevel", () => {
@@ -174,37 +171,5 @@ describe("Tests buildPathRegexStringFromParameters", () => {
         ["petId"],
       ),
     ).toThrow("following path parameters have not been described");
-  });
-});
-
-describe("Tests findPathInObject", () => {
-  const response: Response = {
-    content: {
-      "application/json": {
-        Pet: {
-          id: {
-            type: "integer",
-            format: "int64",
-          },
-          name: {
-            type: "string",
-          },
-          tag: { type: "string" },
-        },
-      },
-    },
-  };
-  it("with empty path", () => {
-    console.log(
-      verifyResponseWithState(response.content["application/json"], {
-        Pet: { id: "5", name: "bar" },
-      }),
-    );
-    console.log(
-      getValidResponsesForOperationWithState(
-        { responses: { 200: { ...response } } },
-        { Pet: { id: "5", name: "bar" }, $code: 200 },
-      ),
-    );
   });
 });

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -110,6 +110,10 @@ describe("Test paths matching on serviceStore", () => {
         description: "The id of the pet to retrieve",
         schema: { type: "string" },
       },
+      {
+        name: "test",
+        in: "path",
+      },
     ],
   };
   const DynamicPathsService = (

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -1,48 +1,66 @@
+import { OpenAPIObject } from "loas3/dist/src/generated/full";
 import { stateStoreFactory } from "../service";
 import { Service } from "../service/service";
 
+const schemaBase: OpenAPIObject = {
+  openapi: "3.0.0",
+  info: {
+    version: "1.0.0",
+    title: "Swagger Petstore",
+    license: { name: "MIT" },
+  },
+  paths: {},
+};
+
 describe("Fluent API and Service instantiation tests", () => {
   // define some service populators that match IOASMappingGenerator type
-  const PetStoreWithoutPaths = [new Service({ schema: {}, name: "petstore" })];
   const PetStoreWithEmptyPaths = [
-    new Service({ schema: { paths: {} }, name: "petstore" }),
+    new Service({ schema: schemaBase, name: "petstore" }),
   ];
-  const PetStoreWithPseudoPaths = [
+  const PetStoreWithEmptyResponses = [
     new Service({
       name: "petstore",
-      schema: { paths: { "/pets": { get: {} } } },
+      schema: { ...schemaBase, paths: { "/pets": { get: { responses: {} } } } },
+    }),
+  ];
+  const PetStoreWithPseudoResponses = [
+    new Service({
+      name: "petstore",
+      schema: {
+        ...schemaBase,
+        paths: {
+          "/pets": {
+            get: { responses: { 200: { description: "Mock response" } } },
+          },
+        },
+      },
     }),
   ];
 
-  test("Store without paths", () => {
-    const store = stateStoreFactory(PetStoreWithoutPaths);
-    expect(store.noservice).toThrow("Can't find specification");
-    expect(store.petstore).toThrow("has no defined paths");
-  });
-
   test("Store with empty paths", () => {
     const store = stateStoreFactory(PetStoreWithEmptyPaths);
+    expect(store.noservice).toThrow("Can't find specification");
     expect(store.petstore).toThrow("has no defined paths");
     expect(store.petstore.get).toThrow("has no defined paths");
   });
 
   test("Store with non-empty paths with non-matching method", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithEmptyResponses);
     expect(store.petstore.post).toThrow("Can't find any endpoints with method");
   });
 
   test("Store with basic call", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithPseudoResponses);
     store.petstore(); // Should pass
   });
 
   test("Store with REST method call", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithPseudoResponses);
     store.petstore.get(); // Should pass
   });
 
   test("Chaining multiple states without REST methods", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithPseudoResponses);
     store
       .petstore()
       .petstore()
@@ -50,7 +68,7 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   test("Chaining multiple states with REST methods", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithPseudoResponses);
     store.petstore
       .get()
       .petstore.get()
@@ -58,7 +76,7 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   test("Chaining multiple methods for a service", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithPseudoResponses);
     store.petstore
       .get()
       .get()
@@ -68,13 +86,13 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   test("Specifying endpoint without rest method", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithPseudoResponses);
     store.petstore("/pets"); // should pass
     expect(() => store.petstore("/pet")).toThrow("Can't find endpoint");
   });
 
   test("Specifying endpoint with rest method", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoPaths);
+    const store = stateStoreFactory(PetStoreWithPseudoResponses);
     store.petstore.get("/pets"); // should pass
     expect(() => store.petstore.post("/pets")).toThrow("Can't find response");
     expect(() => store.petstore.get("/pet")).toThrow("Can't find endpoint");
@@ -102,6 +120,7 @@ describe("Test paths matching on serviceStore", () => {
     return [
       new Service({
         schema: {
+          ...schemaBase,
           paths: {
             [path]: {
               get: {

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,0 +1,179 @@
+import { Response, Schema } from "../service/interfaces";
+import { StateRequestValidator } from "../service/validator";
+
+const schema: Schema = {
+  properties: {
+    test: {
+      type: "object",
+      properties: {
+        id: {
+          type: "integer",
+          format: "int64",
+        },
+      },
+    },
+    name: {
+      type: "string",
+    },
+    foo: {
+      type: "object",
+      properties: {
+        bar: {
+          type: "object",
+          properties: {
+            id: {
+              type: "integer",
+            },
+          },
+        },
+      },
+    },
+    tag: { type: "string" },
+  },
+};
+const response: Response = {
+  content: {
+    "application/json": {
+      schema,
+    },
+  },
+  description: "foo bar",
+};
+
+describe("Tests findStatePathInService", () => {
+  it("with empty path", () => {
+    const resp = response.content as any;
+    const spreadState = StateRequestValidator.spreadStateFromService(
+      resp["application/json"].schema.properties,
+      {},
+    );
+    expect(spreadState).toEqual({}); // Empty state => empty spread state
+  });
+
+  it("with specific path", () => {
+    const resp = response.content as any;
+    const spreadState = StateRequestValidator.spreadStateFromService(
+      resp["application/json"].schema.properties,
+      { test: { id: "a" } },
+    );
+    expect(spreadState).toEqual({
+      // Spreading from "test: { id : { ... " to also inlucde properties
+      test: {
+        properties: {
+          id: {
+            type: "integer",
+            format: "int64",
+          },
+        },
+      },
+    });
+  });
+
+  it("with vague path", () => {
+    const resp = response.content as any;
+    const spreadState = StateRequestValidator.spreadStateFromService(
+      resp["application/json"].schema.properties,
+      { id: "a" },
+    );
+    // Spreading from "id : { ... " should match all nested "id"s
+    expect(spreadState).toEqual({
+      id: {
+        test: {
+          properties: {
+            id: {
+              type: "integer",
+              format: "int64",
+            },
+          },
+        },
+        foo: {
+          properties: {
+            bar: {
+              properties: {
+                id: {
+                  type: "integer",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("with missing parameters", () => {
+    const resp = response.content as any;
+    const spreadState = StateRequestValidator.spreadStateFromService(
+      resp["application/json"].schema.properties,
+      { ida: "a" },
+    );
+    expect(spreadState.ida).toBeUndefined(); // Nothing to spread
+  });
+});
+
+describe("Tests getUpdatedStateFromContent", () => {
+  it("with empty path", () => {
+    const resp = response.content as any;
+    const spreadState = StateRequestValidator.getUpdatedStateFromContent(
+      resp["application/json"],
+      {},
+    );
+    expect(spreadState).toEqual({});
+  });
+
+  it("with invalid parameter", () => {
+    const resp = response.content as any;
+    const spreadState = () =>
+      StateRequestValidator.getUpdatedStateFromContent(
+        resp["application/json"],
+        { boom: 5 },
+      );
+    expect(spreadState).toThrow("Can't find definition for boom");
+  });
+
+  it("with empty schema", () => {
+    const resp = response.content as any;
+    const spreadState = () =>
+      StateRequestValidator.getUpdatedStateFromContent(resp.boom, {});
+    expect(spreadState).toThrow("No schema defined");
+
+    const resp2 = {
+      "application/json": {},
+    };
+    const spreadState2 = () =>
+      StateRequestValidator.getUpdatedStateFromContent(
+        resp2["application/json"],
+        {},
+      );
+    expect(spreadState).toThrow("No schema defined");
+  });
+});
+
+describe("Tests getValidResponsesForOperationWithState", () => {
+  it("with $code specified", () => {
+    const op = { responses: { 200: { ...response } } };
+    const spreadState = StateRequestValidator.getValidResponsesForOperationWithState(
+      op,
+      { $code: 200 },
+    );
+    expect(spreadState).toEqual({ 200: {} });
+  });
+
+  it("with missing $code specified", () => {
+    const op = { responses: { 200: { ...response } } };
+    const spreadState = StateRequestValidator.getValidResponsesForOperationWithState(
+      op,
+      { $code: 404 },
+    );
+    expect(spreadState).toEqual(undefined);
+  });
+
+  it("with no $code specified", () => {
+    const op = { responses: { 200: { ...response } } };
+    const spreadState = () =>
+      StateRequestValidator.getValidResponsesForOperationWithState(op, {
+        id: 5,
+      });
+    expect(spreadState).toThrow("Not implemented yet");
+  });
+});

--- a/packages/unmock-core/src/service/constants.ts
+++ b/packages/unmock-core/src/service/constants.ts
@@ -1,5 +1,6 @@
 import XRegExp from "xregexp";
 
+export const DEFAULT_HTTP_METHOD = "any";
 export const DEFAULT_ENDPOINT = "**";
 export const OAS_PATH_PARAM_REGEXP = XRegExp("{([^}]+)}");
 export const OAS_PATH_PARAMS_KW = "path";

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -1,5 +1,6 @@
-import { DEFAULT_ENDPOINT } from "./constants";
+import { DEFAULT_ENDPOINT, DEFAULT_HTTP_METHOD } from "./constants";
 import {
+  ExtendedHTTPMethod,
   HTTPMethod,
   IService,
   isRESTMethod,
@@ -9,7 +10,7 @@ import { ServiceStore } from "./serviceStore";
 
 const saveStateProxy = (store: ServiceStore, serviceName: string) => (
   endpoint = DEFAULT_ENDPOINT,
-  method: HTTPMethod = "all",
+  method: ExtendedHTTPMethod = DEFAULT_HTTP_METHOD,
   state: UnmockServiceState,
 ) => {
   // Returns a function for the end user to update the state in,

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -4,6 +4,7 @@ import { DEFAULT_HTTP_METHOD } from "./constants";
 
 export {
   isOperation,
+  isSchema,
   MediaType,
   OpenAPIObject,
   Paths,

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -4,12 +4,14 @@ import { DEFAULT_HTTP_METHOD } from "./constants";
 
 export {
   isOperation,
+  MediaType,
   OpenAPIObject,
   Paths,
   Schema,
   Operation,
   Parameter,
   PathItem,
+  Response,
 } from "loas3/dist/src/generated/full";
 
 const RESTMethodTypes = [
@@ -42,7 +44,7 @@ export interface IServiceMapping {
 export interface IStateInput {
   method: ExtendedHTTPMethod;
   endpoint: string;
-  newState: IUnmockServiceState;
+  newState: UnmockServiceState;
 }
 export interface IServiceInput {
   schema: OpenAPIObject;
@@ -71,7 +73,7 @@ export interface IService {
    * Updates the state for given method and endpoint.
    * @param input Describes the new state that matches a method and endpoint.
    */
-  updateState(input: IStateInput): boolean;
+  updateState(input: IStateInput): { success: boolean; error?: string };
 
   /**
    * Match a given request to the service. Return an operation object for successful match,

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -28,10 +28,12 @@ type DEFAULT_HTTP_METHOD_AS_TYPE = typeof DEF_REST_METHOD[number];
 export type HTTPMethod = typeof RESTMethodTypes[number];
 export type ExtendedHTTPMethod = HTTPMethod | DEFAULT_HTTP_METHOD_AS_TYPE;
 
-export const isRESTMethod = (
+export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
+  RESTMethodTypes.toString().includes(maybeMethod.toLowerCase());
+export const isExtendedRESTMethod = (
   maybeMethod: string,
 ): maybeMethod is ExtendedHTTPMethod =>
-  RESTMethodTypes.toString().includes(maybeMethod.toLowerCase());
+  maybeMethod === DEFAULT_HTTP_METHOD || isRESTMethod(maybeMethod);
 
 export interface IServiceMapping {
   [serviceName: string]: IService;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -1,10 +1,13 @@
 import { OpenAPIObject } from "loas3/dist/src/generated/full";
 import { ISerializedRequest } from "../interfaces";
+import { DEFAULT_HTTP_METHOD } from "./constants";
 
 export {
+  isOperation,
   OpenAPIObject,
   Paths,
   Schema,
+  Operation,
   Parameter,
   PathItem,
 } from "loas3/dist/src/generated/full";
@@ -17,11 +20,17 @@ const RESTMethodTypes = [
   "delete",
   "options",
   "trace",
-  "all", // internally used to mark all the above methods.
 ] as const;
-export type HTTPMethod = typeof RESTMethodTypes[number];
 
-export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
+const DEF_REST_METHOD = [DEFAULT_HTTP_METHOD] as const;
+
+type DEFAULT_HTTP_METHOD_AS_TYPE = typeof DEF_REST_METHOD[number];
+export type HTTPMethod = typeof RESTMethodTypes[number];
+export type ExtendedHTTPMethod = HTTPMethod | DEFAULT_HTTP_METHOD_AS_TYPE;
+
+export const isRESTMethod = (
+  maybeMethod: string,
+): maybeMethod is ExtendedHTTPMethod =>
   RESTMethodTypes.toString().includes(maybeMethod.toLowerCase());
 
 export interface IServiceMapping {
@@ -29,7 +38,7 @@ export interface IServiceMapping {
 }
 
 export interface IStateInput {
-  method: HTTPMethod;
+  method: ExtendedHTTPMethod;
   endpoint: string;
   newState: IUnmockServiceState;
 }

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -45,23 +45,17 @@ export interface IService {
    * Name for the service.
    */
   readonly name: string;
+
   /**
    * Holds the OpenAPI Schema object (refered to as OAS).
    */
   readonly schema: OpenAPIObject;
+
   /**
    * Whether the OAS has a defined "paths" object or not.
    */
   hasDefinedPaths: boolean;
-  /**
-   * Verifies the given request for method and endpoint are valid.
-   * Should throw if anything goes wrong.
-   * @param method A string that matches HTTPMethod type.
-   *               Note HTTPMethod includes an "all" method, intended as "whatever method fits".
-   * @param endpoint An endpoint for fetching.
-   *                 Note the default endpoint ("**") should match all endpoints.
-   */
-  verifyRequest(method: HTTPMethod, endpoint: string): void;
+
   /**
    * Updates the state for given method and endpoint.
    * @param input Describes the new state that matches a method and endpoint.

--- a/packages/unmock-core/src/service/parser.ts
+++ b/packages/unmock-core/src/service/parser.ts
@@ -31,9 +31,15 @@ export class ServiceParser implements IServiceParser {
 
     const { val: schema, errors } = loas3(jsYaml.safeLoad(contents));
     if (errors) {
-      throw new Error([
-        "The following errors occured while parsing your loas3 schema",
-        ...errors.map(i => `  ${i.message}`)].join("\n"));
+      throw new Error(
+        [
+          "The following errors occured while parsing your loas3 schema",
+          ...errors.map(i => `  ${i.message}`),
+        ].join("\n"),
+      );
+    }
+    if (schema === undefined) {
+      throw new Error(`Could not load schema from ${contents}`);
     }
 
     // TODO Maybe read from the schema first

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -15,7 +15,6 @@ import {
   UnmockServiceState,
 } from "./interfaces";
 import { OASMatcher } from "./matcher";
-import { getValidResponsesForOperationWithState } from "./util";
 
 const debugLog = debug("unmock:service");
 
@@ -70,6 +69,7 @@ export class Service implements IService {
   public updateState({
     method,
     endpoint,
+    // @ts-ignore
     newState,
   }: IStateInput): { success: boolean; error?: string } {
     // Four possible cases:
@@ -93,8 +93,9 @@ export class Service implements IService {
     }
     debugLog(`Found follow operations: ${operations}`);
 
+    // @ts-ignore
     operations.forEach((op: IOperationForStateUpdate) => {
-      //applyStateToOperation(op, newState);
+      // applyStateToOperation(op, newState);
       // For each operation, verify the new state applies and save in `this.state`
     });
 

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -15,6 +15,7 @@ import {
   UnmockServiceState,
 } from "./interfaces";
 import { OASMatcher } from "./matcher";
+import { getValidResponsesForOperationWithState } from "./util";
 
 const debugLog = debug("unmock:service");
 
@@ -66,7 +67,11 @@ export class Service implements IService {
     return this.matcher.matchToOperationObject(sreq);
   }
 
-  public updateState({ method, endpoint, newState }: IStateInput): boolean {
+  public updateState({
+    method,
+    endpoint,
+    newState,
+  }: IStateInput): { success: boolean; error?: string } {
     // Four possible cases:
     // 1. Default endpoint ("**"), default method ("any") =>
     //    applies to all paths with any method where it fits. If none fit -> return false.
@@ -84,16 +89,16 @@ export class Service implements IService {
     const { operations, error } = this.getOperations(method, endpoint);
     if (error !== undefined) {
       debugLog(`Couldn't find any matching operations: ${error}`);
-      throw new Error(error);
+      return { success: false, error };
     }
     debugLog(`Found follow operations: ${operations}`);
 
     operations.forEach((op: IOperationForStateUpdate) => {
+      //applyStateToOperation(op, newState);
       // For each operation, verify the new state applies and save in `this.state`
     });
 
-    this.state = newState; // For PR purposes, we just save the state as is.
-    return true;
+    return { success: true };
   }
 
   private getOperations(

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -69,7 +69,7 @@ export class Service implements IService {
   public updateState({
     method,
     endpoint,
-    // @ts-ignore
+    // @ts-ignore TODO
     newState,
   }: IStateInput): { success: boolean; error?: string } {
     // Four possible cases:
@@ -93,7 +93,7 @@ export class Service implements IService {
     }
     debugLog(`Found follow operations: ${operations}`);
 
-    // @ts-ignore
+    // @ts-ignore TODO
     operations.forEach((op: IOperationForStateUpdate) => {
       // applyStateToOperation(op, newState);
       // For each operation, verify the new state applies and save in `this.state`

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -37,7 +37,7 @@ export class ServiceStore {
     endpoint: string;
     method: ExtendedHTTPMethod;
     state: UnmockServiceState;
-  }) {
+  }): boolean {
     /**
      * Verifies logical flow of inputs before dispatching the update to
      * the ServiceState object.
@@ -60,10 +60,14 @@ export class ServiceStore {
       );
     }
 
-    this.serviceMapping[service].updateState({
+    const { success, error } = this.serviceMapping[service].updateState({
       endpoint,
       method,
       newState: state,
     });
+    if (error !== undefined) {
+      throw new Error(error);
+    }
+    return success;
   }
 }

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -1,9 +1,9 @@
 import { ISerializedRequest } from "../interfaces";
 import {
-  HTTPMethod,
+  ExtendedHTTPMethod,
   IService,
   IServiceMapping,
-  isRESTMethod,
+  isExtendedRESTMethod,
   MatcherResponse,
   UnmockServiceState,
 } from "./interfaces";
@@ -35,14 +35,17 @@ export class ServiceStore {
   }: {
     serviceName: string;
     endpoint: string;
-    method: HTTPMethod;
+    method: ExtendedHTTPMethod;
     state: UnmockServiceState;
   }) {
     /**
      * Verifies logical flow of inputs before dispatching the update to
      * the ServiceState object.
      */
-    if (this.serviceMapping[service] === undefined || !isRESTMethod(method)) {
+    if (
+      this.serviceMapping[service] === undefined ||
+      !isExtendedRESTMethod(method)
+    ) {
       // Service does not exist, no need to retain state.
       // This method might be called twice in an attempt to recover from the fluent
       // API, where `method` will be passed the service and `service` will be passed
@@ -52,12 +55,10 @@ export class ServiceStore {
       // i.e. `state.github.get(...).post(...)` // make sure both `get` and `post` are correct methods
       throw new Error(
         `Can't find specification for service named '${
-          isRESTMethod(method) ? service : method
+          isExtendedRESTMethod(method) ? service : method
         }'!`,
       );
     }
-
-    this.serviceMapping[service].verifyRequest(method, endpoint);
 
     this.serviceMapping[service].updateState({
       endpoint,

--- a/packages/unmock-core/src/service/util.ts
+++ b/packages/unmock-core/src/service/util.ts
@@ -1,14 +1,6 @@
 import XRegExp from "xregexp";
 import { OAS_PATH_PARAM_REGEXP, OAS_PATH_PARAMS_KW } from "./constants";
-import {
-  MediaType,
-  Operation,
-  Parameter,
-  Paths,
-  Response,
-  Schema,
-  UnmockServiceState,
-} from "./interfaces";
+import { Parameter, Paths } from "./interfaces";
 
 export const getPathParametersFromPath = (path: string): string[] => {
   const pathParameters: string[] = [];
@@ -71,80 +63,6 @@ export const buildPathRegexStringFromParameters = (
     );
   }
   return newPath;
-};
-
-const DFSVerifyNoneAreUndefined = (obj: any, prevPath: string[] = []) => {
-  return Object.keys(obj).forEach((key: string) => {
-    const paramPath = prevPath.concat([key]);
-    if (obj[key] === undefined) {
-      throw new Error(`Can't find definition for ${paramPath.join(".")}`);
-    }
-    if (typeof obj === "object") {
-      DFSVerifyNoneAreUndefined(obj[key], paramPath);
-    }
-  });
-};
-
-export const verifyResponseWithState = (
-  content: MediaType,
-  state: UnmockServiceState,
-) => {
-  // Employ DFS to iterate over state and see if it matches in response...
-  // (For now, ignore $DSL notation and types)
-  const responseModsForState = findPathInObject(state, content) as Record<
-    string,
-    Schema
-  >;
-  // TODO: Ignore DSL/convert elements
-  // verify none of the elements are `undefined`, throws if some are missing
-  DFSVerifyNoneAreUndefined(responseModsForState);
-  return responseModsForState;
-};
-
-export const getValidResponsesForOperationWithState = (
-  operation: Operation,
-  state: UnmockServiceState,
-): { [statusCode: number]: Record<string, Schema> } | undefined => {
-  // Check if any non-DSL specific elements are found in the Operation under responses.
-  // We do not resolve anything at this point.
-  const responses = operation.responses;
-  const statusCode = state.$code;
-  if (statusCode !== undefined) {
-    // Applies only to specific response
-    const response = (responses as any)[statusCode] as Response;
-    if (response === undefined || response.content === undefined) {
-      return undefined;
-    }
-    delete state.$code; // TODO: Remove other top-level DSL elements...
-    const content = response.content[Object.keys(response.content)[0]];
-    return { [statusCode]: verifyResponseWithState(content, state) };
-  }
-  throw new Error(`Not implemented yet for all paths`);
-};
-
-export const findPathInObject = (
-  path: any,
-  obj: any,
-): { [key: string]: any | undefined } => {
-  const matches: { [key: string]: any } = {};
-  for (const key of Object.keys(path)) {
-    if (["string", "number", "boolean"].includes(typeof path[key])) {
-      matches[key] = obj[key]; // undefined if it doesn't exist, otherwise we type check elsewhere.
-      continue;
-    }
-    if (typeof path[key] === "object" && Object.keys(path[key]).length > 0) {
-      if (typeof obj[key] !== "object" || Object.keys(obj[key]).length === 0) {
-        matches[key] = undefined;
-        continue;
-      }
-      matches[key] = findPathInObject(path[key], obj[key]);
-      continue;
-    }
-    throw new Error(
-      `Path[key] (${path} with ${key}) is not an object, string, number or boolean!`,
-    );
-  }
-  return matches;
 };
 
 export const getAtLevel = (

--- a/packages/unmock-core/src/service/util.ts
+++ b/packages/unmock-core/src/service/util.ts
@@ -1,6 +1,12 @@
 import XRegExp from "xregexp";
 import { OAS_PATH_PARAM_REGEXP, OAS_PATH_PARAMS_KW } from "./constants";
-import { Parameter, Paths } from "./interfaces";
+import {
+  Operation,
+  Parameter,
+  Paths,
+  Response,
+  UnmockServiceState,
+} from "./interfaces";
 
 export const getPathParametersFromPath = (path: string): string[] => {
   const pathParameters: string[] = [];
@@ -39,16 +45,13 @@ export const buildPathRegexStringFromParameters = (
   schemaParameters: Parameter[],
   pathParameters: string[],
 ): string => {
-  if (
-    schemaParameters.length === 0 ||
-    Object.values(schemaParameters[0]).length === 0
-  ) {
+  if (schemaParameters.length === 0) {
     return path;
   }
 
   let newPath = `${path}`;
   // Assumption: All methods describe the parameter the same way.
-  Object.values(schemaParameters[0]).forEach((p: any) => {
+  Object.values(schemaParameters).forEach((p: any) => {
     const paramLoc = pathParameters.indexOf(p.name);
     if (paramLoc !== -1) {
       // replace the original path with regex as needed
@@ -68,6 +71,30 @@ export const buildPathRegexStringFromParameters = (
   return newPath;
 };
 
+const verifyResponseWithState = (
+  response: Response,
+  state: UnmockServiceState,
+) => {
+  //
+};
+
+export const getValidResponsesForOperationWithState = (
+  operation: Operation,
+  state: UnmockServiceState,
+): string[] | undefined => {
+  // Check if any non-DSL specific elements are found in the Operation under responses.
+  // We do not resolve anything at this point.
+  const responses = operation.responses;
+  const statusCode = state.$code;
+  if (statusCode !== undefined) {
+    // Applies only to specific response
+    const response = (responses as any)[statusCode];
+    if (response === undefined) {
+      return undefined;
+    }
+  }
+};
+
 export const getAtLevel = (
   nestedObj: any,
   level: number,
@@ -76,6 +103,7 @@ export const getAtLevel = (
   /** Returns all nested objects at a certain level from nestedObj with additional
    * filtering based on key and value from callback. Filtering only applies at the requested level.
    * `level` is 0-based.
+   * Works in BFS manner.
    */
   if (level < 0) {
     throw new Error(`Not sure what should I find at nested level ${level}...`);

--- a/packages/unmock-core/src/service/util.ts
+++ b/packages/unmock-core/src/service/util.ts
@@ -21,12 +21,9 @@ export const getPathParametersFromSchema = (
   const schemaPathParameters = getAtLevel(
     schema[path],
     2,
-    (_: string, v: any) => v.in === OAS_PATH_PARAMS_KW,
+    (_: string | undefined, v: any) => v.in === OAS_PATH_PARAMS_KW,
   ) as Parameter[];
-  if (
-    schemaPathParameters.length === 0 ||
-    Object.keys(schemaPathParameters[0]).length === 0
-  ) {
+  if (schemaPathParameters.length === 0) {
     throw new Error(
       `Found a dynamic path '${path}' but no description for path parameters!`,
     );
@@ -45,7 +42,7 @@ export const buildPathRegexStringFromParameters = (
 
   let newPath = `${path}`;
   // Assumption: All methods describe the parameter the same way.
-  Object.values(schemaParameters).forEach((p: any) => {
+  schemaParameters.forEach((p: Parameter) => {
     const paramLoc = pathParameters.indexOf(p.name);
     if (paramLoc !== -1) {
       // replace the original path with regex as needed
@@ -65,16 +62,15 @@ export const buildPathRegexStringFromParameters = (
   return newPath;
 };
 
+/** Returns all nested objects at a certain level from nestedObj with additional
+ * filtering based on key and value from callback. Filtering only applies at the requested level.
+ * `level` is 0-based. Works in BFS manner.
+ */
 export const getAtLevel = (
   nestedObj: any,
   level: number,
-  filterFn?: (key: string, value: any) => boolean,
+  filterFn?: (key: string | undefined, value: any) => boolean,
 ) => {
-  /** Returns all nested objects at a certain level from nestedObj with additional
-   * filtering based on key and value from callback. Filtering only applies at the requested level.
-   * `level` is 0-based.
-   * Works in BFS manner.
-   */
   if (level < 0) {
     throw new Error(`Not sure what should I find at nested level ${level}...`);
   }
@@ -88,8 +84,15 @@ export const getAtLevel = (
   let prevObjects: any[] = [nestedObj];
   while (i < level) {
     prevObjects.forEach(o => {
-      if (typeof o === "object") {
-        Object.values(o).forEach(v => subObjects.push(v));
+      if (Array.isArray(o)) {
+        o.forEach(e => subObjects.push(e));
+      } else if (typeof o === "object") {
+        const vals = Object.values(o);
+        if (vals.length === 1) {
+          subObjects.push(vals[0]);
+        } else {
+          Object.values(o).forEach(v => subObjects.push(v));
+        }
       }
     });
     prevObjects = subObjects;
@@ -97,7 +100,13 @@ export const getAtLevel = (
     i++;
   }
   prevObjects.forEach(o => {
-    if (typeof o === "object") {
+    if (Array.isArray(o)) {
+      o.forEach(e => {
+        if (filterFn === undefined || filterFn(undefined, e)) {
+          subObjects.push(e);
+        }
+      });
+    } else if (typeof o === "object") {
       Object.keys(o).forEach(k => {
         if (filterFn === undefined || filterFn(k, o[k])) {
           subObjects.push({ [k]: o[k] });

--- a/packages/unmock-core/src/service/validator.ts
+++ b/packages/unmock-core/src/service/validator.ts
@@ -1,0 +1,131 @@
+/**
+ * Contains logic about validating a state request for a service.
+ */
+
+import {
+  isSchema,
+  MediaType,
+  Operation,
+  Response,
+  Schema,
+  UnmockServiceState,
+} from "./interfaces";
+
+export class StateRequestValidator {
+  public static findPathInObject(
+    path: any,
+    obj: any,
+  ): { [pathKey: string]: any | undefined } | undefined {
+    const matches: { [key: string]: any } = {};
+
+    for (const key of Object.keys(path)) {
+      if (["string", "number", "boolean"].includes(typeof path[key])) {
+        if (isSchema(obj[key])) {
+          matches[key] = obj[key];
+        } else {
+          const nestedMatch = this.matchNested(obj, key);
+          matches[key] = nestedMatch;
+        }
+        continue;
+      }
+
+      if (typeof path[key] === "object" && Object.keys(path[key]).length > 0) {
+        matches[key] =
+          typeof obj[key] !== "object" || Object.keys(obj[key]).length === 0
+            ? undefined
+            : this.findPathInObject(path[key], obj[key]);
+        continue;
+      }
+
+      throw new Error(
+        `${path[key]} (object '${JSON.stringify(
+          path,
+        )}' with key '${key}') is not an object, string, number or boolean!`,
+      );
+    }
+    return matches;
+  }
+
+  public static getValidResponsesForOperationWithState(
+    operation: Operation,
+    state: UnmockServiceState,
+  ): { [statusCode: number]: Record<string, Schema> } | undefined {
+    // Check if any non-DSL specific elements are found in the Operation under responses.
+    // We do not resolve anything at this point.
+    const responses = operation.responses;
+    const statusCode = state.$code;
+    if (statusCode !== undefined) {
+      // Applies only to specific response
+      const response = (responses as any)[statusCode] as Response;
+      if (response === undefined || response.content === undefined) {
+        return undefined;
+      }
+      delete state.$code; // TODO: Remove other top-level DSL elements...
+      const content = response.content[Object.keys(response.content)[0]];
+      return {
+        [statusCode]: this.verifyResponseWithState(content, state),
+      };
+    }
+    throw new Error(`Not implemented yet for all paths`);
+  }
+
+  public static verifyResponseWithState(
+    content: MediaType,
+    state: UnmockServiceState,
+  ) {
+    // Employ DFS to iterate over state and see if it matches in response...
+    // (For now, ignore $DSL notation and types)
+    const responseModsForState = this.findPathInObject(
+      state,
+      content,
+    ) as Record<string, Schema>;
+    if (responseModsForState === undefined) {
+      throw new Error();
+    }
+    // TODO: Ignore DSL/convert elements
+    // verify none of the elements are `undefined`, throws if some are missing
+    const { missingParam } = this.DFSVerifyNoneAreUndefined(
+      responseModsForState,
+    );
+    if (missingParam !== undefined) {
+      throw new Error(`Can't find definition for ${missingParam}`);
+    }
+    return responseModsForState;
+  }
+
+  private static DFSVerifyNoneAreUndefined(
+    obj: any,
+    prevPath: string[] = [],
+  ): { missingParam?: string } {
+    for (const key of Object.keys(obj)) {
+      const paramPath = prevPath.concat([key]);
+      if (obj[key] === undefined) {
+        return { missingParam: paramPath.join("\\") };
+      }
+      if (typeof obj === "object") {
+        return this.DFSVerifyNoneAreUndefined(obj[key], paramPath);
+      }
+    }
+    return {};
+  }
+
+  private static matchNested(obj: any, pathKey: string) {
+    const foundPath: { [key: string]: any } = {};
+
+    if (isSchema(obj[pathKey])) {
+      foundPath[pathKey] = obj[pathKey];
+    }
+    if (typeof obj === "object") {
+      Object.keys(obj).forEach((objKey: string) => {
+        const subMatches = StateRequestValidator.matchNested(
+          obj[objKey],
+          pathKey,
+        );
+        if (subMatches !== undefined) {
+          foundPath[objKey] = subMatches;
+        }
+      });
+    }
+    return Object.keys(foundPath).length > 0 ? foundPath : undefined;
+  }
+}

--- a/packages/unmock-core/src/service/validator.ts
+++ b/packages/unmock-core/src/service/validator.ts
@@ -12,40 +12,66 @@ import {
 } from "./interfaces";
 
 export class StateRequestValidator {
-  public static findPathInObject(
-    path: any,
-    obj: any,
-  ): { [pathKey: string]: any | undefined } | undefined {
+  /**
+   * Given a state request, finds the matching objects
+   * within the schema that apply to the request. These
+   * are fetched so that one can use the spread operator
+   * to overwrite the default schema.
+   * The state items are matched by identifying all corresponding
+   * keys nested in the path leading to them.
+   *
+   * @param statePath A state being set in a service (or recursively-called, hence `any`)
+   * @param serviceSchema The top-level (or recursely-called, hence `any`) schema for the service
+   * @returns An object with string-keys leading to the location of matching state for each variable,
+   *          with value being either the Schema defined for that variable, or undefined.
+   */
+  public static findStatePathInService(
+    statePath: any,
+    serviceSchema: any,
+  ): { [pathKey: string]: any | undefined } {
     const matches: { [key: string]: any } = {};
 
-    for (const key of Object.keys(path)) {
-      if (["string", "number", "boolean"].includes(typeof path[key])) {
-        if (isSchema(obj[key])) {
-          matches[key] = obj[key];
-        } else {
-          const nestedMatch = this.matchNested(obj, key);
-          matches[key] = nestedMatch;
-        }
-        continue;
-      }
-
-      if (typeof path[key] === "object" && Object.keys(path[key]).length > 0) {
+    for (const key of Object.keys(statePath)) {
+      // Traverse along the different paths in the state
+      if (["string", "number", "boolean"].includes(typeof statePath[key])) {
+        // The value of the current state key is concrete
+        // If the service schema contains a matching value (schema), store that one
+        // Otherwise recursively look for matching key in nested schema.
+        matches[key] = isSchema(serviceSchema[key])
+          ? serviceSchema[key]
+          : this.matchNested(serviceSchema, key);
+      } else if (
+        typeof statePath[key] === "object" &&
+        Object.keys(statePath[key]).length > 0
+      ) {
+        // The value of the current state key is a valid object (read: path to definition)
+        // If the service schema ends with that key, or does not define more paths - set as undefined
+        // Otherwise continue traversing both the state and the service schema
         matches[key] =
-          typeof obj[key] !== "object" || Object.keys(obj[key]).length === 0
+          typeof serviceSchema[key] !== "object" ||
+          Object.keys(serviceSchema[key]).length === 0
             ? undefined
-            : this.findPathInObject(path[key], obj[key]);
-        continue;
+            : this.findStatePathInService(statePath[key], serviceSchema[key]);
+      } else {
+        // None of the above - this hints at malformed state (i.e. `{ someKey: undefined }`)
+        throw new Error(
+          `${statePath[key]} (object '${JSON.stringify(
+            statePath,
+          )}' with key '${key}') is not an object, string, number or boolean!`,
+        );
       }
-
-      throw new Error(
-        `${path[key]} (object '${JSON.stringify(
-          path,
-        )}' with key '${key}') is not an object, string, number or boolean!`,
-      );
     }
     return matches;
   }
 
+  /**
+   * Given a state and an operation, returns all the valid responses that
+   * match the given state.
+   * First-level filtering is done via $code (status code) if it exists,
+   * otherwise via matching the parameters set in `state`.
+   * @param operation
+   * @param state
+   */
   public static getValidResponsesForOperationWithState(
     operation: Operation,
     state: UnmockServiceState,
@@ -63,25 +89,27 @@ export class StateRequestValidator {
       delete state.$code; // TODO: Remove other top-level DSL elements...
       const content = response.content[Object.keys(response.content)[0]];
       return {
-        [statusCode]: this.verifyResponseWithState(content, state),
+        [statusCode]: this.getUpdatedStateFromContent(content, state),
       };
     }
     throw new Error(`Not implemented yet for all paths`);
   }
 
-  public static verifyResponseWithState(
+  /**
+   * Given a media type, return mapping between state, service and response.
+   * @param content
+   * @param state
+   */
+  public static getUpdatedStateFromContent(
     content: MediaType,
     state: UnmockServiceState,
   ) {
     // Employ DFS to iterate over state and see if it matches in response...
     // (For now, ignore $DSL notation and types)
-    const responseModsForState = this.findPathInObject(
+    const responseModsForState = this.findStatePathInService(
       state,
       content,
     ) as Record<string, Schema>;
-    if (responseModsForState === undefined) {
-      throw new Error();
-    }
     // TODO: Ignore DSL/convert elements
     // verify none of the elements are `undefined`, throws if some are missing
     const { missingParam } = this.DFSVerifyNoneAreUndefined(
@@ -93,6 +121,15 @@ export class StateRequestValidator {
     return responseModsForState;
   }
 
+  /**
+   * Recursively iterates over given `obj` and verifies all values are
+   * properly defined.
+   * @param obj Object to iterate over
+   * @param prevPath (Used internaly) tracked the path to the key that might
+   *                 be undefined.
+   * @return A dictionary, potentially with `missingParam` holding the path
+   *         to a key that holds `undefined` as value.
+   */
   private static DFSVerifyNoneAreUndefined(
     obj: any,
     prevPath: string[] = [],
@@ -109,6 +146,14 @@ export class StateRequestValidator {
     return {};
   }
 
+  /**
+   * Helper method to `findStatePathInService`;
+   * Helps find given `pathKey` in `obj` in a recursive manner.
+   * @param obj
+   * @param pathKey
+   * @returns An object leading up to the requested key and it's value in `obj`
+   *          or `undefined`.
+   */
   private static matchNested(obj: any, pathKey: string) {
     const foundPath: { [key: string]: any } = {};
 

--- a/packages/unmock-core/tslint.json
+++ b/packages/unmock-core/tslint.json
@@ -1,11 +1,10 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended"
-    ],
-    "jsRules": {},
-    "rules": {
-        "arrow-parens": false
-    },
-    "rulesDirectory": []
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended"],
+  "jsRules": {},
+  "rules": {
+    "arrow-parens": false,
+    "object-literal-sort-keys": false
+  },
+  "rulesDirectory": []
 }

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,8 @@
     ],
     "jsRules": {},
     "rules": {
-        "arrow-parens": false
+        "arrow-parens": false,
+        "object-literal-sort-keys": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
- Verify content of given DSL against schema for specified service, in both nested and generic manner (`validator.ts`)
- Fetch relevant operations based on endpoint and method, including `DEFAULT_HTTP_METHOD` and `DEFAULT_ENDPOINT`, and their combinations (`service.ts`)
- Includes minimal parsing of DSL (at the moment only treats `$code`)
- Perks: Fixes typing error in parser, re-introduces `DEFAULT_HTTP_METHOD` as `ExtendedHTTPMethod` type, fixes logical error at `getAtLevel`
- Future PRs:
  - include options (skip runtime tests, match anything nested without specifying the entire response tree)
  - bootstrap to `Service`
- [x] Add tests
- [x] Simplify