### PR TITLE
Refactor the tracking of client requests

### DIFF
--- a/packages/unmock-node/src/backend/client-request-tracker.ts
+++ b/packages/unmock-node/src/backend/client-request-tracker.ts
@@ -76,7 +76,7 @@ export default abstract class ClientRequestTracker {
    * Deletes the corresponding instance from the map of tracked requests.
    * @param incomingMessage Incoming message ("server" side)
    */
-  public static extractTrackedClientRequest(
+  public static popTrackedClientRequest(
     incomingMessage: IncomingMessage,
   ): ClientRequest {
     const { [UNMOCK_INTERNAL_HTTP_HEADER]: reqId } = incomingMessage.headers;

--- a/packages/unmock-node/src/backend/client-request-tracker.ts
+++ b/packages/unmock-node/src/backend/client-request-tracker.ts
@@ -76,7 +76,9 @@ export default abstract class ClientRequestTracker {
       Object.keys(ClientRequestTracker.clientRequests),
     );
     if (typeof reqId !== "string") {
-      throw Error("Expected to get a non empty request ID");
+      throw Error(
+        `Expected to find a string request ID in request header, got type: ${typeof reqId}`,
+      );
     }
     const clientRequest = ClientRequestTracker.clientRequests[reqId];
     if (clientRequest === undefined) {

--- a/packages/unmock-node/src/backend/client-request-tracker.ts
+++ b/packages/unmock-node/src/backend/client-request-tracker.ts
@@ -23,7 +23,8 @@ export default abstract class ClientRequestTracker {
    * to an internal dictionary.
    */
   public static start() {
-    if (ClientRequestTracker.modifiedOnSocket) {
+    if (ClientRequestTracker.active) {
+      // Initialized already
       return;
     }
 
@@ -57,7 +58,7 @@ export default abstract class ClientRequestTracker {
    * Stop tracking client requests, restore `ClientRequest.prototype.onSocket`.
    */
   public static stop() {
-    if (!ClientRequestTracker.modifiedOnSocket) {
+    if (!ClientRequestTracker.active) {
       return;
     }
 
@@ -98,7 +99,7 @@ export default abstract class ClientRequestTracker {
 
   private static origOnSocket?: (socket: net.Socket) => void;
 
-  private static get modifiedOnSocket() {
+  private static get active() {
     return ClientRequestTracker.origOnSocket !== undefined;
   }
 }

--- a/packages/unmock-node/src/backend/client-request-tracker.ts
+++ b/packages/unmock-node/src/backend/client-request-tracker.ts
@@ -1,0 +1,111 @@
+import debug from "debug";
+import { ClientRequest, IncomingMessage } from "http";
+import _ from "lodash";
+import net from "net";
+import { v4 as uuidv4 } from "uuid";
+
+const debugLog = debug("unmock:client-request-tracker");
+
+interface IBypassableSocket extends net.Socket {
+  bypass: () => void;
+}
+
+const UNMOCK_INTERNAL_HTTP_HEADER = "x-unmock-req-id";
+
+/**
+ * "Static" class for tracking client requests.
+ */
+export default abstract class ClientRequestTracker {
+  public static readonly outgoingRequests: {
+    [requestId: string]: {
+      clientRequest: ClientRequest;
+    };
+  } = {};
+  /**
+   * Start tracking client requests by modifying `ClientRequest.prototype.onSocket` to add
+   * a unique identifier to every request header and store the request
+   * to an internal dictionary.
+   */
+  public static start() {
+    if (ClientRequestTracker.modifiedOnSocket) {
+      return;
+    }
+
+    ClientRequestTracker.origOnSocket = ClientRequest.prototype.onSocket;
+
+    /**
+     * When a socket is assigned to a client request, create an internal ID
+     * and add the ID in the request header. Thereby we can map
+     * the server-side incoming request to the corresponding
+     * client request and emit errors properly.
+     * Borrowed from https://github.com/FormidableLabs/yesno.
+     */
+    debugLog("Modifying client request to add request ID");
+    ClientRequest.prototype.onSocket = _.flowRight(
+      ClientRequestTracker.origOnSocket,
+      function(
+        this: ClientRequest,
+        socket: IBypassableSocket,
+      ): IBypassableSocket {
+        const requestId = uuidv4();
+        debugLog(
+          `New socket assigned to client request, assigned ID: ${requestId}`,
+        );
+        ClientRequestTracker.outgoingRequests[requestId] = {
+          clientRequest: this,
+        };
+        this.setHeader(UNMOCK_INTERNAL_HTTP_HEADER, requestId);
+        return socket;
+      },
+    );
+  }
+
+  /**
+   * Stop tracking client requests, restore `ClientRequest.prototype.onSocket`.
+   */
+  public static stop() {
+    if (!ClientRequestTracker.modifiedOnSocket) {
+      return;
+    }
+
+    if (!ClientRequestTracker.origOnSocket) {
+      throw Error("No original onSocket");
+    }
+
+    ClientRequest.prototype.onSocket = ClientRequestTracker.origOnSocket;
+
+    ClientRequestTracker.origOnSocket = undefined;
+  }
+
+  /**
+   * Extract the `ClientRequest` corresponding to the given `IncomingMessage`.
+   * Deletes the corresponding instance from the map of tracked requests.
+   * @param incomingMessage Incoming message ("server" side)
+   */
+  public static extractTrackedClientRequest(
+    incomingMessage: IncomingMessage,
+  ): ClientRequest {
+    const { [UNMOCK_INTERNAL_HTTP_HEADER]: reqId } = incomingMessage.headers;
+    debugLog(
+      `Intercepted incoming request with ID ${reqId}, matching to existing IDs:`,
+      Object.keys(ClientRequestTracker.outgoingRequests),
+    );
+    if (typeof reqId !== "string") {
+      throw Error("Expected to get a non empty request ID");
+    }
+    const outgoingRequest = ClientRequestTracker.outgoingRequests[reqId];
+    if (outgoingRequest === undefined) {
+      throw Error(`Expected to find a client request for request ID ${reqId}`);
+    }
+
+    delete ClientRequestTracker.outgoingRequests[reqId];
+
+    return outgoingRequest.clientRequest;
+  }
+
+  private static origOnSocket?: (socket: net.Socket) => void;
+
+  private static get modifiedOnSocket() {
+    return ClientRequestTracker.origOnSocket !== undefined;
+  }
+}

--- a/packages/unmock-node/src/backend/client-request-tracker.ts
+++ b/packages/unmock-node/src/backend/client-request-tracker.ts
@@ -6,10 +6,6 @@ import { v4 as uuidv4 } from "uuid";
 
 const debugLog = debug("unmock:client-request-tracker");
 
-interface IBypassableSocket extends net.Socket {
-  bypass: () => void;
-}
-
 const UNMOCK_INTERNAL_HTTP_HEADER = "x-unmock-req-id";
 
 /**
@@ -43,10 +39,7 @@ export default abstract class ClientRequestTracker {
     debugLog("Modifying client request to add request ID");
     ClientRequest.prototype.onSocket = _.flowRight(
       ClientRequestTracker.origOnSocket,
-      function(
-        this: ClientRequest,
-        socket: IBypassableSocket,
-      ): IBypassableSocket {
+      function(this: ClientRequest, socket: net.Socket): net.Socket {
         const requestId = uuidv4();
         debugLog(
           `New socket assigned to client request, assigned ID: ${requestId}`,

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -112,7 +112,7 @@ export default class NodeBackend implements IBackend {
     req: IncomingMessage,
     res: ServerResponse,
   ) {
-    const clientRequest = ClientRequestTracker.popTrackedClientRequest(req);
+    const clientRequest = ClientRequestTracker.pop(req);
     handleRequestAndResponse(createResponse, req, res, clientRequest);
   }
 

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -112,7 +112,7 @@ export default class NodeBackend implements IBackend {
     req: IncomingMessage,
     res: ServerResponse,
   ) {
-    const clientRequest = ClientRequestTracker.extractTrackedClientRequest(req);
+    const clientRequest = ClientRequestTracker.popTrackedClientRequest(req);
     handleRequestAndResponse(createResponse, req, res, clientRequest);
   }
 

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -157,6 +157,8 @@ export default class NodeBackend implements IBackend {
       throw Error(`Expected to find a client request for request ID ${reqId}`);
     }
 
+    delete NodeBackend.outgoingRequests[reqId];
+
     return outgoingRequest.clientRequest;
   }
 


### PR DESCRIPTION
- Refactor client request tracking to a separate `ClientRequestTracker` class
- Keep tracking logic in a static object to avoid problems with multiple backends existing simultaneously (maybe the backend should be forced to be a singleton in any case) and being initialized and reset independently
- Delete outgoing requests from the map once the request is intercepted