### PR TITLE
State validation as function

### DIFF
--- a/packages/unmock-core/src/__tests__/providers.test.ts
+++ b/packages/unmock-core/src/__tests__/providers.test.ts
@@ -4,21 +4,21 @@ describe("Test default provider", () => {
   it("returns empty objects for undefined state", () => {
     const p = defProvider();
     expect(p.isEmpty).toBeTruthy();
-    expect(p.top()).toEqual({});
+    expect(p.top).toEqual({});
     expect(p.gen({})).toEqual({});
   });
 
   it("returns empty objects for empty state", () => {
     const p = defProvider({});
     expect(p.isEmpty).toBeTruthy();
-    expect(p.top()).toEqual({});
+    expect(p.top).toEqual({});
     expect(p.gen({})).toEqual({});
   });
 
   it("filters out top level DSL from state", () => {
     const p = defProvider({ $code: 200, foo: "bar" });
     expect(p.isEmpty).toBeFalsy();
-    expect(p.top()).toEqual({ $code: 200 });
+    expect(p.top).toEqual({ $code: 200 });
     expect(p.gen({})).toEqual({}); // no schema to expand
     expect(p.gen({ properties: { foo: { type: "string" } } })).toEqual({
       properties: {

--- a/packages/unmock-core/src/__tests__/providers.test.ts
+++ b/packages/unmock-core/src/__tests__/providers.test.ts
@@ -1,0 +1,29 @@
+import defProvider from "../service/state/providers";
+
+describe("Test default provider", () => {
+  it("returns empty objects for undefined state", () => {
+    const p = defProvider();
+    expect(p.isEmpty).toBeTruthy();
+    expect(p.top()).toEqual({});
+    expect(p.gen({})).toEqual({});
+  });
+
+  it("returns empty objects for empty state", () => {
+    const p = defProvider({});
+    expect(p.isEmpty).toBeTruthy();
+    expect(p.top()).toEqual({});
+    expect(p.gen({})).toEqual({});
+  });
+
+  it("filters out top level DSL from state", () => {
+    const p = defProvider({ $code: 200, foo: "bar" });
+    expect(p.isEmpty).toBeFalsy();
+    expect(p.top()).toEqual({ $code: 200 });
+    expect(p.gen({})).toEqual({}); // no schema to expand
+    expect(p.gen({ properties: { foo: { type: "string" } } })).toEqual({
+      properties: {
+        foo: "bar",
+      },
+    });
+  });
+});

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -31,7 +31,14 @@ describe("Fluent API and Service instantiation tests", () => {
         ...schemaBase,
         paths: {
           "/pets": {
-            get: { responses: { 200: { description: "Mock response" } } },
+            get: {
+              responses: {
+                200: {
+                  description: "Mock response",
+                  content: { "application/json": {} },
+                },
+              },
+            },
           },
         },
       },
@@ -141,7 +148,11 @@ describe("Test paths matching on serviceStore", () => {
                 tags: ["pets"],
                 ...params,
                 responses: {
-                  200: {},
+                  200: {
+                    content: {
+                      "application/json": {},
+                    },
+                  },
                 },
               },
             },

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -35,7 +35,11 @@ describe("Fluent API and Service instantiation tests", () => {
               responses: {
                 200: {
                   description: "Mock response",
-                  content: { "application/json": {} },
+                  content: {
+                    "application/json": {
+                      schema: {},
+                    },
+                  },
                 },
               },
             },
@@ -150,7 +154,9 @@ describe("Test paths matching on serviceStore", () => {
                 responses: {
                   200: {
                     content: {
-                      "application/json": {},
+                      "application/json": {
+                        schema: {},
+                      },
                     },
                   },
                 },

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -1,3 +1,4 @@
+import defProvider from "../service/state/providers";
 import { State } from "../service/state/state";
 
 const fullSchema = {
@@ -70,7 +71,11 @@ describe("Test state management", () => {
     const state = new State();
     expect(
       state.update({
-        stateInput: { method: "any", endpoint: "**", newState: {} },
+        stateInput: {
+          method: "any",
+          endpoint: "**",
+          newState: defProvider(),
+        },
         serviceName: "foo",
         paths: fullSchema.paths,
         schemaEndpoint: "**",
@@ -82,7 +87,7 @@ describe("Test state management", () => {
     const state = new State();
     expect(() =>
       state.update({
-        stateInput: { method: "post", endpoint: "**", newState: {} },
+        stateInput: { method: "post", endpoint: "**", newState: defProvider() },
         serviceName: "foo",
         paths: fullSchema.paths,
         schemaEndpoint: "**",
@@ -94,7 +99,11 @@ describe("Test state management", () => {
     const state = new State();
     expect(() =>
       state.update({
-        stateInput: { method: "post", endpoint: "/test/5", newState: {} },
+        stateInput: {
+          method: "post",
+          endpoint: "/test/5",
+          newState: defProvider(),
+        },
         serviceName: "foo",
         paths: fullSchema.paths,
         schemaEndpoint: "/test/{test_id}",
@@ -108,7 +117,7 @@ describe("Test state management", () => {
       stateInput: {
         method: "get",
         endpoint: "**",
-        newState: { foo: { id: 5 } },
+        newState: defProvider({ foo: { id: 5 } }),
       },
       serviceName: "foo",
       paths: fullSchema.paths,
@@ -139,7 +148,11 @@ describe("Test state management", () => {
   it("saves state from any endpoint and any method as expected", () => {
     const state = new State();
     state.update({
-      stateInput: { method: "any", endpoint: "**", newState: { id: 5 } },
+      stateInput: {
+        method: "any",
+        endpoint: "**",
+        newState: defProvider({ id: 5 }),
+      },
       serviceName: "foo",
       paths: fullSchema.paths,
       schemaEndpoint: "**",
@@ -165,19 +178,31 @@ describe("Test state management", () => {
   it("spreads states from multiple paths correctly", () => {
     const state = new State();
     state.update({
-      stateInput: { method: "any", endpoint: "**", newState: { id: 5 } },
+      stateInput: {
+        method: "any",
+        endpoint: "**",
+        newState: defProvider({ id: 5 }),
+      },
       serviceName: "foo",
       paths: fullSchema.paths,
       schemaEndpoint: "**",
     });
     state.update({
-      stateInput: { method: "any", endpoint: "/test/5", newState: { id: 3 } },
+      stateInput: {
+        method: "any",
+        endpoint: "/test/5",
+        newState: defProvider({ id: 3 }),
+      },
       serviceName: "foo",
       paths: fullSchema.paths,
       schemaEndpoint: "/test/{test_id}",
     });
     state.update({
-      stateInput: { method: "any", endpoint: "/test/*", newState: { id: -1 } },
+      stateInput: {
+        method: "any",
+        endpoint: "/test/*",
+        newState: defProvider({ id: -1 }),
+      },
       serviceName: "foo",
       paths: fullSchema.paths,
       schemaEndpoint: "/test/{test_id}",
@@ -206,7 +231,7 @@ describe("Test state management", () => {
       stateInput: {
         method: "any",
         endpoint: "**",
-        newState: { foo: { id: 5 } },
+        newState: defProvider({ foo: { id: 5 } }),
       },
       serviceName: "foo",
       paths: fullSchema.paths,

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -92,39 +92,39 @@ describe("Tests spreadStateFromService", () => {
   });
 });
 
-describe("Tests getUpdatedStateFromContent", () => {
-  it("with empty path", () => {
-    const resp = response.content as any;
-    const spreadState = getUpdatedStateFromContent(
-      resp["application/json"],
-      {},
-    );
-    expect(spreadState.spreadState).toEqual({});
-  });
+// describe("Tests getUpdatedStateFromContent", () => {
+//   it("with empty path", () => {
+//     const resp = response.content as any;
+//     const spreadState = getUpdatedStateFromContent(
+//       resp["application/json"],
+//       {},
+//     );
+//     expect(spreadState.spreadState).toEqual({});
+//   });
 
-  it("invalid parameter returns error", () => {
-    const resp = response.content as any;
-    const spreadState = getUpdatedStateFromContent(resp["application/json"], {
-      boom: 5,
-    });
-    expect(spreadState.error.msg).toContain("Can't find definition for 'boom'");
-  });
+//   it("invalid parameter returns error", () => {
+//     const resp = response.content as any;
+//     const spreadState = getUpdatedStateFromContent(resp["application/json"], {
+//       boom: 5,
+//     });
+//     expect(spreadState.error.msg).toContain("Can't find definition for 'boom'");
+//   });
 
-  it("empty schema returns error", () => {
-    const resp = response.content as any;
-    const spreadState = getUpdatedStateFromContent(resp.boom, {});
-    expect(spreadState.error.msg).toContain("No schema defined");
+//   it("empty schema returns error", () => {
+//     const resp = response.content as any;
+//     const spreadState = getUpdatedStateFromContent(resp.boom, {});
+//     expect(spreadState.error.msg).toContain("No schema defined");
 
-    const resp2 = {
-      "application/json": {},
-    };
-    const spreadState2 = getUpdatedStateFromContent(
-      resp2["application/json"],
-      {},
-    );
-    expect(spreadState2.error.msg).toContain("No schema defined");
-  });
-});
+//     const resp2 = {
+//       "application/json": {},
+//     };
+//     const spreadState2 = getUpdatedStateFromContent(
+//       resp2["application/json"],
+//       {},
+//     );
+//     expect(spreadState2.error.msg).toContain("No schema defined");
+//   });
+// });
 
 describe("Tests getValidResponsesForOperationWithState", () => {
   it("with $code specified", () => {

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -43,6 +43,7 @@ const response: Response = {
   },
   description: "foo bar",
 };
+const op = { responses: { 200: { ...response } } };
 
 describe("Tests spreadStateFromService", () => {
   it("with empty path", () => {
@@ -92,43 +93,43 @@ describe("Tests spreadStateFromService", () => {
   });
 });
 
-// describe("Tests getUpdatedStateFromContent", () => {
-//   it("with empty path", () => {
-//     const resp = response.content as any;
-//     const spreadState = getUpdatedStateFromContent(
-//       resp["application/json"],
-//       {},
-//     );
-//     expect(spreadState.spreadState).toEqual({});
-//   });
-
-//   it("invalid parameter returns error", () => {
-//     const resp = response.content as any;
-//     const spreadState = getUpdatedStateFromContent(resp["application/json"], {
-//       boom: 5,
-//     });
-//     expect(spreadState.error.msg).toContain("Can't find definition for 'boom'");
-//   });
-
-//   it("empty schema returns error", () => {
-//     const resp = response.content as any;
-//     const spreadState = getUpdatedStateFromContent(resp.boom, {});
-//     expect(spreadState.error.msg).toContain("No schema defined");
-
-//     const resp2 = {
-//       "application/json": {},
-//     };
-//     const spreadState2 = getUpdatedStateFromContent(
-//       resp2["application/json"],
-//       {},
-//     );
-//     expect(spreadState2.error.msg).toContain("No schema defined");
-//   });
-// });
-
 describe("Tests getValidResponsesForOperationWithState", () => {
+  it("with empty state", () => {
+    const spreadState = getValidResponsesForOperationWithState(
+      op,
+      defProvider(),
+    );
+    expect(spreadState.error).toBeUndefined();
+    expect(spreadState.responses).toEqual({
+      200: {
+        "application/json": {},
+      },
+    });
+  });
+
+  it("invalid parameter returns error", () => {
+    const spreadState = getValidResponsesForOperationWithState(
+      op,
+      defProvider({
+        boom: 5,
+      }),
+    );
+    expect(spreadState.error).toContain("Can't find definition for 'boom'");
+  });
+
+  it("empty schema returns error", () => {
+    const spreadState = getValidResponsesForOperationWithState(
+      {
+        responses: {
+          200: { content: { "application/json": {} }, description: "foo" },
+        },
+      },
+      defProvider(),
+    );
+    expect(spreadState.error).toContain("No schema defined");
+  });
+
   it("with $code specified", () => {
-    const op = { responses: { 200: { ...response } } };
     const spreadState = getValidResponsesForOperationWithState(
       op,
       defProvider({
@@ -140,7 +141,6 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("with missing $code specified", () => {
-    const op = { responses: { 200: { ...response } } };
     const spreadState = getValidResponsesForOperationWithState(
       op,
       defProvider({
@@ -154,7 +154,6 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("with no $code specified", () => {
-    const op = { responses: { 200: { ...response } } };
     const spreadState = getValidResponsesForOperationWithState(
       op,
       defProvider({

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,6 +1,6 @@
 import { Response, Schema } from "../service/interfaces";
+import defProvider from "../service/state/providers";
 import {
-  getUpdatedStateFromContent,
   getValidResponsesForOperationWithState,
   spreadStateFromService,
 } from "../service/state/validator";
@@ -129,18 +129,24 @@ describe("Tests spreadStateFromService", () => {
 describe("Tests getValidResponsesForOperationWithState", () => {
   it("with $code specified", () => {
     const op = { responses: { 200: { ...response } } };
-    const spreadState = getValidResponsesForOperationWithState(op, {
-      $code: 200,
-    });
+    const spreadState = getValidResponsesForOperationWithState(
+      op,
+      defProvider({
+        $code: 200,
+      }),
+    );
     expect(spreadState.error).toBeUndefined();
     expect(spreadState.responses).toEqual({ 200: { "application/json": {} } });
   });
 
   it("with missing $code specified", () => {
     const op = { responses: { 200: { ...response } } };
-    const spreadState = getValidResponsesForOperationWithState(op, {
-      $code: 404,
-    });
+    const spreadState = getValidResponsesForOperationWithState(
+      op,
+      defProvider({
+        $code: 404,
+      }),
+    );
     expect(spreadState.responses).toBeUndefined();
     expect(spreadState.error).toContain(
       "Can't find response for given status code '404'!",
@@ -149,9 +155,12 @@ describe("Tests getValidResponsesForOperationWithState", () => {
 
   it("with no $code specified", () => {
     const op = { responses: { 200: { ...response } } };
-    const spreadState = getValidResponsesForOperationWithState(op, {
-      test: { id: 5 },
-    });
+    const spreadState = getValidResponsesForOperationWithState(
+      op,
+      defProvider({
+        test: { id: 5 },
+      }),
+    );
     expect(spreadState.error).toBeUndefined();
     expect(spreadState.responses).toEqual({
       200: {

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -122,6 +122,11 @@ export interface IService {
 /**
  * DSL related parameters that can only be found at the top level
  */
+// Defines a mapping for top level DSL keys, to be used whed in different providers
+export const TopLevelDSLKeys: { [DSLKey: string]: string } = {
+  $code: "number",
+} as const;
+
 interface ITopLevelDSL {
   /**
    * Defines the response based on the requested response code.

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -122,7 +122,7 @@ export interface IService {
 /**
  * DSL related parameters that can only be found at the top level
  */
-// Defines a mapping for top level DSL keys, to be used whed in different providers
+// Defines a mapping for top level DSL keys, to be used with different providers
 export const TopLevelDSLKeys: { [DSLKey: string]: string } = {
   $code: "number",
 } as const;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -53,6 +53,7 @@ export interface IServiceMapping {
 }
 
 export interface IStateInputGenerator {
+  isEmpty: boolean;
   gen: (schema: Schema) => Record<string, Schema>;
   top: () => ITopLevelDSL;
 }

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -52,10 +52,15 @@ export interface IServiceMapping {
   [serviceName: string]: IService;
 }
 
+export interface IStateInputGenerator {
+  gen: (schema: Schema) => Record<string, Schema>;
+  top: () => ITopLevelDSL;
+}
+
 export interface IStateInput {
   method: ExtendedHTTPMethod;
   endpoint: string;
-  newState: UnmockServiceState;
+  newState: IStateInputGenerator;
 }
 export interface IServiceInput {
   schema: OpenAPIObject;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -56,6 +56,12 @@ export interface IStateInputGenerator {
   gen: (schema: Schema) => Record<string, Schema>;
   top: () => ITopLevelDSL;
 }
+export const isStateInputGenerator = (u: any): u is IStateInputGenerator =>
+  u !== undefined &&
+  u.top !== undefined &&
+  u.gen !== undefined &&
+  typeof u.top === "function" &&
+  typeof u.gen === "function";
 
 export interface IStateInput {
   method: ExtendedHTTPMethod;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -55,7 +55,7 @@ export interface IServiceMapping {
 export interface IStateInputGenerator {
   isEmpty: boolean;
   gen: (schema: Schema) => Record<string, Schema>;
-  top: () => ITopLevelDSL;
+  top: ITopLevelDSL;
 }
 export const isStateInputGenerator = (u: any): u is IStateInputGenerator =>
   u !== undefined &&

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -10,6 +10,7 @@ import {
   UnmockServiceState,
 } from "./interfaces";
 import { spreadStateFromService } from "./state/validator";
+import defProvider from "./state/providers";
 
 export class ServiceStore {
   private readonly serviceMapping: IServiceMapping = {};
@@ -75,17 +76,11 @@ export class ServiceStore {
     let stateGen: IStateInputGenerator;
     if (
       state === undefined ||
-      ((state.gen === undefined || typeof state.gen !== "function") &&
-        (state.top === undefined || typeof state.top !== "function"))
+      (["function", "undefined"].includes(typeof state.gen) &&
+        ["function", "undefined"].includes(typeof state.top))
     ) {
       // Given an object, set default generator for state
-      stateGen = {
-        top: () => {
-          const staticState = state as UnmockServiceState;
-          return { $code: staticState.$code };
-        },
-        gen: (schema: Schema) => spreadStateFromService(schema, state),
-      };
+      stateGen = defProvider(state as UnmockServiceState);
     } else {
       stateGen = state as IStateInputGenerator;
     }

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -6,10 +6,8 @@ import {
   isExtendedRESTMethod,
   IStateInputGenerator,
   MatcherResponse,
-  Schema,
   UnmockServiceState,
 } from "./interfaces";
-import { spreadStateFromService } from "./state/validator";
 import defProvider from "./state/providers";
 
 export class ServiceStore {

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -4,6 +4,7 @@ import {
   IService,
   IServiceMapping,
   isExtendedRESTMethod,
+  isStateInputGenerator,
   IStateInputGenerator,
   MatcherResponse,
   UnmockServiceState,
@@ -48,7 +49,7 @@ export class ServiceStore {
     serviceName: string;
     endpoint: string;
     method: ExtendedHTTPMethod;
-    state: IStateInputGenerator | UnmockServiceState;
+    state: IStateInputGenerator | UnmockServiceState | undefined;
   }) {
     /**
      * Verifies logical flow of inputs before dispatching the update to
@@ -72,11 +73,7 @@ export class ServiceStore {
       );
     }
     let stateGen: IStateInputGenerator;
-    if (
-      state === undefined ||
-      (["function", "undefined"].includes(typeof state.gen) &&
-        ["function", "undefined"].includes(typeof state.top))
-    ) {
+    if (!isStateInputGenerator(state)) {
       // Given an object, set default generator for state
       stateGen = defProvider(state as UnmockServiceState);
     } else {

--- a/packages/unmock-core/src/service/state/providers.ts
+++ b/packages/unmock-core/src/service/state/providers.ts
@@ -1,4 +1,8 @@
-import { Schema, UnmockServiceState } from "../interfaces";
+import {
+  IStateInputGenerator,
+  Schema,
+  UnmockServiceState,
+} from "../interfaces";
 import { TopLevelDSLKeys } from "../interfaces";
 import { spreadStateFromService } from "./validator";
 
@@ -22,7 +26,10 @@ const filterTopLevelDSL = (state: UnmockServiceState) => {
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
 };
 
-export default (state: UnmockServiceState | undefined) => ({
+export default (
+  state: UnmockServiceState | undefined,
+): IStateInputGenerator => ({
+  isEmpty: state === undefined || Object.keys(state).length === 0,
   top: () => getTopLevelDSL(state || {}),
   gen: (schema: Schema) =>
     spreadStateFromService(schema, filterTopLevelDSL(state || {})),

--- a/packages/unmock-core/src/service/state/providers.ts
+++ b/packages/unmock-core/src/service/state/providers.ts
@@ -28,7 +28,7 @@ const filterTopLevelDSL = (state: UnmockServiceState) => {
 
 export default (state?: UnmockServiceState): IStateInputGenerator => ({
   isEmpty: state === undefined || Object.keys(state).length === 0,
-  top: () => getTopLevelDSL(state || {}),
+  top: getTopLevelDSL(state || {}),
   gen: (schema: Schema) =>
     spreadStateFromService(schema, filterTopLevelDSL(state || {})),
 });

--- a/packages/unmock-core/src/service/state/providers.ts
+++ b/packages/unmock-core/src/service/state/providers.ts
@@ -26,9 +26,7 @@ const filterTopLevelDSL = (state: UnmockServiceState) => {
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
 };
 
-export default (
-  state: UnmockServiceState | undefined,
-): IStateInputGenerator => ({
+export default (state?: UnmockServiceState): IStateInputGenerator => ({
   isEmpty: state === undefined || Object.keys(state).length === 0,
   top: () => getTopLevelDSL(state || {}),
   gen: (schema: Schema) =>

--- a/packages/unmock-core/src/service/state/providers.ts
+++ b/packages/unmock-core/src/service/state/providers.ts
@@ -21,9 +21,9 @@ const filterTopLevelDSL = (state: UnmockServiceState) => {
     )
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
 };
-};
 
 export default (state: UnmockServiceState | undefined) => ({
   top: () => getTopLevelDSL(state || {}),
-  gen: (schema: Schema) => spreadStateFromService(schema, filterTopLevelDSL(state || {})),
+  gen: (schema: Schema) =>
+    spreadStateFromService(schema, filterTopLevelDSL(state || {})),
 });

--- a/packages/unmock-core/src/service/state/providers.ts
+++ b/packages/unmock-core/src/service/state/providers.ts
@@ -1,0 +1,29 @@
+import { Schema, UnmockServiceState } from "../interfaces";
+import { TopLevelDSLKeys } from "../interfaces";
+import { spreadStateFromService } from "./validator";
+
+const getTopLevelDSL = (state: UnmockServiceState) => {
+  return Object.keys(state)
+    .filter(
+      (key: string) =>
+        TopLevelDSLKeys[key] !== undefined &&
+        TopLevelDSLKeys[key] === typeof state[key],
+    )
+    .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
+};
+
+const filterTopLevelDSL = (state: UnmockServiceState) => {
+  return Object.keys(state)
+    .filter(
+      (key: string) =>
+        TopLevelDSLKeys[key] === undefined ||
+        TopLevelDSLKeys[key] !== typeof state[key],
+    )
+    .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
+};
+};
+
+export default (state: UnmockServiceState | undefined) => ({
+  top: () => getTopLevelDSL(state || {}),
+  gen: (schema: Schema) => spreadStateFromService(schema, filterTopLevelDSL(state || {})),
+});

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -39,7 +39,7 @@ export class State {
       debugLog(`Couldn't find any matching operations: ${ops.error}`);
       throw new Error(ops.error);
     }
-    if (newState === undefined || Object.keys(newState).length === 0) {
+    if (newState === undefined) {
       // No state given, no changes to make
       return;
     }

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -39,7 +39,7 @@ export class State {
       debugLog(`Couldn't find any matching operations: ${ops.error}`);
       throw new Error(ops.error);
     }
-    if (newState === undefined) {
+    if (newState.isEmpty) {
       // No state given, no changes to make
       return;
     }

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -146,9 +146,10 @@ const getStateFromMedia = (
     const content = contentRecord[contentType];
     if (content === undefined || content.schema === undefined) {
       errors.push({
-        msg: `No schema defined in ${JSON.stringify(content)}!`,
+        msg: `No schema defined in '${JSON.stringify(content)}'!`,
         nestedLevel: -1,
       });
+      continue;
     }
     // We assume '$ref' are already resolved at this stage
     const spreadState = state.gen(content.schema as Schema);

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -88,8 +88,7 @@ export const getValidResponsesForOperationWithState = (
   let error: IMissingParam | undefined;
 
   // TODO: Treat other top-level DSL elements...
-  const topDSL = state.top();
-  const statusCode = topDSL.$code;
+  const statusCode = state.top.$code;
   // If $code is undefined, we look over all responses listed and find the suitable ones
   const codes =
     statusCode === undefined ? Object.keys(responses) : [statusCode];

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -150,14 +150,13 @@ const getStateFromMedia = (
         nestedLevel: -1,
       });
     }
-    const schema = content.schema as Schema; // We assume '$ref' are already resolved at this stage
-    const spreadState = state.gen(schema);
+    // We assume '$ref' are already resolved at this stage
+    const spreadState = state.gen(content.schema as Schema);
+
     const missingParam = DFSVerifyNoneAreNull(spreadState);
     if (missingParam !== undefined) {
       errors.push(missingParam);
-    }
-
-    if (spreadState !== undefined) {
+    } else {
       relevantResponses[contentType] = spreadState;
     }
   }

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -7,11 +7,11 @@ import {
   IResponsesFromOperation,
   isReference,
   isSchema,
+  IStateInputGenerator,
   MediaType,
   Operation,
   Responses,
   Schema,
-  UnmockServiceState,
 } from "../interfaces";
 
 // These are specific to OAS and not part of json schema standard
@@ -79,7 +79,7 @@ const oneLevelOfIndirectNestedness = (
  */
 export const getValidResponsesForOperationWithState = (
   operation: Operation,
-  state: UnmockServiceState,
+  state: IStateInputGenerator,
 ): { responses?: IResponsesFromOperation; error?: string } => {
   // Check if any non-DSL specific elements are found in the Operation under responses.
   // We do not resolve anything at this point.
@@ -88,7 +88,8 @@ export const getValidResponsesForOperationWithState = (
   let error: IMissingParam | undefined;
 
   // TODO: Treat other top-level DSL elements...
-  const statusCode = state.$code;
+  const topDSL = state.top();
+  const statusCode = topDSL.$code;
   // If $code is undefined, we look over all responses listed and find the suitable ones
   const codes =
     statusCode === undefined ? Object.keys(responses) : [statusCode];
@@ -104,7 +105,6 @@ export const getValidResponsesForOperationWithState = (
         error: `Can't find response for given status code '${statusCode}'!`,
       };
     }
-    delete state.$code;
   }
 
   for (const code of codes) {
@@ -135,7 +135,7 @@ export const getValidResponsesForOperationWithState = (
 
 const getStateFromMedia = (
   contentRecord: Record<string, MediaType>,
-  state: UnmockServiceState,
+  state: IStateInputGenerator,
 ): {
   responses: IResponsesFromContent;
   errors: IMissingParam[];
@@ -144,48 +144,24 @@ const getStateFromMedia = (
   const relevantResponses: IResponsesFromContent = {};
   for (const contentType of Object.keys(contentRecord)) {
     const content = contentRecord[contentType];
-    const { spreadState, error } = getUpdatedStateFromContent(content, state);
-    if (error !== undefined) {
-      errors.push(error);
+    if (content === undefined || content.schema === undefined) {
+      errors.push({
+        msg: `No schema defined in ${JSON.stringify(content)}!`,
+        nestedLevel: -1,
+      });
     }
+    const schema = content.schema as Schema; // We assume '$ref' are already resolved at this stage
+    const spreadState = state.gen(schema);
+    const missingParam = DFSVerifyNoneAreNull(spreadState);
+    if (missingParam !== undefined) {
+      errors.push(missingParam);
+    }
+
     if (spreadState !== undefined) {
       relevantResponses[contentType] = spreadState;
     }
   }
   return { responses: relevantResponses, errors };
-};
-
-/**
- * Given a media type, return mapping between state, service and response.
- * @param content
- * @param state
- */
-// TODO: exported for testing purposes
-export const getUpdatedStateFromContent = (
-  content: MediaType,
-  state: UnmockServiceState,
-): { spreadState?: Record<string, Schema>; error?: IMissingParam } => {
-  if (content === undefined || content.schema === undefined) {
-    return {
-      error: {
-        msg: `No schema defined in ${JSON.stringify(content)}!`,
-        nestedLevel: -1,
-      },
-    };
-  }
-  const schema = content.schema as Schema; // We assume '$ref' are already resolved at this stage
-  // For now, ignore $DSL notation and types
-  const responseModsForState = spreadStateFromService(schema, state) as Record<
-    string,
-    Schema
-  >;
-
-  // TODO: Ignore DSL/convert elements
-  const missingParam = DFSVerifyNoneAreNull(responseModsForState);
-  if (missingParam !== undefined) {
-    return { error: missingParam };
-  }
-  return { spreadState: responseModsForState };
 };
 
 /**


### PR DESCRIPTION
Changes the state passed to a `IStateInputGenerator` object with 1 function and 2 properties:
1. `gen(schema: Schema)` consumes a `Schema` and generates the expanded matching state based on the schema, filtering out the top-level DSL.
2. `top` contains only the top-level DSL from the given state.
3. `isEmpty` boolean denoting whether or not the state is empty, to avoid generation when unneeded.

The methods wrapping the states are known as `providers`.
Also removes `getUpdatedStateFromContent` and moves the content to `getStateFromMedia` (reducing exports and number of calls), and migrates matching tests.

- [x] Define the default provider to be the current state-schema "unraveler", so that users do not have to specify that if they don't want to.
- [x] Migrate tests
- [x] Add tests for providers