### PR TITLE
[DSL] Translating $size (non top level DSL)

### DIFF
--- a/packages/unmock-core/src/__tests__/dsl.test.ts
+++ b/packages/unmock-core/src/__tests__/dsl.test.ts
@@ -27,16 +27,48 @@ describe("Resolves top level DSL to OAS", () => {
   });
 
   describe("Handles $times correctly", () => {
-    it("Throws on invalid $times (0)", () => {
+    it("Does nothing with invalid $times (0, negative, wrong type) without STRICT_MODE", () => {
+      DSL.STRICT_MODE = false;
+      let translated = DSL.translateTopLevelToOAS(
+        { $times: 0.3 },
+        responsesWithoutProperties,
+      );
+      expect(translated).toEqual({ 200: { "application/json": {} } });
+
+      translated = DSL.translateTopLevelToOAS(
+        { $times: -2 },
+        responsesWithoutProperties,
+      );
+      expect(translated).toEqual({ 200: { "application/json": {} } });
+
+      translated = DSL.translateTopLevelToOAS(
+        { $times: undefined },
+        responsesWithoutProperties,
+      );
+      expect(translated).toEqual({ 200: { "application/json": {} } });
+    });
+
+    it("Throws on invalid $times (0) with STRICT_MODE", () => {
+      DSL.STRICT_MODE = true;
       const translated = () =>
         DSL.translateTopLevelToOAS({ $times: 0.3 }, responsesWithoutProperties);
       expect(translated).toThrow("Can't set response $times to 0.3"); // 0.3 gets rounded to 0 and throws
     });
 
-    it("Throws on invalid $times (negative)", () => {
+    it("Throws on invalid $times (negative) with STRICT_MODE", () => {
+      DSL.STRICT_MODE = true;
       const translated = () =>
         DSL.translateTopLevelToOAS({ $times: -1 }, responsesWithoutProperties);
       expect(translated).toThrow("Can't set response $times to -1");
+    });
+
+    it("Throws on invalid $times (wrong type) with STRICT_MODE", () => {
+      DSL.STRICT_MODE = true;
+      const translated = () =>
+        DSL.translateTopLevelToOAS({ $times: "a" }, responsesWithoutProperties);
+      expect(translated).toThrow(
+        "Can't set response $times with non-numeric value!",
+      );
     });
 
     it("Adds properties when missing", () => {

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,4 +1,4 @@
-import { Response, Schema } from "../service/interfaces";
+import { MediaType, Response, Schema } from "../service/interfaces";
 import defProvider from "../service/state/providers";
 import {
   getValidResponsesForOperationWithState,
@@ -8,7 +8,7 @@ import {
 const schema: Schema = {
   properties: {
     test: {
-      type: "object",
+      type: "array",
       properties: {
         id: {
           type: "integer",

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -8,7 +8,7 @@ import {
 const schema: Schema = {
   properties: {
     test: {
-      type: "array",
+      type: "object",
       properties: {
         id: {
           type: "integer",

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,4 +1,4 @@
-import { MediaType, Response, Schema } from "../service/interfaces";
+import { Response, Schema } from "../service/interfaces";
 import defProvider from "../service/state/providers";
 import {
   getValidResponsesForOperationWithState,

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -52,14 +52,7 @@ export function responseCreatorFactory({
 }
 
 const setupJSFUnmockProperties = () => {
-  jsf.define("unmock-size", (value: number, schema: Schema) => {
-    if (schema.type !== "array") {
-      return schema; // validate type
-    }
-    schema.minItems = value;
-    schema.maxItems = value;
-    return schema;
-  });
+  // Handle post-generation references, etc?
 };
 
 const getStateForOperation = (

--- a/packages/unmock-core/src/service/dsl/actors.ts
+++ b/packages/unmock-core/src/service/dsl/actors.ts
@@ -1,0 +1,40 @@
+import debug from "debug";
+import { mediaTypeToSchema } from "../interfaces";
+import { SCHEMA_TIMES } from "./constants";
+import { Props } from "./interfaces";
+
+const debugLog = debug("unmock:dsl:actors");
+
+/*
+ * Handlers (actOn$X) are found here. They modify the behaviour/schemas according to specific DSL instructions.
+ */
+
+/**
+ * Acts on the $times argument in top level DSL by synchronizing and modifying the copied and original schemas.
+ * The value of $times is decreased by 1 and removed from the copied schema.
+ * If the new value is less than 0 (i.e. this state has expired),
+ * the content is removed from **both** the copied and original schemas.
+ * @param copiedSchema
+ * @param originalSchema
+ * @param mediaType
+ */
+export const actOn$times = (
+  copiedSchema: mediaTypeToSchema,
+  originalSchema: mediaTypeToSchema,
+  mediaType: string,
+) => {
+  // update the default value
+  const origTimes = (originalSchema[mediaType].properties as Props)[
+    SCHEMA_TIMES
+  ];
+  origTimes.default -= 1;
+  // delete value in copy (for clean return)
+  delete (copiedSchema[mediaType].properties as Props)[SCHEMA_TIMES];
+  if (origTimes.default < 0) {
+    debugLog(
+      `$times has expired for '${mediaType}', removing state in both copied and original`,
+    );
+    delete copiedSchema[mediaType];
+    delete originalSchema[mediaType];
+  }
+};

--- a/packages/unmock-core/src/service/dsl/actors.ts
+++ b/packages/unmock-core/src/service/dsl/actors.ts
@@ -6,7 +6,7 @@ import { Props } from "./interfaces";
 const debugLog = debug("unmock:dsl:actors");
 
 /*
- * Handlers (actOn$X) are found here. They modify the behaviour/schemas according to specific DSL instructions.
+ * Actors (actOn$X) are found here. They modify the behaviour/schemas according to specific DSL instructions.
  */
 
 /**

--- a/packages/unmock-core/src/service/dsl/constants.ts
+++ b/packages/unmock-core/src/service/dsl/constants.ts
@@ -1,0 +1,3 @@
+const SCHEMA_PREFIX = "x-unmock-";
+export const SCHEMA_TIMES = `${SCHEMA_PREFIX}times`;
+export const UNMOCK_TYPE = "unmock";

--- a/packages/unmock-core/src/service/dsl/dsl.ts
+++ b/packages/unmock-core/src/service/dsl/dsl.ts
@@ -1,93 +1,17 @@
 import debug from "debug";
 import { cloneDeep } from "lodash";
-import {
-  codeToMedia,
-  isReference,
-  mediaTypeToSchema,
-  Schema,
-} from "../interfaces";
+import { codeToMedia, Schema } from "../interfaces";
+import { actOn$times } from "./actors";
+import { SCHEMA_TIMES } from "./constants";
 import { ITopLevelDSL } from "./interfaces";
+import { translate$size, translate$times } from "./translators";
+import {
+  hasUnmockProperty,
+  injectUnmockProperty,
+  throwOnErrorIfStrict,
+} from "./utils";
 
 const debugLog = debug("unmock:dsl");
-
-type Props = Record<string, Schema>;
-const SCHEMA_PREFIX = "x-unmock-";
-const SCHEMA_TIMES = `${SCHEMA_PREFIX}times`;
-const UNMOCK_TYPE = "unmock";
-interface IUnmockProperty {
-  [key: string]: {
-    type: string;
-    default: any;
-  };
-}
-
-/**
- * Every proper unmock property is an object of type `UNMOCK_TYPE` with the value set in `default`
- * @param name
- * @param value
- */
-const buildUnmockPropety = (name: string, value: any) => ({
-  [name]: { type: UNMOCK_TYPE, default: value },
-});
-
-/**
- * Modifies responses in-place by injecting the given `unmockProperty` to every response's `properties`
- * @param responses
- * @param unmockProperty
- */
-const injectUnmockProperty = (
-  responses: codeToMedia,
-  unmockProperty: IUnmockProperty,
-) => {
-  Object.values(responses).forEach((response: mediaTypeToSchema) => {
-    Object.values(response).forEach((schema: Schema) => {
-      schema.properties = {
-        ...schema.properties,
-        ...unmockProperty,
-      };
-    });
-  });
-};
-
-/**
- * Checks if given schema has the given unmock property with given `name`
- * @param schema
- * @param name
- */
-const hasUnmockProperty = (schema: Schema, name: string) => {
-  const log = (found: boolean) =>
-    debugLog(
-      `${found ? "Found" : "Can't find"} '${name}' in ${JSON.stringify(
-        schema,
-      )}`,
-    );
-  if (schema.properties === undefined) {
-    log(false);
-    return false;
-  }
-  const prop = schema.properties[name];
-  if (prop === undefined || isReference(prop)) {
-    log(false);
-    return false;
-  }
-  log(prop.type === UNMOCK_TYPE);
-  return prop.type === UNMOCK_TYPE;
-};
-
-/**
- * Used with STRICT_MODE to enable throwing or ignoring errors and logging them as they happen.
- * @param fn
- */
-const throwOnErrorIfStrict = (fn: () => void) => {
-  try {
-    fn();
-  } catch (e) {
-    if (DSL.STRICT_MODE) {
-      throw e;
-    }
-    debugLog(e.message);
-  }
-};
 
 /**
  * Handles DSL arguments by translating them to OAS where needed.
@@ -186,73 +110,3 @@ export abstract class DSL {
     return copy;
   }
 }
-
-/*
- * Handlers (actOn$X) are found here. They modify the behaviour/schemas according to specific DSL instructions.
- */
-
-/**
- * Acts on the $times argument in top level DSL by synchronizing and modifying the copied and original schemas.
- * The value of $times is decreased by 1 and removed from the copied schema.
- * If the new value is less than 0 (i.e. this state has expired),
- * the content is removed from **both** the copied and original schemas.
- * @param copiedSchema
- * @param originalSchema
- * @param mediaType
- */
-const actOn$times = (
-  copiedSchema: mediaTypeToSchema,
-  originalSchema: mediaTypeToSchema,
-  mediaType: string,
-) => {
-  // update the default value
-  const origTimes = (originalSchema[mediaType].properties as Props)[
-    SCHEMA_TIMES
-  ];
-  origTimes.default -= 1;
-  // delete value in copy (for clean return)
-  delete (copiedSchema[mediaType].properties as Props)[SCHEMA_TIMES];
-  if (origTimes.default < 0) {
-    debugLog(
-      `$times has expired for '${mediaType}', removing state in both copied and original`,
-    );
-    delete copiedSchema[mediaType];
-    delete originalSchema[mediaType];
-  }
-};
-
-/*
- * Translators (translate$X) are found here. They translate a DSL instruction to OAS, without modifying any schemas.
- */
-
-const translate$times = (times: any) => {
-  if (typeof times !== "number") {
-    throw new Error("Can't set response $times with non-numeric value!");
-  }
-  const roundTimes = Math.round(times); // We ignore floats by rounding to an integer
-  if (roundTimes < 1) {
-    throw new Error(`Can't set response $times to ${times}!`);
-  }
-  debugLog(`Rounded response $times to ${times}`);
-  return buildUnmockPropety(SCHEMA_TIMES, times);
-};
-
-/**
- * Translates the $size argument in the DSL, by verifying its location and value is logical.
- * @param state
- * @param schema
- */
-const translate$size = (state: any, schema: Schema): any => {
-  // assumes state.$size exists
-  if (schema.type === undefined || schema.type !== "array") {
-    throw new Error("Can't set '$size' for non-array elements!");
-  }
-  if (typeof state.$size !== "number") {
-    throw new Error("Can't request a non-number size of array!");
-  }
-  const nElements = Math.round(state.$size);
-  if (nElements < 0) {
-    throw new Error("Can't request a non-positive size of array!");
-  }
-  return { minItems: nElements, maxItems: nElements };
-};

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -19,6 +19,7 @@ export interface ITopLevelDSL {
 /**
  * DSL related parameters that can be found at any level in the schema
  */
+
 export interface IDSL {
   /**
    * Used to control and generate arrays of specific sizes.

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -1,3 +1,5 @@
+import { Schema } from "../interfaces";
+
 /**
  * DSL related parameters that can only be found at the top level
  */
@@ -26,4 +28,13 @@ export interface IDSL {
    */
   $size?: number;
   [key: string]: number | string | boolean | undefined;
+}
+
+export type Props = Record<string, Schema>;
+
+export interface IUnmockProperty {
+  [key: string]: {
+    type: string;
+    default: any;
+  };
 }

--- a/packages/unmock-core/src/service/dsl/translators.ts
+++ b/packages/unmock-core/src/service/dsl/translators.ts
@@ -31,10 +31,10 @@ export const translate$size = (state: any, schema: Schema): any => {
     throw new Error("Can't set '$size' for non-array elements!");
   }
   if (typeof state.$size !== "number") {
-    throw new Error("Can't request a non-number size of array!");
+    throw new Error("Can't request a non-numeric size of array!");
   }
   const nElements = Math.round(state.$size);
-  if (nElements < 0) {
+  if (nElements < 1) {
     throw new Error("Can't request a non-positive size of array!");
   }
   return { minItems: nElements, maxItems: nElements };

--- a/packages/unmock-core/src/service/dsl/translators.ts
+++ b/packages/unmock-core/src/service/dsl/translators.ts
@@ -1,0 +1,41 @@
+import debug from "debug";
+import { Schema } from "../interfaces";
+import { SCHEMA_TIMES } from "./constants";
+import { buildUnmockPropety } from "./utils";
+
+const debugLog = debug("unmock:dsl:translators");
+/*
+ * Translators (translate$X) are found here. They translate a DSL instruction to OAS, without modifying any schemas.
+ */
+
+export const translate$times = (times: any) => {
+  if (typeof times !== "number") {
+    throw new Error("Can't set response $times with non-numeric value!");
+  }
+  const roundTimes = Math.round(times); // We ignore floats by rounding to an integer
+  if (roundTimes < 1) {
+    throw new Error(`Can't set response $times to ${times}!`);
+  }
+  debugLog(`Rounded response $times to ${times}`);
+  return buildUnmockPropety(SCHEMA_TIMES, times);
+};
+
+/**
+ * Translates the $size argument in the DSL, by verifying its location and value is logical.
+ * @param state
+ * @param schema
+ */
+export const translate$size = (state: any, schema: Schema): any => {
+  // assumes state.$size exists
+  if (schema.type === undefined || schema.type !== "array") {
+    throw new Error("Can't set '$size' for non-array elements!");
+  }
+  if (typeof state.$size !== "number") {
+    throw new Error("Can't request a non-number size of array!");
+  }
+  const nElements = Math.round(state.$size);
+  if (nElements < 0) {
+    throw new Error("Can't request a non-positive size of array!");
+  }
+  return { minItems: nElements, maxItems: nElements };
+};

--- a/packages/unmock-core/src/service/dsl/utils.ts
+++ b/packages/unmock-core/src/service/dsl/utils.ts
@@ -1,5 +1,16 @@
-import { UnmockServiceState } from "../interfaces";
-import { TopLevelDSLKeys } from "./interfaces";
+import debug from "debug";
+import {
+  codeToMedia,
+  isReference,
+  mediaTypeToSchema,
+  Schema,
+  UnmockServiceState,
+} from "../interfaces";
+import { UNMOCK_TYPE } from "./constants";
+import { DSL } from "./dsl";
+import { IUnmockProperty, TopLevelDSLKeys } from "./interfaces";
+
+const debugLog = debug("unmock:dsl:utils");
 
 export const getTopLevelDSL = (state: UnmockServiceState) => {
   return Object.keys(state)
@@ -19,4 +30,67 @@ export const filterTopLevelDSL = (state: UnmockServiceState) => {
         TopLevelDSLKeys[key] !== typeof state[key],
     )
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
+};
+
+export const throwOnErrorIfStrict = (fn: () => void) => {
+  try {
+    fn();
+  } catch (e) {
+    if (DSL.STRICT_MODE) {
+      throw e;
+    }
+  }
+};
+
+/**
+ * Every proper unmock property is an object of type `UNMOCK_TYPE` with the value set in `default`
+ * @param name
+ * @param value
+ */
+export const buildUnmockPropety = (name: string, value: any) => ({
+  [name]: { type: UNMOCK_TYPE, default: value },
+});
+
+/**
+ * Modifies responses in-place by injecting the given `unmockProperty` to every response's `properties`
+ * @param responses
+ * @param unmockProperty
+ */
+export const injectUnmockProperty = (
+  responses: codeToMedia,
+  unmockProperty: IUnmockProperty,
+) => {
+  Object.values(responses).forEach((response: mediaTypeToSchema) => {
+    Object.values(response).forEach((schema: Schema) => {
+      schema.properties = {
+        ...schema.properties,
+        ...unmockProperty,
+      };
+    });
+  });
+};
+
+/**
+ * Checks if given schema has the given unmock property with given `name`
+ * @param schema
+ * @param name
+ */
+export const hasUnmockProperty = (schema: Schema, name: string) => {
+  const log = (found: boolean) =>
+    debugLog(
+      `${found ? "Found" : "Can't find"} '${name}' in ${JSON.stringify(
+        schema,
+      )}`,
+    );
+  if (schema.properties === undefined) {
+    log(false);
+    return false;
+  }
+  const prop = schema.properties[name];
+  if (prop === undefined || isReference(prop)) {
+    log(false);
+    return false;
+  }
+  log(prop.type === UNMOCK_TYPE);
+  return prop.type === UNMOCK_TYPE;
 };

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -3,6 +3,7 @@
  */
 
 import Ajv from "ajv";
+import { DSL } from "../dsl";
 import {
   codeToMedia,
   isReference,
@@ -13,7 +14,6 @@ import {
   Responses,
   Schema,
 } from "../interfaces";
-import { DSL } from "../dsl";
 
 // These are specific to OAS and not part of json schema standard
 const ajv = new Ajv({ unknownFormats: ["int32", "int64"] });

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -35,7 +35,7 @@ const hasNestedItems = (obj: any) =>
   NESTED_SCHEMA_ITEMS.some((key: string) => obj[key] !== undefined);
 
 const isConcreteValue = (obj: any) =>
-  ["string", "number", "boolean"].includes(typeof obj);
+  ["string", "number", "boolean"].includes(typeof obj) || isSchema(obj);
 
 const isNonEmptyObject = (obj: any) =>
   typeof obj === "object" && Object.keys(obj).length > 0;
@@ -184,6 +184,7 @@ export const spreadStateFromService = (
   statePath: any,
 ): { [pathKey: string]: any | null } => {
   let matches: { [key: string]: any } = {};
+
   for (const key of Object.keys(statePath)) {
     const scm = serviceSchema[key];
     const stateValue = statePath[key];
@@ -199,7 +200,12 @@ export const spreadStateFromService = (
       }
     } else if (scm !== undefined) {
       if (isConcreteValue(stateValue)) {
-        // Option 2: Current scheme has matching key, and the state specifies a non-object. Validate schema.
+        // Option 2: Current scheme has matching key, and the state specifies a non-object (or schema). Validate schema.
+        console.log(statePath);
+        console.log(key);
+        console.log(stateValue);
+        console.log(serviceSchema);
+        console.log(scm);
         const spread = {
           [key]:
             isSchema(scm) && ajv.validate(scm, stateValue) ? stateValue : null,

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -192,7 +192,12 @@ export const spreadStateFromService = (
     if (scm === undefined) {
       if (hasNestedItems(serviceSchema)) {
         // Option 1: current schema has no matching key, but contains indirection (items/properties, etc)
-        const spread = oneLevelOfIndirectNestedness(serviceSchema, statePath);
+        // `statePath` at this point may also contain DSL elements, so we parse them before moving onwards
+        const translated = DSL.translateDSLToOAS(statePath, serviceSchema);
+        const spread = {
+          ...oneLevelOfIndirectNestedness(serviceSchema, statePath),
+          ...translated,
+        };
         if (Object.keys(spread).length === 0) {
           spread[key] = null;
         }

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -88,7 +88,6 @@ export const getValidResponsesForOperationWithState = (
   const relevantResponses: codeToMedia = {};
   let error: IMissingParam | undefined;
 
-  // TODO: Treat other top-level DSL elements...
   const statusCode = state.top.$code;
   // If $code is undefined, we look over all responses listed and find the suitable ones
   const codes =


### PR DESCRIPTION
- Translate `$size` argument to `minItems` and `maxItems`. This also reduces the responsibility of the generator since everything is OAS compliant.
- Handles inconsistency (i.e. `$size` given to non-array types, or invalid value for `$size` is given) based on `DSL.STRICT_MODE`. When `true`, throws an error. When `false`, treat "as is" (i.e. non-DSL argument).
- Splits subpackage to different responsibilities (actors and translators).
- [x] Add tests
- [x] Rebase after merging #74 