### PR TITLE
Add text dsl

### DIFF
--- a/packages/unmock-core/src/__tests__/dsl.test.ts
+++ b/packages/unmock-core/src/__tests__/dsl.test.ts
@@ -1,5 +1,5 @@
 import { DSL } from "../service/dsl";
-import { codeToMedia } from "../service/interfaces";
+import { codeToMedia, Schema } from "../service/interfaces";
 
 // tslint:disable: object-literal-key-quotes
 
@@ -21,22 +21,54 @@ const responsesWithProperties: codeToMedia = {
   },
 };
 
-describe("Resolves top level DSL to OAS", () => {
+describe("Translates top level DSL to OAS", () => {
   it("Returns undefined with undefined input", () => {
     expect(DSL.translateTopLevelToOAS({}, undefined)).toBeUndefined();
   });
 
   describe("Handles $times correctly", () => {
-    it("Throws on invalid $times (0)", () => {
+    it("Does nothing with invalid $times (0, negative, wrong type) without STRICT_MODE", () => {
+      DSL.STRICT_MODE = false;
+      let translated = DSL.translateTopLevelToOAS(
+        { $times: 0.3 },
+        responsesWithoutProperties,
+      );
+      expect(translated).toEqual({ 200: { "application/json": {} } });
+
+      translated = DSL.translateTopLevelToOAS(
+        { $times: -2 },
+        responsesWithoutProperties,
+      );
+      expect(translated).toEqual({ 200: { "application/json": {} } });
+
+      translated = DSL.translateTopLevelToOAS(
+        { $times: undefined },
+        responsesWithoutProperties,
+      );
+      expect(translated).toEqual({ 200: { "application/json": {} } });
+    });
+
+    it("Throws on invalid $times (0) with STRICT_MODE", () => {
+      DSL.STRICT_MODE = true;
       const translated = () =>
         DSL.translateTopLevelToOAS({ $times: 0.3 }, responsesWithoutProperties);
       expect(translated).toThrow("Can't set response $times to 0.3"); // 0.3 gets rounded to 0 and throws
     });
 
-    it("Throws on invalid $times (negative)", () => {
+    it("Throws on invalid $times (negative) with STRICT_MODE", () => {
+      DSL.STRICT_MODE = true;
       const translated = () =>
         DSL.translateTopLevelToOAS({ $times: -1 }, responsesWithoutProperties);
       expect(translated).toThrow("Can't set response $times to -1");
+    });
+
+    it("Throws on invalid $times (wrong type) with STRICT_MODE", () => {
+      DSL.STRICT_MODE = true;
+      const translated = () =>
+        DSL.translateTopLevelToOAS({ $times: "a" }, responsesWithoutProperties);
+      expect(translated).toThrow(
+        "Can't set response $times with non-numeric value!",
+      );
     });
 
     it("Adds properties when missing", () => {
@@ -68,6 +100,80 @@ describe("Resolves top level DSL to OAS", () => {
           },
         },
       });
+    });
+  });
+});
+
+describe("Translates non-top level DSL to OAS", () => {
+  it("Returns empty translation for empty state", () => {
+    expect(DSL.translateDSLToOAS({}, {})).toEqual({});
+  });
+
+  describe("Translates $size correctly", () => {
+    let arraySchema: Schema;
+
+    beforeEach(() => {
+      arraySchema = {
+        type: "array",
+        items: {
+          properties: {
+            id: {
+              type: "integer",
+            },
+          },
+        },
+      };
+    });
+
+    it("Leaves $size intact with invalid input without strict mode", () => {
+      DSL.STRICT_MODE = false;
+      // Test with non-numeric
+      const state: { $size: any } = { $size: "a" };
+      let translated = DSL.translateDSLToOAS(state, arraySchema);
+      expect(translated).toEqual({}); // Nothing was translated
+      expect(state).toEqual({ $size: "a" });
+
+      // Test with non-positive input
+      state.$size = -1;
+      translated = DSL.translateDSLToOAS(state, arraySchema);
+      expect(translated).toEqual({}); // Nothing was translated
+      expect(state).toEqual({ $size: -1 });
+
+      // Test with non-array input
+      state.$size = 5;
+      arraySchema.type = "object";
+      translated = DSL.translateDSLToOAS(state, arraySchema);
+      expect(translated).toEqual({}); // Nothing was translated
+      expect(state).toEqual({ $size: 5 });
+    });
+
+    it("Throws with non-numeric input in strict mode", () => {
+      DSL.STRICT_MODE = true;
+      const state = { $size: "a" };
+      const translated = () => DSL.translateDSLToOAS(state, arraySchema);
+      expect(translated).toThrow("non-numeric");
+    });
+
+    it("Throws with non-positive input in strict mode", () => {
+      DSL.STRICT_MODE = true;
+      const state = { $size: 0.3 }; // rounded to 0
+      const translated = () => DSL.translateDSLToOAS(state, arraySchema);
+      expect(translated).toThrow("non-positive");
+    });
+
+    it("Throws with non-array input in strict mode", () => {
+      DSL.STRICT_MODE = true;
+      const state = { $size: 3 };
+      arraySchema.type = "object";
+      const translated = () => DSL.translateDSLToOAS(state, arraySchema);
+      expect(translated).toThrow("non-array");
+    });
+
+    it("Translates $size correctly", () => {
+      const state = { $size: 3, id: 5 };
+      const translated = DSL.translateDSLToOAS(state, arraySchema);
+      expect(state).toEqual({ id: 5 }); // $size element should be removed
+      expect(translated).toEqual({ maxItems: 3, minItems: 3 });
     });
   });
 });

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -123,7 +123,7 @@ describe("Test state management", () => {
       paths: fullSchema.paths,
       schemaEndpoint: "**",
     });
-    const stateResult = state.getState(
+    const stateResult = state.augmentedStates(
       "get",
       "/",
       fullSchema.paths["/test/{test_id}"].get,
@@ -158,7 +158,11 @@ describe("Test state management", () => {
       schemaEndpoint: "**",
     });
     const getRes = () =>
-      state.getState("get", "/", fullSchema.paths["/test/{test_id}"].get);
+      state.augmentedStates(
+        "get",
+        "/",
+        fullSchema.paths["/test/{test_id}"].get,
+      );
     expect(getRes()).toEqual({
       200: {
         "application/json": {
@@ -210,7 +214,7 @@ describe("Test state management", () => {
       paths: fullSchema.paths,
       schemaEndpoint: "**",
     });
-    const stateResult = state.getState(
+    const stateResult = state.augmentedStates(
       "get",
       "/",
       fullSchema.paths["/test/{test_id}"].get,
@@ -260,7 +264,7 @@ describe("Test state management", () => {
       paths: fullSchema.paths,
       schemaEndpoint: "/test/{test_id}",
     });
-    const stateResult = state.getState(
+    const stateResult = state.augmentedStates(
       "get",
       "/test/5",
       fullSchema.paths["/test/{test_id}"].get,
@@ -290,7 +294,7 @@ describe("Test state management", () => {
       paths: fullSchema.paths,
       schemaEndpoint: "**",
     });
-    const stateResult = state.getState(
+    const stateResult = state.augmentedStates(
       "get",
       "/",
       fullSchema.paths["/test/{test_id}"].get,

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -52,14 +52,7 @@ export function responseCreatorFactory({
 }
 
 const setupJSFUnmockProperties = () => {
-  jsf.define("unmock-size", (value: number, schema: Schema) => {
-    if (schema.type !== "array") {
-      return schema; // validate type
-    }
-    schema.minItems = value;
-    schema.maxItems = value;
-    return schema;
-  });
+  // Handle post-generation references, etc?
 };
 
 const getStateForOperation = (

--- a/packages/unmock-core/src/service/dsl/actors.ts
+++ b/packages/unmock-core/src/service/dsl/actors.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { mediaTypeToSchema } from "../interfaces";
-import { SCHEMA_TIMES } from "./constants";
+import { SCHEMA_TEXT, SCHEMA_TIMES } from "./constants";
 import { Props } from "./interfaces";
 
 const debugLog = debug("unmock:dsl:actors");
@@ -36,5 +36,18 @@ export const actOn$times = (
     );
     delete copiedSchema[mediaType];
     delete originalSchema[mediaType];
+  }
+};
+
+export const actOn$text = (copiedSchema: mediaTypeToSchema) => {
+  for (const mediaType of Object.keys(copiedSchema)) {
+    const isStringType = copiedSchema[mediaType].type === "string";
+    const value = (copiedSchema[mediaType].properties as Props)[SCHEMA_TEXT];
+    // Remove the property from the schema
+    delete (copiedSchema[mediaType].properties as Props)[SCHEMA_TEXT];
+    if (isStringType) {
+      // Using JSF 'const' to generate constant values.
+      (copiedSchema[mediaType] as any).const = value.default;
+    }
   }
 };

--- a/packages/unmock-core/src/service/dsl/actors.ts
+++ b/packages/unmock-core/src/service/dsl/actors.ts
@@ -1,0 +1,40 @@
+import debug from "debug";
+import { mediaTypeToSchema } from "../interfaces";
+import { SCHEMA_TIMES } from "./constants";
+import { Props } from "./interfaces";
+
+const debugLog = debug("unmock:dsl:actors");
+
+/*
+ * Actors (actOn$X) are found here. They modify the behaviour/schemas according to specific DSL instructions.
+ */
+
+/**
+ * Acts on the $times argument in top level DSL by synchronizing and modifying the copied and original schemas.
+ * The value of $times is decreased by 1 and removed from the copied schema.
+ * If the new value is less than 0 (i.e. this state has expired),
+ * the content is removed from **both** the copied and original schemas.
+ * @param copiedSchema
+ * @param originalSchema
+ * @param mediaType
+ */
+export const actOn$times = (
+  copiedSchema: mediaTypeToSchema,
+  originalSchema: mediaTypeToSchema,
+  mediaType: string,
+) => {
+  // update the default value
+  const origTimes = (originalSchema[mediaType].properties as Props)[
+    SCHEMA_TIMES
+  ];
+  origTimes.default -= 1;
+  // delete value in copy (for clean return)
+  delete (copiedSchema[mediaType].properties as Props)[SCHEMA_TIMES];
+  if (origTimes.default < 0) {
+    debugLog(
+      `$times has expired for '${mediaType}', removing state in both copied and original`,
+    );
+    delete copiedSchema[mediaType];
+    delete originalSchema[mediaType];
+  }
+};

--- a/packages/unmock-core/src/service/dsl/constants.ts
+++ b/packages/unmock-core/src/service/dsl/constants.ts
@@ -1,0 +1,3 @@
+const SCHEMA_PREFIX = "x-unmock-";
+export const SCHEMA_TIMES = `${SCHEMA_PREFIX}times`;
+export const UNMOCK_TYPE = "unmock";

--- a/packages/unmock-core/src/service/dsl/constants.ts
+++ b/packages/unmock-core/src/service/dsl/constants.ts
@@ -1,3 +1,4 @@
 const SCHEMA_PREFIX = "x-unmock-";
 export const SCHEMA_TIMES = `${SCHEMA_PREFIX}times`;
+export const SCHEMA_TEXT = `${SCHEMA_PREFIX}text`;
 export const UNMOCK_TYPE = "unmock";

--- a/packages/unmock-core/src/service/dsl/dsl.ts
+++ b/packages/unmock-core/src/service/dsl/dsl.ts
@@ -1,10 +1,10 @@
 import debug from "debug";
 import { cloneDeep } from "lodash";
 import { codeToMedia, Schema } from "../interfaces";
-import { actOn$times } from "./actors";
-import { SCHEMA_TIMES } from "./constants";
+import { actOn$text, actOn$times } from "./actors";
+import { SCHEMA_TEXT, SCHEMA_TIMES } from "./constants";
 import { ITopLevelDSL } from "./interfaces";
-import { translate$size, translate$times } from "./translators";
+import { translate$size, translate$text, translate$times } from "./translators";
 import {
   hasUnmockProperty,
   injectUnmockProperty,
@@ -65,6 +65,12 @@ export abstract class DSL {
         injectUnmockProperty(responses, translated);
       });
     }
+    if (top.$text !== undefined) {
+      throwOnErrorIfStrict(() => {
+        const translated = translate$text(top.$text);
+        injectUnmockProperty(responses, translated);
+      });
+    }
     return responses;
   }
 
@@ -84,9 +90,14 @@ export abstract class DSL {
         if (schema.properties === undefined) {
           continue;
         }
+
         if (hasUnmockProperty(schema, SCHEMA_TIMES)) {
           actOn$times(copy[code], states[code], mediaType);
         }
+        if (hasUnmockProperty(schema, SCHEMA_TEXT)) {
+          actOn$text(copy[code]);
+        }
+
         if (Object.keys(schema.properties).length === 0) {
           debugLog(
             `schema.properties is now empty, removing 'properties' from copied response '${code}/${mediaType}'`,

--- a/packages/unmock-core/src/service/dsl/dsl.ts
+++ b/packages/unmock-core/src/service/dsl/dsl.ts
@@ -44,34 +44,34 @@ export abstract class DSL {
     return translated;
   }
   /**
-   * Replaces top-level DSL elements in `top` with injected OAS items in every `response` in `responses`.
+   * Replaces top-level DSL elements in `top` with injected OAS items in every `response` in `states`.
    * Objects injected are always prefixed with `x-unmock-`, and have a `type` equal to `unmock`, with the
    * relevant value being stored in `default`.
    * @param top
-   * @param responses
+   * @param states
    */
   public static translateTopLevelToOAS(
     top: ITopLevelDSL,
-    responses: codeToMedia | undefined,
+    states: codeToMedia | undefined,
   ): codeToMedia | undefined {
-    if (responses === undefined) {
-      return responses;
+    if (states === undefined) {
+      return states;
     }
     // Handles top-level schema and injects the literals to responses.
     // $code is a special case, handled outside this function (acts as a key and not a value)
     if (top.$times !== undefined) {
       throwOnErrorIfStrict(() => {
         const translated = translate$times(top.$times);
-        injectUnmockProperty(responses, translated);
+        injectUnmockProperty(states, translated);
       });
     }
     if (top.$text !== undefined) {
       throwOnErrorIfStrict(() => {
         const translated = translate$text(top.$text);
-        injectUnmockProperty(responses, translated);
+        injectUnmockProperty(states, translated);
       });
     }
-    return responses;
+    return states;
   }
 
   /**

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -1,3 +1,5 @@
+import { Schema } from "../interfaces";
+
 /**
  * DSL related parameters that can only be found at the top level
  */
@@ -19,10 +21,20 @@ export interface ITopLevelDSL {
 /**
  * DSL related parameters that can be found at any level in the schema
  */
+
 export interface IDSL {
   /**
    * Used to control and generate arrays of specific sizes.
    */
   $size?: number;
   [key: string]: number | string | boolean | undefined;
+}
+
+export type Props = Record<string, Schema>;
+
+export interface IUnmockProperty {
+  [key: string]: {
+    type: string;
+    default: any;
+  };
 }

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -7,6 +7,7 @@ import { Schema } from "../interfaces";
 export const TopLevelDSLKeys: { [DSLKey: string]: string } = {
   $code: "number",
   $times: "number",
+  $text: "string",
 } as const;
 
 export interface ITopLevelDSL {
@@ -15,7 +16,12 @@ export interface ITopLevelDSL {
    * If the requested response code is not found, returns 'default'
    */
   $code?: number;
+  /**
+   * Defines the number of times a specific state will be used before expiring
+   */
   $times?: number;
+  /** Defines a textual response if the schema matches */
+  $text?: string;
 }
 
 /**

--- a/packages/unmock-core/src/service/dsl/translators.ts
+++ b/packages/unmock-core/src/service/dsl/translators.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { Schema } from "../interfaces";
-import { SCHEMA_TIMES } from "./constants";
+import { SCHEMA_TEXT, SCHEMA_TIMES } from "./constants";
 import { buildUnmockPropety } from "./utils";
 
 const debugLog = debug("unmock:dsl:translators");
@@ -18,6 +18,13 @@ export const translate$times = (times: any) => {
   }
   debugLog(`Rounded response $times to ${times}`);
   return buildUnmockPropety(SCHEMA_TIMES, times);
+};
+
+export const translate$text = (text: any) => {
+  if (typeof text !== "string") {
+    throw new Error("Can't set text/plain response to non-string value!");
+  }
+  return buildUnmockPropety(SCHEMA_TEXT, text);
 };
 
 /**

--- a/packages/unmock-core/src/service/dsl/translators.ts
+++ b/packages/unmock-core/src/service/dsl/translators.ts
@@ -1,0 +1,41 @@
+import debug from "debug";
+import { Schema } from "../interfaces";
+import { SCHEMA_TIMES } from "./constants";
+import { buildUnmockPropety } from "./utils";
+
+const debugLog = debug("unmock:dsl:translators");
+/*
+ * Translators (translate$X) are found here. They translate a DSL instruction to OAS, without modifying any schemas.
+ */
+
+export const translate$times = (times: any) => {
+  if (typeof times !== "number") {
+    throw new Error("Can't set response $times with non-numeric value!");
+  }
+  const roundTimes = Math.round(times); // We ignore floats by rounding to an integer
+  if (roundTimes < 1) {
+    throw new Error(`Can't set response $times to ${times}!`);
+  }
+  debugLog(`Rounded response $times to ${times}`);
+  return buildUnmockPropety(SCHEMA_TIMES, times);
+};
+
+/**
+ * Translates the $size argument in the DSL, by verifying its location and value is logical.
+ * @param state
+ * @param schema
+ */
+export const translate$size = (state: any, schema: Schema): any => {
+  // assumes state.$size exists
+  if (schema.type === undefined || schema.type !== "array") {
+    throw new Error("Can't set '$size' for non-array elements!");
+  }
+  if (typeof state.$size !== "number") {
+    throw new Error("Can't request a non-numeric size of array!");
+  }
+  const nElements = Math.round(state.$size);
+  if (nElements < 1) {
+    throw new Error("Can't request a non-positive size of array!");
+  }
+  return { minItems: nElements, maxItems: nElements };
+};

--- a/packages/unmock-core/src/service/dsl/utils.ts
+++ b/packages/unmock-core/src/service/dsl/utils.ts
@@ -1,5 +1,16 @@
-import { UnmockServiceState } from "../interfaces";
-import { TopLevelDSLKeys } from "./interfaces";
+import debug from "debug";
+import {
+  codeToMedia,
+  isReference,
+  mediaTypeToSchema,
+  Schema,
+  UnmockServiceState,
+} from "../interfaces";
+import { UNMOCK_TYPE } from "./constants";
+import { DSL } from "./dsl";
+import { IUnmockProperty, TopLevelDSLKeys } from "./interfaces";
+
+const debugLog = debug("unmock:dsl:utils");
 
 export const getTopLevelDSL = (state: UnmockServiceState) => {
   return Object.keys(state)
@@ -19,4 +30,67 @@ export const filterTopLevelDSL = (state: UnmockServiceState) => {
         TopLevelDSLKeys[key] !== typeof state[key],
     )
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
+};
+
+export const throwOnErrorIfStrict = (fn: () => void) => {
+  try {
+    fn();
+  } catch (e) {
+    if (DSL.STRICT_MODE) {
+      throw e;
+    }
+  }
+};
+
+/**
+ * Every proper unmock property is an object of type `UNMOCK_TYPE` with the value set in `default`
+ * @param name
+ * @param value
+ */
+export const buildUnmockPropety = (name: string, value: any) => ({
+  [name]: { type: UNMOCK_TYPE, default: value },
+});
+
+/**
+ * Modifies responses in-place by injecting the given `unmockProperty` to every response's `properties`
+ * @param responses
+ * @param unmockProperty
+ */
+export const injectUnmockProperty = (
+  responses: codeToMedia,
+  unmockProperty: IUnmockProperty,
+) => {
+  Object.values(responses).forEach((response: mediaTypeToSchema) => {
+    Object.values(response).forEach((schema: Schema) => {
+      schema.properties = {
+        ...schema.properties,
+        ...unmockProperty,
+      };
+    });
+  });
+};
+
+/**
+ * Checks if given schema has the given unmock property with given `name`
+ * @param schema
+ * @param name
+ */
+export const hasUnmockProperty = (schema: Schema, name: string) => {
+  const log = (found: boolean) =>
+    debugLog(
+      `${found ? "Found" : "Can't find"} '${name}' in ${JSON.stringify(
+        schema,
+      )}`,
+    );
+  if (schema.properties === undefined) {
+    log(false);
+    return false;
+  }
+  const prop = schema.properties[name];
+  if (prop === undefined || isReference(prop)) {
+    log(false);
+    return false;
+  }
+  log(prop.type === UNMOCK_TYPE);
+  return prop.type === UNMOCK_TYPE;
 };

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -55,11 +55,12 @@ export class State {
       );
       if (stateResponses.error === undefined) {
         debugLog(`Matched successfully for ${op.operation.operationId}`);
-        const augmentedResponses = DSL.translateTopLevelToOAS(
+        // We apply the augmentation to copies, not the original schema.
+        const augmentedStates = DSL.translateTopLevelToOAS(
           newState.top,
           stateResponses.responses,
         );
-        this.updateStateInternal(endpoint, method, augmentedResponses);
+        this.updateStateInternal(endpoint, method, augmentedStates);
         return true;
       }
       // failed path

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -71,7 +71,7 @@ const oneLevelOfIndirectNestedness = (
 };
 
 /**
- * Given a state and an operation, returns all the valid responses that
+ * Given a state and an operation, returns **a copy** of all the valid responses that
  * match the given state.
  * First-level filtering is done via $code (status code) if it exists,
  * otherwise via matching the parameters set in `state`.

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -3,6 +3,7 @@
  */
 
 import Ajv from "ajv";
+import { DSL } from "../dsl";
 import {
   codeToMedia,
   isReference,
@@ -87,7 +88,6 @@ export const getValidResponsesForOperationWithState = (
   const relevantResponses: codeToMedia = {};
   let error: IMissingParam | undefined;
 
-  // TODO: Treat other top-level DSL elements...
   const statusCode = state.top.$code;
   // If $code is undefined, we look over all responses listed and find the suitable ones
   const codes =
@@ -184,6 +184,7 @@ export const spreadStateFromService = (
   statePath: any,
 ): { [pathKey: string]: any | null } => {
   let matches: { [key: string]: any } = {};
+
   for (const key of Object.keys(statePath)) {
     const scm = serviceSchema[key];
     const stateValue = statePath[key];
@@ -199,7 +200,8 @@ export const spreadStateFromService = (
       }
     } else if (scm !== undefined) {
       if (isConcreteValue(stateValue)) {
-        // Option 2: Current scheme has matching key, and the state specifies a non-object. Validate schema.
+        // Option 2: Current scheme has matching key, and the state specifies a non-object (or schema). Validate schema.
+        // TODO do we want to throw for invalid types?
         const spread = {
           [key]:
             isSchema(scm) && ajv.validate(scm, stateValue) ? stateValue : null,
@@ -207,7 +209,11 @@ export const spreadStateFromService = (
         matches = { ...matches, ...spread };
       } else if (hasNestedItems(scm) || isNonEmptyObject(scm)) {
         // Option 3: Current scheme has matching key, state specifies an object - traverse schema and indirection
-        const spread = { [key]: spreadStateFromService(scm, stateValue) };
+        // `stateValue` at this point may also contain DSL elements, so we parse them before moving onwards
+        const translated = DSL.translateDSLToOAS(stateValue, scm);
+        const spread = {
+          [key]: { ...spreadStateFromService(scm, stateValue), ...translated },
+        };
         matches = {
           ...matches,
           ...oneLevelOfIndirectNestedness(scm, statePath, spread),

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -192,7 +192,12 @@ export const spreadStateFromService = (
     if (scm === undefined) {
       if (hasNestedItems(serviceSchema)) {
         // Option 1: current schema has no matching key, but contains indirection (items/properties, etc)
-        const spread = oneLevelOfIndirectNestedness(serviceSchema, statePath);
+        // `statePath` at this point may also contain DSL elements, so we parse them before moving onwards
+        const translated = DSL.translateDSLToOAS(statePath, serviceSchema);
+        const spread = {
+          ...oneLevelOfIndirectNestedness(serviceSchema, statePath),
+          ...translated,
+        };
         if (Object.keys(spread).length === 0) {
           spread[key] = null;
         }


### PR DESCRIPTION
Should we use `$text` to specify `text/plain` responses? And if so, should we only allow it at the top-most level?
- [ ] Rebase after merging #76 