### PR TITLE
Add text middleware

### DIFF
--- a/packages/unmock-core/src/__tests__/middleware.test.ts
+++ b/packages/unmock-core/src/__tests__/middleware.test.ts
@@ -35,15 +35,12 @@ const schema: Schema = {
   },
 };
 
-const textSchema: Schema = {
-  type: "string",
-};
-
 describe("Test text provider", () => {
   it("returns empty object for undefined state", () => {
     const p = textMW();
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
+    // @ts-ignore // deliberately checking with empty input
     expect(p.gen()).toEqual({});
   });
 
@@ -51,6 +48,7 @@ describe("Test text provider", () => {
     const p = textMW("");
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
+    // @ts-ignore // deliberately checking with empty input
     expect(p.gen()).toEqual({});
   });
 
@@ -58,6 +56,7 @@ describe("Test text provider", () => {
     const p = textMW("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
+    // @ts-ignore // deliberately checking with empty input
     expect(p.gen()).toEqual({});
   });
 
@@ -98,7 +97,10 @@ describe("Test default provider", () => {
     expect(p.gen({})).toEqual({}); // no schema to expand
     expect(p.gen({ properties: { foo: { type: "string" } } })).toEqual({
       properties: {
-        foo: "bar",
+        foo: {
+          type: "string",
+          const: "bar",
+        },
       },
     });
   });

--- a/packages/unmock-core/src/__tests__/middleware.test.ts
+++ b/packages/unmock-core/src/__tests__/middleware.test.ts
@@ -1,6 +1,7 @@
 import { Schema } from "../service/interfaces";
 import defMiddleware, {
   spreadStateFromService,
+  textMW,
 } from "../service/state/middleware";
 
 const schema: Schema = {
@@ -33,6 +34,47 @@ const schema: Schema = {
     tag: { type: "string" },
   },
 };
+
+const textSchema: Schema = {
+  type: "string",
+};
+
+describe("Test text provider", () => {
+  it("returns empty object for undefined state", () => {
+    const p = textMW();
+    expect(p.isEmpty).toBeTruthy();
+    expect(p.top).toEqual({});
+    expect(p.gen()).toEqual({});
+  });
+
+  it("returns empty object for empty state", () => {
+    const p = textMW("");
+    expect(p.isEmpty).toBeTruthy();
+    expect(p.top).toEqual({});
+    expect(p.gen()).toEqual({});
+  });
+
+  it("returns empty object for empty schema", () => {
+    const p = textMW("foo");
+    expect(p.isEmpty).toBeFalsy();
+    expect(p.top).toEqual({});
+    expect(p.gen()).toEqual({});
+  });
+
+  it("returns empty object for non-text schema", () => {
+    const p = textMW("foo");
+    expect(p.isEmpty).toBeFalsy();
+    expect(p.top).toEqual({});
+    expect(p.gen({ type: "array", items: {} })).toEqual({});
+  });
+
+  it("returns correct state object for valid input", () => {
+    const p = textMW("foo");
+    expect(p.isEmpty).toBeFalsy();
+    expect(p.top).toEqual({});
+    expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
+  });
+});
 
 describe("Test default provider", () => {
   it("returns empty objects for undefined state", () => {

--- a/packages/unmock-core/src/__tests__/middleware.test.ts
+++ b/packages/unmock-core/src/__tests__/middleware.test.ts
@@ -73,6 +73,13 @@ describe("Test text provider", () => {
     expect(p.top).toEqual({});
     expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
   });
+
+  it("top level DSL doesn't change response", () => {
+    const p = textMW("foo", { $code: 200, notDSL: "a" });
+    expect(p.isEmpty).toBeFalsy();
+    expect(p.top).toEqual({ $code: 200 }); // non DSL is filtered out
+    expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
+  });
 });
 
 describe("Test default provider", () => {

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -1,4 +1,9 @@
-import defMiddleware from "../service/state/middleware";
+import {
+  ExtendedHTTPMethod,
+  HTTPMethod,
+  IStateInputGenerator,
+} from "../service/interfaces";
+import defMiddleware, { textMW } from "../service/state/middleware";
 import { State } from "../service/state/state";
 
 const fullSchema = {
@@ -37,11 +42,7 @@ const fullSchema = {
               },
               "text/plain": {
                 schema: {
-                  properties: {
-                    notId: {
-                      type: "string",
-                    },
-                  },
+                  type: "string",
                 },
               },
             },
@@ -66,72 +67,53 @@ const fullSchema = {
   },
 };
 
+const updateState = (
+  state: State,
+  method: ExtendedHTTPMethod,
+  endpoint: string,
+  newState: IStateInputGenerator,
+  schemaEndpoint: string,
+) =>
+  state.update({
+    stateInput: {
+      method,
+      endpoint,
+      newState,
+    },
+    serviceName: "foo",
+    paths: fullSchema.paths,
+    schemaEndpoint,
+  });
+
+const getState = (state: State, method: HTTPMethod, endpoint: string) =>
+  state.getState(method, endpoint, fullSchema.paths["/test/{test_id}"].get);
+
 describe("Test state management", () => {
   it("returns undefined when setting empty state", () => {
     const state = new State();
     expect(
-      state.update({
-        stateInput: {
-          method: "any",
-          endpoint: "**",
-          newState: defMiddleware(),
-        },
-        serviceName: "foo",
-        paths: fullSchema.paths,
-        schemaEndpoint: "**",
-      }),
+      updateState(state, "any", "**", defMiddleware(), "**"),
     ).toBeUndefined();
   });
 
   it("throws when setting state for non-existing method with generic endpoint", () => {
     const state = new State();
     expect(() =>
-      state.update({
-        stateInput: {
-          method: "post",
-          endpoint: "**",
-          newState: defMiddleware(),
-        },
-        serviceName: "foo",
-        paths: fullSchema.paths,
-        schemaEndpoint: "**",
-      }),
+      updateState(state, "post", "**", defMiddleware(), "**"),
     ).toThrow("Can't find any endpoints with method 'post'");
   });
 
   it("throws when setting state for non-existing method with specific, existing endpoint", () => {
     const state = new State();
     expect(() =>
-      state.update({
-        stateInput: {
-          method: "post",
-          endpoint: "/test/5",
-          newState: defMiddleware(),
-        },
-        serviceName: "foo",
-        paths: fullSchema.paths,
-        schemaEndpoint: "/test/{test_id}",
-      }),
+      updateState(state, "post", "/test/5", defMiddleware(), "/test/{test_id}"),
     ).toThrow("Can't find response for 'post /test/5'");
   });
 
   it("saves state from any endpoint and get method as expected", () => {
     const state = new State();
-    state.update({
-      stateInput: {
-        method: "get",
-        endpoint: "**",
-        newState: defMiddleware({ foo: { id: 5 } }),
-      },
-      serviceName: "foo",
-      paths: fullSchema.paths,
-      schemaEndpoint: "**",
-    });
-    const stateResult = state.getState(
-      "get",
-      "/",
-      fullSchema.paths["/test/{test_id}"].get,
-    );
+    updateState(state, "get", "**", defMiddleware({ foo: { id: 5 } }), "**");
+    const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: {
         "application/json": {
@@ -151,18 +133,8 @@ describe("Test state management", () => {
 
   it("parses $times on specific endpoint as expected", () => {
     const state = new State();
-    state.update({
-      stateInput: {
-        method: "get",
-        endpoint: "**",
-        newState: defMiddleware({ id: 5, $times: 2 }),
-      },
-      serviceName: "foo",
-      paths: fullSchema.paths,
-      schemaEndpoint: "**",
-    });
-    const getRes = () =>
-      state.getState("get", "/", fullSchema.paths["/test/{test_id}"].get);
+    updateState(state, "get", "**", defMiddleware({ id: 5, $times: 2 }), "**");
+    const getRes = () => getState(state, "get", "/");
     expect(getRes()).toEqual({
       200: {
         "application/json": {
@@ -204,21 +176,8 @@ describe("Test state management", () => {
 
   it("saves state from any endpoint and any method as expected", () => {
     const state = new State();
-    state.update({
-      stateInput: {
-        method: "any",
-        endpoint: "**",
-        newState: defMiddleware({ id: 5 }),
-      },
-      serviceName: "foo",
-      paths: fullSchema.paths,
-      schemaEndpoint: "**",
-    });
-    const stateResult = state.getState(
-      "get",
-      "/",
-      fullSchema.paths["/test/{test_id}"].get,
-    );
+    updateState(state, "any", "**", defMiddleware({ id: 5 }), "**");
+    const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: {
         "application/json": {
@@ -234,41 +193,22 @@ describe("Test state management", () => {
 
   it("spreads states from multiple paths correctly", () => {
     const state = new State();
-    state.update({
-      stateInput: {
-        method: "any",
-        endpoint: "**",
-        newState: defMiddleware({ id: 5 }),
-      },
-      serviceName: "foo",
-      paths: fullSchema.paths,
-      schemaEndpoint: "**",
-    });
-    state.update({
-      stateInput: {
-        method: "any",
-        endpoint: "/test/5",
-        newState: defMiddleware({ id: 3 }),
-      },
-      serviceName: "foo",
-      paths: fullSchema.paths,
-      schemaEndpoint: "/test/{test_id}",
-    });
-    state.update({
-      stateInput: {
-        method: "any",
-        endpoint: "/test/*",
-        newState: defMiddleware({ id: -1 }),
-      },
-      serviceName: "foo",
-      paths: fullSchema.paths,
-      schemaEndpoint: "/test/{test_id}",
-    });
-    const stateResult = state.getState(
-      "get",
+    updateState(state, "any", "**", defMiddleware({ id: 5 }), "**");
+    updateState(
+      state,
+      "any",
       "/test/5",
-      fullSchema.paths["/test/{test_id}"].get,
+      defMiddleware({ id: 3 }),
+      "/test/{test_id}",
     );
+    updateState(
+      state,
+      "any",
+      "/test/*",
+      defMiddleware({ id: -1 }),
+      "/test/{test_id}",
+    );
+    const stateResult = getState(state, "get", "/test/5");
     expect(stateResult).toEqual({
       200: {
         "application/json": {
@@ -284,21 +224,8 @@ describe("Test state management", () => {
 
   it("saves nested state correctly", () => {
     const state = new State();
-    state.update({
-      stateInput: {
-        method: "any",
-        endpoint: "**",
-        newState: defMiddleware({ foo: { id: 5 } }),
-      },
-      serviceName: "foo",
-      paths: fullSchema.paths,
-      schemaEndpoint: "**",
-    });
-    const stateResult = state.getState(
-      "get",
-      "/",
-      fullSchema.paths["/test/{test_id}"].get,
-    );
+    updateState(state, "any", "**", defMiddleware({ foo: { id: 5 } }), "**");
+    const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: {
         "application/json": {

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -121,7 +121,10 @@ describe("Test state management", () => {
             properties: {
               foo: {
                 properties: {
-                  id: 5,
+                  id: {
+                    type: "integer",
+                    const: 5,
+                  },
                 },
               },
             },
@@ -140,7 +143,10 @@ describe("Test state management", () => {
         "application/json": {
           items: {
             properties: {
-              id: 5,
+              id: {
+                type: "integer",
+                const: 5,
+              },
             },
           },
         },
@@ -151,7 +157,10 @@ describe("Test state management", () => {
         "application/json": {
           items: {
             properties: {
-              id: 5,
+              id: {
+                type: "integer",
+                const: 5,
+              },
             },
           },
         },
@@ -164,7 +173,10 @@ describe("Test state management", () => {
             properties: {
               foo: {
                 properties: {
-                  id: 5,
+                  id: {
+                    type: "integer",
+                    const: 5,
+                  },
                 },
               },
             },
@@ -183,7 +195,10 @@ describe("Test state management", () => {
         "application/json": {
           items: {
             properties: {
-              id: 5,
+              id: {
+                type: "integer",
+                const: 5,
+              },
             },
           },
         },
@@ -214,7 +229,10 @@ describe("Test state management", () => {
         "application/json": {
           items: {
             properties: {
-              id: 3,
+              id: {
+                type: "integer",
+                const: 3,
+              },
             },
           },
         },
@@ -233,7 +251,10 @@ describe("Test state management", () => {
             properties: {
               foo: {
                 properties: {
-                  id: 5,
+                  id: {
+                    type: "integer",
+                    const: 5,
+                  },
                 },
               },
             },

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -242,4 +242,13 @@ describe("Test state management", () => {
       },
     });
   });
+
+  it("Handles textual state correctly", () => {
+    const state = new State();
+    updateState(state, "any", "**", textMW("foobar"), "**");
+    const stateResult = getState(state, "get", "/");
+    expect(stateResult).toEqual({
+      200: { "text/plain": { const: "foobar", type: "string" } },
+    });
+  });
 });

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,6 +1,6 @@
 import { Response, Responses, Schema } from "../service/interfaces";
 import defMiddleware from "../service/state/middleware";
-import { getValidResponsesForOperationWithState } from "../service/state/validator";
+import { getValidStatesForOperationWithState } from "../service/state/validator";
 
 const arraySchema: Schema = {
   type: "array",
@@ -63,7 +63,7 @@ const arrResponses: { responses: Responses } = {
 
 describe("Tests getValidResponsesForOperationWithState", () => {
   it("with empty state", () => {
-    const spreadState = getValidResponsesForOperationWithState(
+    const spreadState = getValidStatesForOperationWithState(
       op,
       defMiddleware(),
     );
@@ -72,7 +72,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("invalid parameter returns error", () => {
-    const spreadState = getValidResponsesForOperationWithState(
+    const spreadState = getValidStatesForOperationWithState(
       op,
       defMiddleware({
         boom: 5,
@@ -82,7 +82,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("empty schema returns error", () => {
-    const spreadState = getValidResponsesForOperationWithState(
+    const spreadState = getValidStatesForOperationWithState(
       {
         responses: {
           200: { content: { "application/json": {} }, description: "foo" },
@@ -94,7 +94,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("with $code specified", () => {
-    const spreadState = getValidResponsesForOperationWithState(
+    const spreadState = getValidStatesForOperationWithState(
       op,
       defMiddleware({
         $code: 200,
@@ -112,7 +112,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("with $size in top-level specified", () => {
-    const spreadState = getValidResponsesForOperationWithState(
+    const spreadState = getValidStatesForOperationWithState(
       arrResponses,
       defMiddleware({ $size: 5 }),
     );
@@ -128,7 +128,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("with missing $code specified", () => {
-    const spreadState = getValidResponsesForOperationWithState(
+    const spreadState = getValidStatesForOperationWithState(
       op,
       defMiddleware({
         $code: 404,
@@ -141,7 +141,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   });
 
   it("with no $code specified", () => {
-    const spreadState = getValidResponsesForOperationWithState(
+    const spreadState = getValidStatesForOperationWithState(
       op,
       defMiddleware({
         test: { id: 5 },

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,4 +1,4 @@
-import { Response, Schema } from "../service/interfaces";
+import { Response, Responses, Schema } from "../service/interfaces";
 import defMiddleware from "../service/state/middleware";
 import { getValidResponsesForOperationWithState } from "../service/state/validator";
 
@@ -68,11 +68,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       defMiddleware(),
     );
     expect(spreadState.error).toBeUndefined();
-    expect(spreadState.responses).toEqual({
-      200: {
-        "application/json": {},
-      },
-    });
+    expect(spreadState.responses).toBeUndefined();
   });
 
   it("invalid parameter returns error", () => {
@@ -102,10 +98,17 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       op,
       defMiddleware({
         $code: 200,
+        tag: "foo",
       }),
     );
     expect(spreadState.error).toBeUndefined();
-    expect(spreadState.responses).toEqual({ 200: { "application/json": {} } });
+    expect(spreadState.responses).toEqual({
+      200: {
+        "application/json": {
+          properties: { tag: { type: "string", const: "foo" } },
+        },
+      },
+    });
   });
 
   it("with $size in top-level specified", () => {
@@ -151,7 +154,11 @@ describe("Tests getValidResponsesForOperationWithState", () => {
           properties: {
             test: {
               properties: {
-                id: 5,
+                id: {
+                  type: "integer",
+                  format: "int64",
+                  const: 5,
+                },
               },
             },
           },

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -101,6 +101,20 @@ const getStateForOperation = (
   };
 };
 
+/**
+ * Provides a work-around with for functions that may fail with a default value.
+ * Attemps to return `f(value)`. If an error is thrown, returns `value`.
+ * @param value
+ * @param f
+ */
+const tryCatch = (value: any, f: (value: any) => any) => {
+  try {
+    return f(value);
+  } catch {
+    return value;
+  }
+};
+
 const chooseResponseFromOperation = (
   operation: Operation,
 ): { $code: string; template: Schema } => {
@@ -152,15 +166,10 @@ const generateMockFromTemplate = (
   // First iteration simply parses these and returns the updated schema
   const resolvedTemplate = jsf.generate(template);
   jsf.reset();
-  // After one-pass resolving we might have new parameters to resolve.
-  let body: string;
-  try {
-    body = JSON.stringify(jsf.generate(resolvedTemplate));
-  } catch {
-    body = JSON.stringify(resolvedTemplate);
-  }
 
-  // 5. Generate as needed
+  // After one-pass resolving we might have new parameters to resolve.
+  const body = JSON.stringify(tryCatch(resolvedTemplate, jsf.generate));
+
   return {
     body,
     // TODO: headers

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -152,10 +152,17 @@ const generateMockFromTemplate = (
   // First iteration simply parses these and returns the updated schema
   const resolvedTemplate = jsf.generate(template);
   jsf.reset();
+  // After one-pass resolving we might have new parameters to resolve.
+  let body: string;
+  try {
+    body = JSON.stringify(jsf.generate(resolvedTemplate));
+  } catch {
+    body = JSON.stringify(resolvedTemplate);
+  }
 
   // 5. Generate as needed
   return {
-    body: JSON.stringify(jsf.generate(resolvedTemplate)),
+    body,
     // TODO: headers
     statusCode: +$code || 200,
   };

--- a/packages/unmock-core/src/service/dsl/index.ts
+++ b/packages/unmock-core/src/service/dsl/index.ts
@@ -1,2 +1,3 @@
 export { getTopLevelDSL, filterTopLevelDSL } from "./utils";
 export { DSL } from "./dsl";
+export { ITopLevelDSL } from "./interfaces";

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -54,8 +54,18 @@ export interface IServiceMapping {
 }
 
 export interface IStateInputGenerator {
+  /**
+   * Whether or not the given state is actually empty
+   */
   isEmpty: boolean;
-  gen: (schema: Schema) => Record<string, Schema>;
+  /**
+   * Generates a new state (copy) based on the given schema, so that
+   * future processes can use it without modifying the original schema.
+   */
+  gen: (schema: Schema) => Record<string, Schema> | Schema;
+  /**
+   * Returns top-level DSL, if it exists.
+   */
   top: ITopLevelDSL;
 }
 export const isStateInputGenerator = (u: any): u is IStateInputGenerator =>

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -72,7 +72,6 @@ export const isStateInputGenerator = (u: any): u is IStateInputGenerator =>
   u !== undefined &&
   u.top !== undefined &&
   u.gen !== undefined &&
-  typeof u.top === "function" &&
   typeof u.gen === "function";
 
 export interface IStateInput {

--- a/packages/unmock-core/src/service/state/middleware.ts
+++ b/packages/unmock-core/src/service/state/middleware.ts
@@ -17,6 +17,19 @@ export default (state?: UnmockServiceState): IStateInputGenerator => ({
     spreadStateFromService(schema, filterTopLevelDSL(state || {})),
 });
 
+export const textMW = (state?: string): IStateInputGenerator => ({
+  isEmpty: typeof state !== "string" || state.length === 0,
+  top: {},
+  gen: (schema: Schema) => generateTextResponse(schema, state),
+});
+
+const generateTextResponse = (schema: Schema, state: string | undefined) => {
+  if (state === undefined || schema === undefined || schema.type !== "string") {
+    return {};
+  }
+  return { ...schema, const: state };
+};
+
 /**
  * Given a state request, finds the matching objects
  * within the schema that apply to the request. These

--- a/packages/unmock-core/src/service/state/middleware.ts
+++ b/packages/unmock-core/src/service/state/middleware.ts
@@ -1,5 +1,5 @@
 import Ajv from "ajv";
-import { DSL, filterTopLevelDSL, getTopLevelDSL } from "../dsl";
+import { DSL, filterTopLevelDSL, getTopLevelDSL, ITopLevelDSL } from "../dsl";
 import {
   isSchema,
   IStateInputGenerator,
@@ -17,9 +17,12 @@ export default (state?: UnmockServiceState): IStateInputGenerator => ({
     spreadStateFromService(schema, filterTopLevelDSL(state || {})),
 });
 
-export const textMW = (state?: string): IStateInputGenerator => ({
+export const textMW = (
+  state?: string,
+  dsl?: ITopLevelDSL,
+): IStateInputGenerator => ({
   isEmpty: typeof state !== "string" || state.length === 0,
-  top: {},
+  top: getTopLevelDSL((dsl || {}) as UnmockServiceState),
   gen: (schema: Schema) => generateTextResponse(schema, state),
 });
 

--- a/packages/unmock-core/src/service/state/middleware.ts
+++ b/packages/unmock-core/src/service/state/middleware.ts
@@ -75,7 +75,9 @@ export const spreadStateFromService = (
         // TODO do we want to throw for invalid types?
         const spread = {
           [key]:
-            isSchema(scm) && ajv.validate(scm, stateValue) ? stateValue : null,
+            isSchema(scm) && ajv.validate(scm, stateValue)
+              ? { ...scm, const: stateValue }
+              : null,
         };
         matches = { ...matches, ...spread };
       } else if (hasNestedItems(scm) || isNonEmptyObject(scm)) {

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -10,7 +10,7 @@ import {
 } from "../interfaces";
 import { IOperationForStateUpdate, IStateUpdate } from "./interfaces";
 import { filterStatesByOperation, getOperations } from "./utils";
-import { getValidResponsesForOperationWithState } from "./validator";
+import { getValidStatesForOperationWithState } from "./validator";
 
 const debugLog = debug("unmock:state");
 
@@ -49,7 +49,7 @@ export class State {
     let errorMsg: string | undefined;
     const opsResult = ops.operations.some((op: IOperationForStateUpdate) => {
       // For each operation, verify the new state applies and save in `this.state`
-      const stateResponses = getValidResponsesForOperationWithState(
+      const stateResponses = getValidStatesForOperationWithState(
         op.operation,
         newState,
       );

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -20,6 +20,11 @@ interface IResponsesFromContent {
   [contentType: string]: Record<string, Schema> | Schema;
 }
 
+interface IValidState {
+  responses?: codeToMedia;
+  error?: IMissingParam;
+}
+
 interface IMissingParam {
   msg: string;
   nestedLevel: number;
@@ -35,87 +40,108 @@ const chooseDeepestMissingParam = (
     initError,
   );
 
-const responseForStateWithCode = (
+/**
+ * Given a response, state and code, attempts to fetch the copied, spread state that matches the different
+ * content types in `response`.
+ * @param response
+ * @param state
+ * @param code
+ */
+const validStatesForStateWithCode = (
   response: Reference | Response | undefined,
   state: IStateInputGenerator,
-  code: number,
-): { responses?: codeToMedia; error?: string } => {
+  code: number | string,
+): IValidState => {
   if (
     response === undefined ||
     isReference(response) ||
     response.content === undefined
   ) {
     return {
-      error: `Can't find response for given status code '${code}'!`,
+      error: {
+        msg: `Can't find response for given status code '${code}'!`,
+        nestedLevel: -1,
+      },
     };
   }
   const stateMedia = getStateFromMedia(response.content, state);
   const error = chooseDeepestMissingParam(stateMedia.errors);
   return {
     responses: { [code]: stateMedia.responses },
-    error: error === undefined ? undefined : error.msg,
+    error,
   };
 };
+
 /**
- * Given a state and an operation, returns all the valid responses that
- * match the given state.
+ * Given responses and a state, attempts to fetch the copied spread states that matches the different
+ * response codes and content types in `responses`.
+ * @param operationResponses
+ * @param state
+ */
+const validStatesForStateWithoutCode = (
+  operationResponses: Responses,
+  state: IStateInputGenerator,
+): IValidState => {
+  const relevantResponses: codeToMedia = {};
+  let err: IMissingParam | undefined;
+
+  for (const code of Object.keys(operationResponses)) {
+    const { responses, error } = validStatesForStateWithCode(
+      operationResponses[code as codeType],
+      state,
+      code,
+    );
+    err = error === undefined ? err : chooseDeepestMissingParam([error], err);
+
+    if (responses === undefined) {
+      continue;
+    }
+
+    const resp = responses[code];
+    const filteredStateMedia = Object.keys(resp).reduce(
+      (acc: IResponsesFromContent, contentType: string) =>
+        Object.keys(resp[contentType]).length > 0
+          ? Object.assign(acc, { [contentType]: resp[contentType] })
+          : acc,
+      {},
+    );
+
+    if (Object.keys(filteredStateMedia).length > 0) {
+      relevantResponses[code] = filteredStateMedia;
+    }
+  }
+
+  return Object.keys(relevantResponses).length > 0
+    ? { responses: relevantResponses }
+    : { error: err };
+};
+/**
+ * Given a state and an operation, creates a copy of the requested state for each response that it matches.
  * First-level filtering is done via $code (status code) if it exists,
  * otherwise via matching the parameters set in `state`.
  * @param operation
  * @param state
  */
-export const getValidResponsesForOperationWithState = (
+export const getValidStatesForOperationWithState = (
   operation: Operation,
   state: IStateInputGenerator,
-): { responses?: codeToMedia; error?: string } => {
-  // Check if any non-DSL specific elements are found in the Operation under responses.
-  // We do not resolve anything at this point.
-  const responses = operation.responses;
-  const relevantResponses: codeToMedia = {};
-  let error: IMissingParam | undefined;
-
-  const statusCode = state.top.$code;
-  // If $code is undefined, we look over all responses listed and find the suitable ones
-  if (statusCode !== undefined) {
-    // Applies only to specific response
-    return responseForStateWithCode(
-      responses[String(statusCode) as codeType],
-      state,
-      statusCode,
-    );
-  }
-
-  for (const code of Object.keys(responses)) {
-    const response = responses[code as codeType];
-    if (
-      response === undefined ||
-      isReference(response) ||
-      response.content === undefined
-    ) {
-      continue;
-    }
-    const stateMedia = getStateFromMedia(response.content, state);
-    const filteredStateMedia = Object.keys(stateMedia.responses).reduce(
-      (acc: IResponsesFromContent, contentType: string) => {
-        const schemaOrRecord = stateMedia.responses[contentType];
-        if (Object.keys(schemaOrRecord).length > 0) {
-          acc[contentType] = schemaOrRecord;
-        }
-        return acc;
-      },
-      {},
-    );
-    if (Object.keys(filteredStateMedia).length > 0) {
-      relevantResponses[code] = filteredStateMedia;
-    }
-    error = chooseDeepestMissingParam(stateMedia.errors, error);
-  }
-  if (Object.keys(relevantResponses).length > 0) {
-    return { responses: relevantResponses };
-  }
-  return {
-    error: error === undefined ? undefined : error.msg,
-  };
+): {
+  responses: codeToMedia | undefined;
+  error: string | undefined;
+} => {
+  const resps = operation.responses;
+  const code = state.top.$code;
+  const { responses, error } =
+    code !== undefined
+      ? // If $code is defined, we fetch the response even if no other state was set
+        validStatesForStateWithCode(
+          resps[String(code) as codeType],
+          state,
+          code,
+        )
+      : // Otherwise, iterate over all status codes and find the ones matching the given state
+        validStatesForStateWithoutCode(resps, state);
+  return { responses, error: error === undefined ? error : error.msg };
 };
 
 const getStateFromMedia = (

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -119,7 +119,7 @@ const getStateFromMedia = (
     const missingParam = DFSVerifyNoneAreNull(spreadState);
     if (missingParam !== undefined) {
       errors.push(missingParam);
-    } else {
+    } else if (Object.keys(spreadState).length > 0) {
       relevantResponses[contentType] = spreadState;
     }
   }

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -15,7 +15,7 @@ import {
 type codeType = keyof Responses;
 
 interface IResponsesFromContent {
-  [contentType: string]: Record<string, Schema>;
+  [contentType: string]: Record<string, Schema> | Schema;
 }
 
 interface IMissingParam {

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -25,11 +25,12 @@ describe("Node.js interceptor", () => {
       const data = response.data;
       // As no specific code was set, we expect either valid response
       // or an error response (based on service specification)
+
       if (data.message !== undefined) {
         // error message chosen at random
         expect(typeof data.code === "number").toBeTruthy();
         expect(typeof data.message === "string").toBeTruthy();
-      } else {
+      } else if (typeof data !== "string") {
         expect(data.length).toBeGreaterThan(0);
         expect(
           data.every(

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import path from "path";
 import { UnmockOptions } from "unmock-core";
+import { textMW } from "unmock-core/dist/service/state/middleware";
 import NodeBackend from "../../backend";
 
 const servicesDirectory = path.join(__dirname, "..", "loaders", "resources");
@@ -33,7 +34,7 @@ describe("Node.js interceptor", () => {
       throw new Error("Shouldn't be here :(");
     });
 
-    test("Gets correct code upon request without other state", async () => {
+    test("gets correct code upon request without other state", async () => {
       states.petstore({ $code: 200 });
       const response = await axios("http://petstore.swagger.io/v1/pets");
       expect(response.status).toBe(200);
@@ -67,6 +68,13 @@ describe("Node.js interceptor", () => {
       const response2 = await axios("http://petstore.swagger.io/v1/pets/3");
       expect(response2.status).toBe(200);
       expect(response2.data.every((pet: any) => pet.id === -1)).toBeTruthy();
+    });
+
+    test("gets correct state when setting textual middleware", async () => {
+      states.petstore(textMW("foo"));
+      const response = await axios("http://petstore.swagger.io/v1/pets");
+      expect(response.status).toBe(200);
+      expect(response.data).toBe("foo");
     });
   });
 });

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -77,7 +77,7 @@ describe("Node.js interceptor", () => {
       expect(response.data).toBe("foo");
     });
 
-    test("gets correct state when setting textual middleware with DSL", async () => {
+    test("throws when setting textual middleware with DSL with non-existing status code", async () => {
       expect(() => states.petstore(textMW("foo", { $code: 400 }))).toThrow(
         "status code '400'",
       );

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -76,5 +76,11 @@ describe("Node.js interceptor", () => {
       expect(response.status).toBe(200);
       expect(response.data).toBe("foo");
     });
+
+    test("gets correct state when setting textual middleware with DSL", async () => {
+      expect(() => states.petstore(textMW("foo", { $code: 400 }))).toThrow(
+        "status code '400'",
+      );
+    });
   });
 });

--- a/packages/unmock-node/src/__tests__/loaders/resources/petstore/index.yaml
+++ b/packages/unmock-node/src/__tests__/loaders/resources/petstore/index.yaml
@@ -30,7 +30,7 @@ paths:
               schema:
                 type: string
           content:
-            application/json:    
+            application/json:
               schema:
                 type: array
                 items:
@@ -49,6 +49,9 @@ paths:
         default:
           description: unexpected error
           content:
+            text/plain:
+              schema:
+                type: string
             application/json:
               schema:
                 required:


### PR DESCRIPTION
- Adds (badly named) `textMW` to set string-based states. Accepts a string argument and optional top-level DSL to ask for e.g. status code response.
  - This, in theory, lays the basis for possible future middlewares such as binary, file, etc (in _Open API schema-speak_, these are all schemas of `type: string` and different `format`). As a result, should these middlewares be inheritable classes?
- Cleans up some old code in validator and generator, that would otherwise crash on text results (both purposefully originally and unintentionally).
- Adds tests