### PR TITLE
[Hotfix] Generator missing values from schema

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/**"
   ],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "name": "unmock-cli",
   "displayName": "unmock-cli",
   "license": "MIT",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "name": "unmock-core",
   "displayName": "unmock-core",
   "main": "dist/index.js",

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -190,6 +190,10 @@ const generateMockFromTemplate = (
 
   // Setup the unmock properties for jsf parsing
   setupJSFUnmockProperties();
+  if (template.required === undefined) {
+    // if `required` is not found, then generate everything
+    jsf.option("alwaysFakeOptionals", true);
+  }
   // First iteration simply parses these and returns the updated schema
   const resolvedTemplate = jsf.generate(template);
   jsf.reset();

--- a/packages/unmock-jsdom/package.json
+++ b/packages/unmock-jsdom/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "name": "unmock-jsdom",
   "displayName": "unmock-jsdom",
   "main": "dist/index.js",

--- a/packages/unmock-node/package.json
+++ b/packages/unmock-node/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "name": "unmock-node",
   "displayName": "unmock-node",
   "main": "dist/index.js",

--- a/packages/unmock/package.json
+++ b/packages/unmock/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "name": "unmock",
   "displayName": "unmock",
   "license": "MIT",


### PR DESCRIPTION
If the `required` field in `Schema` is not specified, then `json-schema-faker` by default randomly decides which fields to generate.
As a hotfix, if the `required` field is not present, pass an option to `json-schema-faker` to generate all fields.