### PR TITLE
Hotfix/reset use default

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/**"
   ],
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "name": "unmock-cli",
   "displayName": "unmock-cli",
   "license": "MIT",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "name": "unmock-core",
   "displayName": "unmock-core",
   "main": "dist/index.js",

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -195,6 +195,7 @@ const generateMockFromTemplate = (
     jsf.option("alwaysFakeOptionals", true);
   }
   // First iteration simply parses these and returns the updated schema
+  jsf.option("useDefaultValue", false);
   const resolvedTemplate = jsf.generate(template);
   jsf.reset();
 
@@ -202,7 +203,7 @@ const generateMockFromTemplate = (
   const body = JSON.stringify(tryCatch(resolvedTemplate, jsf.generate));
   jsf.option("useDefaultValue", true);
   const resHeaders = jsf.generate(normalizeHeaders(headers));
-  jsf.reset();
+  jsf.option("useDefaultValue", false);
 
   return {
     body,

--- a/packages/unmock-jsdom/package.json
+++ b/packages/unmock-jsdom/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "name": "unmock-jsdom",
   "displayName": "unmock-jsdom",
   "main": "dist/index.js",

--- a/packages/unmock-node/package.json
+++ b/packages/unmock-node/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "name": "unmock-node",
   "displayName": "unmock-node",
   "main": "dist/index.js",

--- a/packages/unmock/package.json
+++ b/packages/unmock/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "name": "unmock",
   "displayName": "unmock",
   "license": "MIT",


### PR DESCRIPTION
Solves #93 
`jsf.reset()` did not cancel the `useDefaultValue` option. Cancelled it before `body` generation and following header generation.