### PR TITLE
Renames middleware to transformers and textMW to textResponse

### DIFF
--- a/packages/unmock-core/src/__tests__/middleware.test.ts
+++ b/packages/unmock-core/src/__tests__/middleware.test.ts
@@ -1,4 +1,4 @@
-import { middleware } from "../index";
+import { transformers } from "../index";
 import { Schema } from "../service/interfaces";
 
 const schema: Schema = {
@@ -34,7 +34,7 @@ const schema: Schema = {
 
 describe("Test text provider", () => {
   it("returns empty object for undefined state", () => {
-    const p = middleware.textMW();
+    const p = transformers.textResponse();
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
@@ -42,7 +42,7 @@ describe("Test text provider", () => {
   });
 
   it("returns empty object for empty state", () => {
-    const p = middleware.textMW("");
+    const p = transformers.textResponse("");
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
@@ -50,7 +50,7 @@ describe("Test text provider", () => {
   });
 
   it("returns empty object for empty schema", () => {
-    const p = middleware.textMW("foo");
+    const p = transformers.textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
@@ -58,14 +58,14 @@ describe("Test text provider", () => {
   });
 
   it("returns empty object for non-text schema", () => {
-    const p = middleware.textMW("foo");
+    const p = transformers.textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     expect(p.gen({ type: "array", items: {} })).toEqual({});
   });
 
   it("returns correct state object for valid input", () => {
-    const p = middleware.textMW("foo");
+    const p = transformers.textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
@@ -73,7 +73,7 @@ describe("Test text provider", () => {
 
   it("top level DSL doesn't change response", () => {
     // @ts-ignore // invalid value on purpose
-    const p = middleware.textMW("foo", { $code: 200, notDSL: "a" });
+    const p = transformers.textResponse("foo", { $code: 200, notDSL: "a" });
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({ $code: 200 }); // non DSL is filtered out
     expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
@@ -82,21 +82,21 @@ describe("Test text provider", () => {
 
 describe("Test default provider", () => {
   it("returns empty objects for undefined state", () => {
-    const p = middleware.default();
+    const p = transformers.default();
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     expect(p.gen({})).toEqual({});
   });
 
   it("returns empty objects for empty state", () => {
-    const p = middleware.default({});
+    const p = transformers.default({});
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     expect(p.gen({})).toEqual({});
   });
 
   it("filters out top level DSL from state", () => {
-    const p = middleware.default({ $code: 200, foo: "bar" });
+    const p = transformers.default({ $code: 200, foo: "bar" });
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({ $code: 200 });
     expect(p.gen({})).toEqual({}); // no schema to expand
@@ -111,12 +111,12 @@ describe("Test default provider", () => {
   });
 
   it("with empty path", () => {
-    const spreadState = middleware.default({}).gen(schema);
+    const spreadState = transformers.default({}).gen(schema);
     expect(spreadState).toEqual({}); // Empty state => empty spread state
   });
 
   it("with specific path", () => {
-    const spreadState = middleware
+    const spreadState = transformers
       .default({
         test: { id: "a" },
       })
@@ -134,13 +134,13 @@ describe("Test default provider", () => {
   });
 
   it("with vague path", () => {
-    const spreadState = middleware.default({ id: 5 }).gen(schema);
+    const spreadState = transformers.default({ id: 5 }).gen(schema);
     // no "id" in top-most level or immediately under properties\items
     expect(spreadState).toEqual({ id: null });
   });
 
   it("with missing parameters", () => {
-    const spreadState = middleware.default({ ida: "a" }).gen(schema);
+    const spreadState = transformers.default({ ida: "a" }).gen(schema);
     expect(spreadState).toEqual({ ida: null }); // Nothing to spread
   });
 });

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -1,5 +1,5 @@
-import { OpenAPIObject } from "loas3/dist/src/generated/full";
 import { stateStoreFactory } from "../service";
+import { OpenAPIObject } from "../service/interfaces";
 import { Service } from "../service/service";
 import { ServiceStore } from "../service/serviceStore";
 

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -3,8 +3,8 @@ import {
   HTTPMethod,
   IStateInputGenerator,
 } from "../service/interfaces";
-import defMiddleware, { textMW } from "../service/state/middleware";
 import { State } from "../service/state/state";
+import defMiddleware, { textResponse } from "../service/state/transformers";
 
 const fullSchema = {
   openapi: "",
@@ -272,7 +272,7 @@ describe("Test state management", () => {
 
   it("Handles textual state correctly", () => {
     const state = new State();
-    updateState(state, "any", "**", textMW("foobar"), "**");
+    updateState(state, "any", "**", textResponse("foobar"), "**");
     const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: { "text/plain": { const: "foobar", type: "string" } },

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,5 +1,5 @@
 import { Response, Responses, Schema } from "../service/interfaces";
-import defMiddleware from "../service/state/middleware";
+import defMiddleware from "../service/state/transformers";
 import { getValidStatesForOperationWithState } from "../service/state/validator";
 
 const arraySchema: Schema = {

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -1,6 +1,6 @@
 import { IBackend, IUnmockOptions } from "./interfaces";
 import { UnmockOptions } from "./options";
-import * as mw from "./service/state/middleware";
+import * as trns from "./service/state/transformers";
 // top-level exports
 export { UnmockOptions } from "./options";
 export * from "./interfaces";
@@ -17,4 +17,4 @@ export const unmock = (baseOptions: UnmockOptions, backend: IBackend) => (
     throw new Error("Are you trying to run unmock in production?");
   };
 };
-export const middleware = mw;
+export const transformers = trns;

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -9,7 +9,7 @@ import {
   MatcherResponse,
   UnmockServiceState,
 } from "./interfaces";
-import defMiddleware from "./state/middleware";
+import defMiddleware from "./state/transformers";
 
 export class ServiceStore {
   private readonly serviceMapping: IServiceMapping = {};

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -17,7 +17,7 @@ export default (state?: UnmockServiceState): IStateInputGenerator => ({
     spreadStateFromService(schema, filterTopLevelDSL(state || {})),
 });
 
-export const textMW = (
+export const textResponse = (
   state?: string,
   dsl?: ITopLevelDSL,
 ): IStateInputGenerator => ({

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 import path from "path";
-import { UnmockOptions } from "unmock-core";
-import { textMW } from "unmock-core/dist/service/state/middleware";
+import { transformers, UnmockOptions } from "unmock-core";
 import NodeBackend from "../../backend";
 
 const servicesDirectory = path.join(__dirname, "..", "loaders", "resources");
@@ -71,16 +70,16 @@ describe("Node.js interceptor", () => {
     });
 
     test("gets correct state when setting textual middleware", async () => {
-      states.petstore(textMW("foo"));
+      states.petstore(transformers.textResponse("foo"));
       const response = await axios("http://petstore.swagger.io/v1/pets");
       expect(response.status).toBe(200);
       expect(response.data).toBe("foo");
     });
 
     test("throws when setting textual middleware with DSL with non-existing status code", async () => {
-      expect(() => states.petstore(textMW("foo", { $code: 400 }))).toThrow(
-        "status code '400'",
-      );
+      expect(() =>
+        states.petstore(transformers.textResponse("foo", { $code: 400 })),
+      ).toThrow("status code '400'");
     });
   });
 });

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -1,7 +1,7 @@
 import { unmock, UnmockOptions } from "unmock-core";
 import NodeBackend from "./backend";
 import _WinstonLogger from "./logger/winston-logger";
-export { middleware } from "unmock-core";
+export { transformers } from "unmock-core";
 
 const backend = new NodeBackend();
 


### PR DESCRIPTION
Would probably make things more readable easier to understand.