### PR TITLE
Adds typing for state store

### DIFF
--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -1,4 +1,4 @@
-import { stateStoreFactory } from "../service";
+import { stateFacadeFactory } from "../service";
 import { OpenAPIObject } from "../service/interfaces";
 import { Service } from "../service/service";
 import { ServiceStore } from "../service/serviceStore";
@@ -50,29 +50,29 @@ describe("Fluent API and Service instantiation tests", () => {
   ]);
 
   it("Store with empty paths throws", () => {
-    const store = stateStoreFactory(PetStoreWithEmptyPaths);
+    const store = stateFacadeFactory(PetStoreWithEmptyPaths);
     expect(store.noservice).toThrow("Can't find specification");
     expect(store.petstore).toThrow("has no defined paths");
     expect(store.petstore.get).toThrow("has no defined paths");
   });
 
   it("Store with non-empty paths with non-matching method throws", () => {
-    const store = stateStoreFactory(PetStoreWithEmptyResponses);
+    const store = stateFacadeFactory(PetStoreWithEmptyResponses);
     expect(store.petstore.post).toThrow("Can't find any endpoints with method");
   });
 
   it("Store with existing path does not throw", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore(); // Should pass
   });
 
   it("Store with REST method call does not throw", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore.get(); // Should pass
   });
 
   it("Chaining multiple states without REST methods does not throw", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store
       .petstore()
       .petstore()
@@ -80,7 +80,7 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   it("Chaining multiple states with REST methods does not throw", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore
       .get()
       .petstore.get()
@@ -88,31 +88,31 @@ describe("Fluent API and Service instantiation tests", () => {
   });
 
   it("Chaining multiple methods for a service does not throw", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore
       .get()
       .get()
       .petstore();
   });
   it("Non HTTP methods are recognized as services and throws", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     expect(store.get).toThrow("Can't find specification");
     expect(store.petstore.get().boom).toThrow("Can't find specification");
   });
 
   it("Specifying missing endpoint without rest method throws", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore("/pets"); // should pass
     expect(() => store.petstore("/pet")).toThrow("Can't find endpoint");
   });
 
   it("Specifying existing endpoint with rest method does not throw", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore.get("/pets"); // should pass
   });
 
   it("Specifying missing endpoint with rest method throws", () => {
-    const store = stateStoreFactory(PetStoreWithPseudoResponses);
+    const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     expect(() => store.petstore.post("/pets")).toThrow("Can't find response");
     expect(() => store.petstore.get("/pet")).toThrow("Can't find endpoint");
   });
@@ -170,7 +170,7 @@ describe("Test paths matching on serviceStore", () => {
   };
 
   it("Paths are converted to regexp", () => {
-    const store = stateStoreFactory(DynamicPathsService(petStoreParameters));
+    const store = stateFacadeFactory(DynamicPathsService(petStoreParameters));
     store.petstore("/pets/2"); // Should pass
     store.petstore("/pets/{petId}"); // should pass
     expect(() => store.petstore("/pet/2")).toThrow("Can't find endpoint");
@@ -178,17 +178,17 @@ describe("Test paths matching on serviceStore", () => {
   });
 
   it("attempting to create a store with missing parameters throws", () => {
-    expect(() => stateStoreFactory(DynamicPathsService({}))).toThrow(
+    expect(() => stateFacadeFactory(DynamicPathsService({}))).toThrow(
       "no description for path parameters!",
     );
     expect(() =>
-      stateStoreFactory(DynamicPathsService({ parameters: {} })),
+      stateFacadeFactory(DynamicPathsService({ parameters: {} })),
     ).toThrow("no description for path parameters!");
   });
 
   it("attempting to create a store with partially missing parameters throws", () => {
     expect(() =>
-      stateStoreFactory(
+      stateFacadeFactory(
         DynamicPathsService(petStoreParameters, "/{boom}", "{foo}"),
       ),
     ).toThrow("following path parameters have not been described");

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -11,7 +11,7 @@ import {
   IServiceDef,
   IServiceDefLoader,
 } from "./interfaces";
-import { stateStoreFactory } from "./service";
+import { stateFacadeFactory } from "./service";
 import {
   codeToMedia,
   Dereferencer,
@@ -47,7 +47,7 @@ export function responseCreatorFactory({
     parser.parse(serviceDef),
   );
   const serviceStore = new ServiceStore(services);
-  const stateStore = stateStoreFactory(serviceStore);
+  const stateStore = stateFacadeFactory(serviceStore);
   return {
     stateStore,
     createResponse: (sreq: ISerializedRequest) =>

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -3,8 +3,8 @@ import {
   ExtendedHTTPMethod,
   HTTPMethod,
   isRESTMethod,
-  UnmockServiceState,
   IStateInputGenerator,
+  UnmockServiceState,
 } from "./interfaces";
 import { ServiceStore } from "./serviceStore";
 export { ServiceParser } from "./parser";

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -3,7 +3,7 @@ import {
   ExtendedHTTPMethod,
   HTTPMethod,
   isRESTMethod,
-  StateStoreType,
+  StateFacadeType,
   UnmockServiceState,
 } from "./interfaces";
 import { ServiceStore } from "./serviceStore";
@@ -75,5 +75,6 @@ const StateHandler = (prevServiceName?: string) => {
 };
 
 // Returns as any to allow for type-free DSL-like access to services and states
-export const stateStoreFactory = (serviceStore: ServiceStore): StateStoreType =>
-  new Proxy(serviceStore, StateHandler()) as any;
+export const stateFacadeFactory = (
+  serviceStore: ServiceStore,
+): StateFacadeType => new Proxy(serviceStore, StateHandler()) as any;

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -5,6 +5,7 @@ import {
   isRESTMethod,
   IStateInputGenerator,
   UnmockServiceState,
+  StateStoreType,
 } from "./interfaces";
 import { ServiceStore } from "./serviceStore";
 export { ServiceParser } from "./parser";
@@ -73,48 +74,6 @@ const StateHandler = (prevServiceName?: string) => {
     },
   };
 };
-
-type SetStateForAllPaths =
-  /**
-   * Sets the given state for all endpoints in the current service, for which the state can be applied.
-   * @param state An object setting the state or a DSL transformer used to set it.
-   * @throws If the given state cannot be applied to any endpoint.
-   */
-  (
-    state: IStateInputGenerator | UnmockServiceState,
-  ) => StateStoreType & SetStateForSpecificMethod;
-
-type SetStateForMatchingEndpoint =
-  /**
-   * Sets the given state for the given endpoint (or matching endpoints if using a glob pattern).
-   * @param {string} endpoint Desired endpoint for the state.
-   *   You may use single asterisks for single path item replacement.
-   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
-   *            an asterisk may be used instead of {pet_id} or a specific id.
-   * @param state An object setting the state or a DSL transformer used to set it.
-   * @throws If the state cannot be applied to the given endpoint.
-   */
-  (
-    endpoint: string,
-    state: IStateInputGenerator | UnmockServiceState,
-  ) => StateStoreType & SetStateForSpecificMethod;
-
-type SetStateType = SetStateForAllPaths & SetStateForMatchingEndpoint;
-
-interface IResetState {
-  /**
-   * Resets the state for the current service, or for the entire state store.
-   * You may not continue using the fluent API after this call.
-   */
-  reset(): void;
-}
-
-type SetStateForSpecificMethod = Record<HTTPMethod, SetStateType> & IResetState;
-
-type StateStoreType = {
-  // Has either `reset()` function or string signature with function call
-  [serviceName: string]: SetStateType & SetStateForSpecificMethod;
-} & IResetState;
 
 // Returns as any to allow for type-free DSL-like access to services and states
 export const stateStoreFactory = (serviceStore: ServiceStore): StateStoreType =>

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -87,7 +87,8 @@ type SetStateForAllPaths =
 type SetStateForMatchingEndpoint =
   /**
    * Sets the given state for the given endpoint (or matching endpoints if using a glob pattern).
-   * @param {string} endpoint Desired endpoint for the state. You may use single asterisks for pattern replacement.
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
    *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
    *            an asterisk may be used instead of {pet_id} or a specific id.
    * @param state An object setting the state or a DSL transformer used to set it.

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -3,9 +3,8 @@ import {
   ExtendedHTTPMethod,
   HTTPMethod,
   isRESTMethod,
-  IStateInputGenerator,
-  UnmockServiceState,
   StateStoreType,
+  UnmockServiceState,
 } from "./interfaces";
 import { ServiceStore } from "./serviceStore";
 export { ServiceParser } from "./parser";

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -74,19 +74,38 @@ const StateHandler = (prevServiceName?: string) => {
   };
 };
 
-type SetStateForAllPaths = (
-  state: IStateInputGenerator | UnmockServiceState,
-) => StateStoreType & SetStateForSpecificMethod;
+type SetStateForAllPaths =
+  /**
+   * Sets the given state for all endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any endpoint.
+   */
+  (
+    state: IStateInputGenerator | UnmockServiceState,
+  ) => StateStoreType & SetStateForSpecificMethod;
 
-type SetStateForMatchingEndpoint = (
-  endpoint: string,
-  state: IStateInputGenerator | UnmockServiceState,
-) => StateStoreType & SetStateForSpecificMethod;
+type SetStateForMatchingEndpoint =
+  /**
+   * Sets the given state for the given endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state. You may use single asterisks for pattern replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint.
+   */
+  (
+    endpoint: string,
+    state: IStateInputGenerator | UnmockServiceState,
+  ) => StateStoreType & SetStateForSpecificMethod;
 
 type SetStateType = SetStateForAllPaths & SetStateForMatchingEndpoint;
 
 interface IResetState {
-  reset: () => void;
+  /**
+   * Resets the state for the current service, or for the entire state store.
+   * You may not continue using the fluent API after this call.
+   */
+  reset(): void;
 }
 
 type SetStateForSpecificMethod = {

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -109,11 +109,7 @@ interface IResetState {
   reset(): void;
 }
 
-type SetStateForSpecificMethod = {
-  // All HTTP methods can set a state
-  [P in HTTPMethod]: SetStateType;
-} &
-  IResetState;
+type SetStateForSpecificMethod = Record<HTTPMethod, SetStateType> & IResetState;
 
 type StateStoreType = {
   // Has either `reset()` function or string signature with function call

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -167,7 +167,7 @@ export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 // ##########################
 
 // Used to define the simplify the types used
-type FluentStateStore = StateStoreType & SetStateForSpecificMethod;
+type FluentStateStore = StateFacadeType & SetStateForSpecificMethod;
 type StateInput = IStateInputGenerator | UnmockServiceState;
 
 // Used to incorporate the reset method when needed
@@ -347,7 +347,7 @@ type SetStateForMatchingEndpoint =
    */
   (endpoint: string, state: StateInput) => FluentStateStore;
 
-export type StateStoreType = {
+export type StateFacadeType = {
   // Has either `reset()` function or string signature with function call
   [serviceName: string]: SetStateForAllPaths &
     SetStateForMatchingEndpoint &

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -161,3 +161,195 @@ export interface IUnmockServiceState
  * Validation can be done either in runtime or via IDE extensions.
  */
 export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
+
+// ##########################
+// Type definitions for the Proxy class used to wrap the State Store.
+// ##########################
+
+// Used to define the simplify the types used
+type FluentStateStore = StateStoreType & SetStateForSpecificMethod;
+type StateInput = IStateInputGenerator | UnmockServiceState;
+
+// Used to incorporate the reset method when needed
+interface IResetState {
+  /**
+   * Resets the state for the current service, or for the entire state store.
+   * You may not continue using the fluent API after this call.
+   */
+  reset(): void;
+}
+
+// Manually sync'd with HTTPMethod: ["get", "head", "post", "put", "patch", "delete", "options", "trace"]
+type SetStateForSpecificMethod = {
+  /**
+   * Sets the given state for all GET endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any GET endpoint, or if no GET endpoints exist.
+   */
+  get(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given GET endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint, or if the endpoint does not specify a GET operation.
+   */
+  get(endpoint: string, state: StateInput): FluentStateStore;
+
+  /**
+   * Sets the given state for all HEAD endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any HEAD endpoint, or if no HEAD endpoints exist.
+   */
+  head(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given HEAD endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint, or if the endpoint does not specify a HEAD operation.
+   */
+  head(endpoint: string, state: StateInput): FluentStateStore;
+
+  /**
+   * Sets the given state for all POST endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any POST endpoint, or if no POST endpoints exist.
+   */
+  post(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given POST endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint,
+   *         or if the endpoint does not specify a POST operation.
+   */
+  post(endpoint: string, state: StateInput): FluentStateStore;
+
+  /**
+   * Sets the given state for all PUT endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any PUT endpoint,
+   *         or if no PUT endpoints exist.
+   */
+  put(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given PUT endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint,
+   *         or if the endpoint does not specify a PUT operation.
+   */
+  put(endpoint: string, state: StateInput): FluentStateStore;
+
+  /**
+   * Sets the given state for all PATCH endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any PATCH endpoint,
+   *         or if no PATCH endpoints exist.
+   */
+  patch(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given PATCH endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint,
+   *         or if the endpoint does not specify a PATCH operation.
+   */
+  patch(endpoint: string, state: StateInput): FluentStateStore;
+
+  /**
+   * Sets the given state for all DELETE endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any DELETE endpoint, or if no DELETE endpoints exist.
+   */
+  delete(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given DELETE endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint,
+   *         or if the endpoint does not specify a DELETE operation.
+   */
+  delete(endpoint: string, state: StateInput): FluentStateStore;
+
+  /**
+   * Sets the given state for all OPTIONS endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any OPTIONS endpoint, or if no OPTIONS endpoints exist.
+   */
+  options(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given OPTIONS endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint,
+   *         or if the endpoint does not specify a OPTIONS operation.
+   */
+  options(endpoint: string, state: StateInput): FluentStateStore;
+
+  /**
+   * Sets the given state for all TRACE endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any TRACE endpoint, or if no TRACE endpoints exist.
+   */
+  trace(state: StateInput): FluentStateStore;
+  /**
+   * Sets the given state for the given TRACE endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint,
+   *         or if the endpoint does not specify a TRACE operation.
+   */
+  trace(endpoint: string, state: StateInput): FluentStateStore;
+} & IResetState;
+
+// Used for service-general state setups
+type SetStateForAllPaths =
+  /**
+   * Sets the given state for all endpoints in the current service, for which the state can be applied.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the given state cannot be applied to any endpoint.
+   */
+  (state: StateInput) => FluentStateStore;
+
+type SetStateForMatchingEndpoint =
+  /**
+   * Sets the given state for the given endpoint (or matching endpoints if using a glob pattern).
+   * @param {string} endpoint Desired endpoint for the state.
+   *   You may use single asterisks for single path item replacement.
+   *   Example: If a service specified an endpoint '/pets/{pet_id}/name',
+   *            an asterisk may be used instead of {pet_id} or a specific id.
+   * @param state An object setting the state or a DSL transformer used to set it.
+   * @throws If the state cannot be applied to the given endpoint.
+   */
+  (endpoint: string, state: StateInput) => FluentStateStore;
+
+export type StateStoreType = {
+  // Has either `reset()` function or string signature with function call
+  [serviceName: string]: SetStateForAllPaths &
+    SetStateForMatchingEndpoint &
+    SetStateForSpecificMethod;
+} & IResetState;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -154,9 +154,10 @@ interface IUnmockServiceState
   extends INestedState<
     IDSL | string | number | (() => string | number) | undefined | boolean
   > {}
+
 /**
  * Defines how a state can look like without validation against
  * the actual service specification.
  * Validation can be done either in runtime or via IDE extensions.
  */
-export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL;
+export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -150,7 +150,7 @@ interface INestedState<T> {
   [key: string]: INestedState<T> | T;
 }
 
-interface IUnmockServiceState
+export interface IUnmockServiceState
   extends INestedState<
     IDSL | string | number | (() => string | number) | undefined | boolean
   > {}


### PR DESCRIPTION
Adds hinting and typing for unmock-related state store management. This includes suggestions on the fluent API and inputs when setting a state.

The main caveat at the moment is that the REST methods are manually typed (including their `JSDoc`) so that they get a method type and not a property type.

I've checked various edge cases but please pull and try it out, maybe break it with various calls via e.g. `const myTestStore = stateStoreFactory(new ServiceStore([]));`.