### PR TITLE
Fix small oversights

### DIFF
--- a/packages/unmock-cli/src/__tests__/tsconfig.json
+++ b/packages/unmock-cli/src/__tests__/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.test.base",
+  "include": ["**/*"],
+  "references": [
+    { "path": "../../" }
+  ]
+}

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -31,9 +31,9 @@ describe("Tests generator", () => {
     const { stateStore } = responseCreatorFactory({
       serviceDefLoader,
     });
-    stateStore.slack(); // should pass
-    stateStore.petstore(); // should pass
-    expect(() => stateStore.github()).toThrow("service named 'github'"); // no github service
+    stateStore.slack({}); // should pass
+    stateStore.petstore({}); // should pass
+    expect(() => stateStore.github({})).toThrow("service named 'github'"); // no github service
   });
 
   it("sets a state for swagger api converted to openapi", () => {

--- a/packages/unmock-core/src/__tests__/serviceStore.test.ts
+++ b/packages/unmock-core/src/__tests__/serviceStore.test.ts
@@ -63,58 +63,60 @@ describe("Fluent API and Service instantiation tests", () => {
 
   it("Store with existing path does not throw", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
-    store.petstore(); // Should pass
+    store.petstore({}); // Should pass
   });
 
   it("Store with REST method call does not throw", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
-    store.petstore.get(); // Should pass
+    store.petstore.get({}); // Should pass
   });
 
   it("Chaining multiple states without REST methods does not throw", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store
-      .petstore()
-      .petstore()
-      .petstore();
+      .petstore({})
+      .petstore({})
+      .petstore({});
   });
 
   it("Chaining multiple states with REST methods does not throw", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore
-      .get()
-      .petstore.get()
-      .petstore();
+      .get({})
+      .petstore.get({})
+      .petstore({});
   });
 
   it("Chaining multiple methods for a service does not throw", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     store.petstore
-      .get()
-      .get()
-      .petstore();
+      .get({})
+      .get({})
+      .petstore({});
   });
   it("Non HTTP methods are recognized as services and throws", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
     expect(store.get).toThrow("Can't find specification");
-    expect(store.petstore.get().boom).toThrow("Can't find specification");
+    expect(store.petstore.get({}).boom).toThrow("Can't find specification");
   });
 
   it("Specifying missing endpoint without rest method throws", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
-    store.petstore("/pets"); // should pass
-    expect(() => store.petstore("/pet")).toThrow("Can't find endpoint");
+    store.petstore("/pets", {}); // should pass
+    expect(() => store.petstore("/pet", {})).toThrow("Can't find endpoint");
   });
 
   it("Specifying existing endpoint with rest method does not throw", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
-    store.petstore.get("/pets"); // should pass
+    store.petstore.get("/pets", {}); // should pass
   });
 
   it("Specifying missing endpoint with rest method throws", () => {
     const store = stateFacadeFactory(PetStoreWithPseudoResponses);
-    expect(() => store.petstore.post("/pets")).toThrow("Can't find response");
-    expect(() => store.petstore.get("/pet")).toThrow("Can't find endpoint");
+    expect(() => store.petstore.post("/pets", {})).toThrow(
+      "Can't find response",
+    );
+    expect(() => store.petstore.get("/pet", {})).toThrow("Can't find endpoint");
   });
 });
 
@@ -171,10 +173,10 @@ describe("Test paths matching on serviceStore", () => {
 
   it("Paths are converted to regexp", () => {
     const store = stateFacadeFactory(DynamicPathsService(petStoreParameters));
-    store.petstore("/pets/2"); // Should pass
-    store.petstore("/pets/{petId}"); // should pass
-    expect(() => store.petstore("/pet/2")).toThrow("Can't find endpoint");
-    expect(() => store.petstore("/pets/")).toThrow("Can't find endpoint");
+    store.petstore("/pets/2", {}); // Should pass
+    store.petstore("/pets/{petId}", {}); // should pass
+    expect(() => store.petstore("/pet/2", {})).toThrow("Can't find endpoint");
+    expect(() => store.petstore("/pets/", {})).toThrow("Can't find endpoint");
   });
 
   it("attempting to create a store with missing parameters throws", () => {

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -22,6 +22,7 @@ import {
   Response,
   Responses,
   Schema,
+  StateFacadeType,
 } from "./service/interfaces";
 import { ServiceParser } from "./service/parser";
 import { ServiceStore } from "./service/serviceStore";
@@ -40,7 +41,7 @@ export function responseCreatorFactory({
   serviceDefLoader,
 }: {
   serviceDefLoader: IServiceDefLoader;
-}): { stateStore: any; createResponse: CreateResponse } {
+}): { stateStore: StateFacadeType; createResponse: CreateResponse } {
   const serviceDefs: IServiceDef[] = serviceDefLoader.loadSync();
   const parser = new ServiceParser();
   const services: IService[] = serviceDefs.map(serviceDef =>

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -28,11 +28,9 @@ export class OASMatcher {
     reqPath: string,
     serverPathPrefix: string,
   ) {
-    const serverUrlWithoutTrailingSlash = serverPathPrefix.replace(/\/$/, "");
-    const regexToRemoveFromReqPath = new RegExp(
-      `^${serverUrlWithoutTrailingSlash}`,
-    );
-    return reqPath.replace(regexToRemoveFromReqPath, "");
+    const pathSuffix = serverPathPrefix.endsWith("/") ? "" : "/";
+    const serverPathRegex = new RegExp(`^${serverPathPrefix + pathSuffix}`);
+    return reqPath.replace(serverPathRegex, "/");
   }
 
   private static buildRegexpForPaths(

--- a/packages/unmock/src/__tests__/tsconfig.json
+++ b/packages/unmock/src/__tests__/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.test.base",
+  "include": ["**/*"],
+  "references": [
+    { "path": "../../" }
+  ]
+}


### PR DESCRIPTION
- Forgot to update states returned from e.g. `responseCreatorFactory` to use the new types from #99 
- Updates `matcher` to replace server path prefix fully and not by partial match. Error rose when trying to set state for path `/api.test` when the server prefix is `/api`. Instead of replacing `/api` with the empty string, replaces `/api/` with `/` instead.