### PR TITLE
Accept text response natively

### DIFF
--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -1,10 +1,10 @@
-import { dsl } from "..";
 import {
   ExtendedHTTPMethod,
   HTTPMethod,
   IStateInputGenerator,
 } from "../service/interfaces";
 import { State } from "../service/state/state";
+import { objResponse, textResponse } from "../service/state/transformers";
 
 const fullSchema = {
   openapi: "",
@@ -98,33 +98,27 @@ describe("Test state management", () => {
   it("returns undefined when setting empty state", () => {
     const state = new State();
     expect(
-      updateState(state, "any", "**", dsl.objResponse(), "**"),
+      updateState(state, "any", "**", objResponse(), "**"),
     ).toBeUndefined();
   });
 
   it("throws when setting state for non-existing method with generic endpoint", () => {
     const state = new State();
-    expect(() =>
-      updateState(state, "post", "**", dsl.objResponse(), "**"),
-    ).toThrow("Can't find any endpoints with method 'post'");
+    expect(() => updateState(state, "post", "**", objResponse(), "**")).toThrow(
+      "Can't find any endpoints with method 'post'",
+    );
   });
 
   it("throws when setting state for non-existing method with specific, existing endpoint", () => {
     const state = new State();
     expect(() =>
-      updateState(
-        state,
-        "post",
-        "/test/5",
-        dsl.objResponse(),
-        "/test/{test_id}",
-      ),
+      updateState(state, "post", "/test/5", objResponse(), "/test/{test_id}"),
     ).toThrow("Can't find response for 'post /test/5'");
   });
 
   it("saves state from any endpoint and get method as expected", () => {
     const state = new State();
-    updateState(state, "get", "**", dsl.objResponse({ foo: { id: 5 } }), "**");
+    updateState(state, "get", "**", objResponse({ foo: { id: 5 } }), "**");
     const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: {
@@ -148,13 +142,7 @@ describe("Test state management", () => {
 
   it("parses $times on specific endpoint as expected", () => {
     const state = new State();
-    updateState(
-      state,
-      "get",
-      "**",
-      dsl.objResponse({ id: 5, $times: 2 }),
-      "**",
-    );
+    updateState(state, "get", "**", objResponse({ id: 5, $times: 2 }), "**");
     const getRes = () => getState(state, "get", "/");
     expect(getRes()).toEqual({
       200: {
@@ -206,7 +194,7 @@ describe("Test state management", () => {
 
   it("saves state from any endpoint and any method as expected", () => {
     const state = new State();
-    updateState(state, "any", "**", dsl.objResponse({ id: 5 }), "**");
+    updateState(state, "any", "**", objResponse({ id: 5 }), "**");
     const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: {
@@ -226,19 +214,19 @@ describe("Test state management", () => {
 
   it("spreads states from multiple paths correctly", () => {
     const state = new State();
-    updateState(state, "any", "**", dsl.objResponse({ id: 5 }), "**");
+    updateState(state, "any", "**", objResponse({ id: 5 }), "**");
     updateState(
       state,
       "any",
       "/test/5",
-      dsl.objResponse({ id: 3 }),
+      objResponse({ id: 3 }),
       "/test/{test_id}",
     );
     updateState(
       state,
       "any",
       "/test/*",
-      dsl.objResponse({ id: -1 }),
+      objResponse({ id: -1 }),
       "/test/{test_id}",
     );
     const stateResult = getState(state, "get", "/test/5");
@@ -260,7 +248,7 @@ describe("Test state management", () => {
 
   it("saves nested state correctly", () => {
     const state = new State();
-    updateState(state, "any", "**", dsl.objResponse({ foo: { id: 5 } }), "**");
+    updateState(state, "any", "**", objResponse({ foo: { id: 5 } }), "**");
     const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: {
@@ -284,7 +272,7 @@ describe("Test state management", () => {
 
   it("Handles textual state correctly", () => {
     const state = new State();
-    updateState(state, "any", "**", dsl.textResponse("foobar"), "**");
+    updateState(state, "any", "**", textResponse("foobar"), "**");
     const stateResult = getState(state, "get", "/");
     expect(stateResult).toEqual({
       200: { "text/plain": { const: "foobar", type: "string" } },

--- a/packages/unmock-core/src/__tests__/transformers.test.ts
+++ b/packages/unmock-core/src/__tests__/transformers.test.ts
@@ -1,5 +1,5 @@
-import { dsl } from "..";
 import { Schema } from "../service/interfaces";
+import { objResponse, textResponse } from "../service/state/transformers";
 
 const schema: Schema = {
   properties: {
@@ -34,7 +34,7 @@ const schema: Schema = {
 
 describe("Test text provider", () => {
   it("returns empty object for undefined state", () => {
-    const p = dsl.textResponse();
+    const p = textResponse();
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
@@ -42,7 +42,7 @@ describe("Test text provider", () => {
   });
 
   it("returns empty object for empty state", () => {
-    const p = dsl.textResponse("");
+    const p = textResponse("");
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
@@ -50,7 +50,7 @@ describe("Test text provider", () => {
   });
 
   it("returns empty object for empty schema", () => {
-    const p = dsl.textResponse("foo");
+    const p = textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
@@ -58,14 +58,14 @@ describe("Test text provider", () => {
   });
 
   it("returns empty object for non-text schema", () => {
-    const p = dsl.textResponse("foo");
+    const p = textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     expect(p.gen({ type: "array", items: {} })).toEqual({});
   });
 
   it("returns correct state object for valid input", () => {
-    const p = dsl.textResponse("foo");
+    const p = textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
@@ -73,7 +73,7 @@ describe("Test text provider", () => {
 
   it("top level DSL doesn't change response", () => {
     // @ts-ignore // invalid value on purpose
-    const p = dsl.textResponse("foo", { $code: 200, notDSL: "a" });
+    const p = textResponse("foo", { $code: 200, notDSL: "a" });
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({ $code: 200 }); // non DSL is filtered out
     expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
@@ -82,21 +82,21 @@ describe("Test text provider", () => {
 
 describe("Test default provider", () => {
   it("returns empty objects for undefined state", () => {
-    const p = dsl.objResponse();
+    const p = objResponse();
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     expect(p.gen({})).toEqual({});
   });
 
   it("returns empty objects for empty state", () => {
-    const p = dsl.objResponse({});
+    const p = objResponse({});
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     expect(p.gen({})).toEqual({});
   });
 
   it("filters out top level DSL from state", () => {
-    const p = dsl.objResponse({ $code: 200, foo: "bar" });
+    const p = objResponse({ $code: 200, foo: "bar" });
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({ $code: 200 });
     expect(p.gen({})).toEqual({}); // no schema to expand
@@ -111,16 +111,14 @@ describe("Test default provider", () => {
   });
 
   it("with empty path", () => {
-    const spreadState = dsl.objResponse({}).gen(schema);
+    const spreadState = objResponse({}).gen(schema);
     expect(spreadState).toEqual({}); // Empty state => empty spread state
   });
 
   it("with specific path", () => {
-    const spreadState = dsl
-      .objResponse({
-        test: { id: "a" },
-      })
-      .gen(schema);
+    const spreadState = objResponse({
+      test: { id: "a" },
+    }).gen(schema);
     expect(spreadState).toEqual({
       // Spreading from "test: { id : { ... " to also inlucde properties
       properties: {
@@ -134,13 +132,13 @@ describe("Test default provider", () => {
   });
 
   it("with vague path", () => {
-    const spreadState = dsl.objResponse({ id: 5 }).gen(schema);
+    const spreadState = objResponse({ id: 5 }).gen(schema);
     // no "id" in top-most level or immediately under properties\items
     expect(spreadState).toEqual({ id: null });
   });
 
   it("with missing parameters", () => {
-    const spreadState = dsl.objResponse({ ida: "a" }).gen(schema);
+    const spreadState = objResponse({ ida: "a" }).gen(schema);
     expect(spreadState).toEqual({ ida: null }); // Nothing to spread
   });
 });

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -1,5 +1,5 @@
-import { dsl } from "..";
 import { Response, Responses, Schema } from "../service/interfaces";
+import { objResponse } from "../service/state/transformers";
 import { getValidStatesForOperationWithState } from "../service/state/validator";
 
 const arraySchema: Schema = {
@@ -66,7 +66,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   it("with empty state", () => {
     const spreadState = getValidStatesForOperationWithState(
       op,
-      dsl.objResponse(),
+      objResponse(),
       deref,
     );
     expect(spreadState.error).toBeUndefined();
@@ -76,7 +76,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   it("invalid parameter returns error", () => {
     const spreadState = getValidStatesForOperationWithState(
       op,
-      dsl.objResponse({
+      objResponse({
         boom: 5,
       }),
       deref,
@@ -91,7 +91,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
           200: { content: { "application/json": {} }, description: "foo" },
         },
       },
-      dsl.objResponse(),
+      objResponse(),
       deref,
     );
     expect(spreadState.error).toContain("No schema defined");
@@ -100,7 +100,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   it("with $code specified", () => {
     const spreadState = getValidStatesForOperationWithState(
       op,
-      dsl.objResponse({
+      objResponse({
         $code: 200,
         tag: "foo",
       }),
@@ -119,7 +119,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   it("with $size in top-level specified", () => {
     const spreadState = getValidStatesForOperationWithState(
       arrResponses,
-      dsl.objResponse({ $size: 5 }),
+      objResponse({ $size: 5 }),
       deref,
     );
     expect(spreadState.error).toBeUndefined();
@@ -136,7 +136,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   it("with missing $code specified", () => {
     const spreadState = getValidStatesForOperationWithState(
       op,
-      dsl.objResponse({
+      objResponse({
         $code: 404,
       }),
       deref,
@@ -150,7 +150,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
   it("with no $code specified", () => {
     const spreadState = getValidStatesForOperationWithState(
       op,
-      dsl.objResponse({
+      objResponse({
         test: { id: 5 },
       }),
       deref,

--- a/packages/unmock-core/src/service/index.ts
+++ b/packages/unmock-core/src/service/index.ts
@@ -11,10 +11,13 @@ export { ServiceParser } from "./parser";
 
 const saveStateProxy = (store: ServiceStore, serviceName: string) => (
   method: ExtendedHTTPMethod = DEFAULT_STATE_HTTP_METHOD,
-) => (endpoint = DEFAULT_STATE_ENDPOINT, state: UnmockServiceState) => {
+) => (
+  endpoint = DEFAULT_STATE_ENDPOINT,
+  state: UnmockServiceState | undefined | string,
+) => {
   // Returns a function for the end user to update the state in,
   // while maintaining endpoints and methods.
-  if (typeof endpoint !== "string") {
+  if (state === undefined) {
     state = endpoint;
     endpoint = DEFAULT_STATE_ENDPOINT;
   }

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -9,7 +9,7 @@ import {
   MatcherResponse,
   UnmockServiceState,
 } from "./interfaces";
-import { objResponse } from "./state/transformers";
+import { objResponse, textResponse } from "./state/transformers";
 
 export class ServiceStore {
   private readonly serviceMapping: IServiceMapping = {};
@@ -49,7 +49,7 @@ export class ServiceStore {
     serviceName: string;
     endpoint: string;
     method: ExtendedHTTPMethod;
-    state: IStateInputGenerator | UnmockServiceState | undefined;
+    state: IStateInputGenerator | UnmockServiceState | string | undefined;
   }) {
     /**
      * Verifies logical flow of inputs before dispatching the update to
@@ -75,7 +75,10 @@ export class ServiceStore {
     let stateGen: IStateInputGenerator;
     if (!isStateInputGenerator(state)) {
       // Given an object, set default generator for state
-      stateGen = objResponse(state as UnmockServiceState);
+      stateGen =
+        typeof state === "string"
+          ? textResponse(state)
+          : objResponse(state as UnmockServiceState);
     } else {
       stateGen = state as IStateInputGenerator;
     }

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import path from "path";
-import { CorePackage, dsl, UnmockOptions } from "unmock-core";
+import { CorePackage, UnmockOptions } from "unmock-core";
+import { dsl } from "../..";
 import NodeBackend from "../../backend";
 
 class StateTestPackage extends CorePackage {
@@ -77,11 +78,18 @@ describe("Node.js interceptor", () => {
       expect(response2.data.every((pet: any) => pet.id === -1)).toBeTruthy();
     });
 
-    test("gets correct state when setting textual middleware", async () => {
-      states.petstore(dsl.textResponse("foo"));
+    test("gets correct state when setting textual response", async () => {
+      states.petstore("foo");
       const response = await axios("http://petstore.swagger.io/v1/pets");
       expect(response.status).toBe(200);
       expect(response.data).toBe("foo");
+    });
+
+    test("gets correct state when setting textual response with path", async () => {
+      states.petstore("/pets", "bar");
+      const response = await axios("http://petstore.swagger.io/v1/pets");
+      expect(response.status).toBe(200);
+      expect(response.data).toBe("bar");
     });
 
     test("throws when setting textual middleware with DSL with non-existing status code", async () => {


### PR DESCRIPTION
- Parses string states as `textResponse` by default.
- Leaves `objResponse` and `textResponse` as exports under hoisted `transformers` as `dsl`.
- Updates tests to reflect import changes.