### PR TITLE
Update CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,10 @@ jobs:
           - "34:32:ff:02:fe:1e:00:10:49:75:8e:d4:6c:2b:12:ca"
     - run:
         name: "Authenticate with GH"
-        command: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
+        command: |
+          git config user.email "dev@meeshkan.com"
+          git config user.name "Meeshkan Dev Team"
+          git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
     - run:
         name: "Tag current release"
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,9 @@ jobs:
         name: "Tag current release"
         command: |
           TAG=v`cat packages/unmock-core/package.json | grep version | awk 'BEGIN { FS = "\"" } { print $4 }'`
-          git tag -a $TAG
+          git tag -a $TAG -m $TAG
           git push origin $TAG
-    - run: npm run publish --yes
+    - run: npx lerna publish --from-package --yes
 
 workflows:
   version: 2


### PR DESCRIPTION
Automatic tagging still failed due to missing user name and email definitions.
Adds these and use the native `lerna publish` instead of an npm command.