### PR TITLE
Fix bug of accidentally deleting the build after compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "npm prune && del-cli ./packages/*/dist ./packages/*/tsconfig.tsbuildinfo",
-    "compile": "tsc --build tsconfig.build.json && npm run compile:tests",
+    "compile": "tsc --build tsconfig.build.json",
     "compile:clean": "tsc --build tsconfig.build.json --clean",
     "compile:tests": "tsc --build tsconfig.test.json && tsc --build tsconfig.test.json --clean",
     "watch": "tsc --build tsconfig.build.json --watch",


### PR DESCRIPTION
This had the side-effect that the build was deleted after `npm run compile`. The bad news is that type-errors in tests are not detected but I think we can live with that for a while. To re-add, as far as I can see we could 

1. Add a separate CI build step to compile tests. If running `--clean` after that, one would need to separately run `npm run compile` after the tests were cleaned.
2. Modify test compile so that it does not delete stuff from the build. I don't currently know enough of about the lerna+tsconfig but I think we can worry about it later.

FYI @mikesol @idantene 