### PR TITLE
[Release] v0.1.5.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # CHANGELOG.md
 
+## 0.1.5 (2019-07-26)
+
+Fix:
+
+  - `dist/` directory was missing from the release because of a bug in the CI/CD pipeline [#107](https://github.com/unmock/unmock-js/pull/107)
+
 ## 0.1.4 (2019-07-25)
 
 Features:

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/**"
   ],
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "npm prune && del-cli ./packages/*/dist ./packages/*/tsconfig.tsbuildinfo",
-    "compile": "tsc --build tsconfig.build.json && npm run compile:tests",
+    "compile": "tsc --build tsconfig.build.json",
     "compile:clean": "tsc --build tsconfig.build.json --clean",
     "compile:tests": "tsc --build tsconfig.test.json && tsc --build tsconfig.test.json --clean",
     "watch": "tsc --build tsconfig.build.json --watch",

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "name": "unmock-cli",
   "displayName": "unmock-cli",
   "license": "MIT",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "name": "unmock-core",
   "displayName": "unmock-core",
   "main": "dist/index.js",

--- a/packages/unmock-jsdom/package.json
+++ b/packages/unmock-jsdom/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "name": "unmock-jsdom",
   "displayName": "unmock-jsdom",
   "main": "dist/index.js",

--- a/packages/unmock-node/package.json
+++ b/packages/unmock-node/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "name": "unmock-node",
   "displayName": "unmock-node",
   "main": "dist/index.js",

--- a/packages/unmock/package.json
+++ b/packages/unmock/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "name": "unmock",
   "displayName": "unmock",
   "license": "MIT",


### PR DESCRIPTION
Fixes the bug of `dist/` directory being missing from the release because of a bug in the CI/CD pipeline [#107](https://github.com/unmock/unmock-js/pull/107).