### PR TITLE
Throw better error message when no match is found.

### DIFF
--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -45,7 +45,7 @@ describe("Node.js interceptor", () => {
       try {
         await axios("http://example.org");
       } catch (err) {
-        expect(err.message).toBe("No matching template found");
+        expect(err.message).toEqual(expect.stringContaining("No matching template"));
         return;
       }
       throw new Error("Should not get here");

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -45,7 +45,7 @@ describe("Node.js interceptor", () => {
       try {
         await axios("http://example.org");
       } catch (err) {
-        expect(err.message).toEqual(expect.stringContaining("No matching template"));
+        expect(err.message).toContain("No matching template");
         return;
       }
       throw new Error("Should not get here");

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -30,6 +30,10 @@ const respondFromSerializedResponse = (
   res.end(serializedResponse.body);
 };
 
+const errorForMissingTemplate = (sreq: ISerializedRequest) => {
+  return `No matching template found`;
+};
+
 async function handleRequestAndResponse(
   createResponse: CreateResponse,
   req: IncomingMessage,
@@ -44,9 +48,9 @@ async function handleRequestAndResponse(
     );
 
     if (serializedResponse === undefined) {
-      // TODO Handle this properly
       debugLog("No match found, emitting error");
-      clientRequest.emit("error", Error("No matching template found"));
+      const errMsg = errorForMissingTemplate(serializedRequest);
+      clientRequest.emit("error", Error(errMsg));
       return;
     }
     respondFromSerializedResponse(serializedResponse, res);
@@ -132,6 +136,7 @@ export default class NodeBackend implements IBackend {
     req: IncomingMessage,
     res: ServerResponse,
   ) {
+    debugLog("Handling incoming message...");
     const clientRequest = ClientRequestTracker.pop(req);
     handleRequestAndResponse(createResponse, req, res, clientRequest);
   }

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -31,7 +31,10 @@ const respondFromSerializedResponse = (
 };
 
 const errorForMissingTemplate = (sreq: ISerializedRequest) => {
-  return `No matching template found`;
+  return `No matching template found for intercepted request. Please ensure that
+  1. You have defined a service for host ${sreq.protocol}://${sreq.host}
+  2. The service has a path matching "${sreq.method} ${sreq.path}"
+  `;
 };
 
 async function handleRequestAndResponse(


### PR DESCRIPTION
- Adds a more descriptive error message when no match is found. One could go much fancier here by checking if the `__unmock__` directory exists or if the service existed but I think that can be done when adding CLI stuff.
- Do we want to link docs at some point? Probably not yet as they're not that stable and https://docs.unmock.io even points to wrong docs.