### PR TITLE
Handle request in the check phase of the event loop.

### DIFF
--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -50,5 +50,18 @@ describe("Node.js interceptor", () => {
       }
       throw new Error("Should not get here");
     });
+
+    test("respects cancellation", async () => {
+      const cancelTokenSource = axios.CancelToken.source();
+      setImmediate(() => cancelTokenSource.cancel());
+      try {
+        await axios("http://example.org", { cancelToken : cancelTokenSource.token} );
+      } catch (err) {
+        expect(axios.isCancel(err)).toBe(true);
+        return;
+      }
+      throw new Error("Was supposed to throw a cancellation error");
+    });
+
   });
 });

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -55,13 +55,14 @@ describe("Node.js interceptor", () => {
       const cancelTokenSource = axios.CancelToken.source();
       setImmediate(() => cancelTokenSource.cancel());
       try {
-        await axios("http://example.org", { cancelToken : cancelTokenSource.token} );
+        await axios("http://example.org", {
+          cancelToken: cancelTokenSource.token,
+        });
       } catch (err) {
         expect(axios.isCancel(err)).toBe(true);
         return;
       }
       throw new Error("Was supposed to throw a cancellation error");
     });
-
   });
 });

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -141,7 +141,7 @@ export default class NodeBackend implements IBackend {
   ) {
     debugLog("Handling incoming message...");
     req.on("error", (e: any) => debugLog("Error on intercepted request:", e));
-    req.on("aborted", () => {
+    req.on("abort", () => {
       debugLog("Intercepted request aborted");
     });
     const clientRequest = ClientRequestTracker.pop(req);

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -140,8 +140,12 @@ export default class NodeBackend implements IBackend {
     res: ServerResponse,
   ) {
     debugLog("Handling incoming message...");
+    req.on("error", (e: any) => debugLog("Error on intercepted request:", e));
+    req.on("aborted", () => {
+      debugLog("Intercepted request aborted");
+    });
     const clientRequest = ClientRequestTracker.pop(req);
-    handleRequestAndResponse(createResponse, req, res, clientRequest);
+    setImmediate(() => handleRequestAndResponse(createResponse, req, res, clientRequest));
   }
 
   private mitmOnConnect(


### PR DESCRIPTION
- Use `setImmediate` to defer handling the request and response, allows canceling the request with `setImmediate`
- Would it be better to defer to the timer phase of the event loop with `setTimeout(..., 0)`? That would allow more simply simulating also the delay
- General comment: `req.abort()` is not handled anywhere, not sure if it's required and how unmock+mitm would handle that
