### PR TITLE
Make flaky mode the non-default, and set non-existing codes using 'default' response

### DIFF
--- a/packages/unmock-core/src/__tests__/corePackage.test.ts
+++ b/packages/unmock-core/src/__tests__/corePackage.test.ts
@@ -16,41 +16,48 @@ class TestBackend implements IBackend {
 }
 const backend = new TestBackend();
 
-describe("tests allowedHosts", () => {
-  test("defaults work as expected", () => {
-    const pkg = new TestPackage(backend);
-    expect(pkg.isWhitelisted("127.0.0.1")).toEqual(true);
-    expect(pkg.isWhitelisted("127.0.2.1")).toEqual(false);
-  });
+describe("Tests core package", () => {
+  describe("tests allowedHosts", () => {
+    let pkg: TestPackage;
+    beforeEach(() => {
+      pkg = new TestPackage(backend);
+    });
 
-  test("with wildcard mid-string", () => {
-    const pkg = new TestPackage(backend);
-    pkg.setAllowedHosts("12*.0.*.1");
-    expect(pkg.isWhitelisted("127.0.foobar.1")).toEqual(true);
-    expect(pkg.isWhitelisted("127.0..1")).toEqual(true);
-    expect(pkg.isWhitelisted("127.0.1")).toEqual(false);
-    expect(pkg.isWhitelisted("12.5.0.1.2.3.4.1")).toEqual(true);
-  });
+    test("defaults work as expected", () => {
+      expect(pkg.allowedHosts.isWhitelisted("127.0.0.1")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("127.0.2.1")).toEqual(false);
+    });
 
-  test("modified post-initialization", () => {
-    const pkg = new TestPackage(backend);
-    expect(pkg.isWhitelisted("127.0.0.1")).toEqual(true);
-    expect(pkg.isWhitelisted("127.0.2.1")).toEqual(false);
-    pkg.setAllowedHosts(["*foo*bar*.com"]);
-    expect(pkg.isWhitelisted("127.0.foobar.1")).toEqual(false);
-    expect(pkg.isWhitelisted("127.0.0.1")).toEqual(false);
-    expect(pkg.isWhitelisted("foobar.com")).toEqual(true);
-    expect(pkg.isWhitelisted("https://foo.bar.com")).toEqual(true);
-  });
+    test("with wildcard mid-string", () => {
+      pkg.allowedHosts.set("12*.0.*.1");
+      expect(pkg.allowedHosts.isWhitelisted("127.0.foobar.1")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("127.0..1")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("127.0.1")).toEqual(false);
+      expect(pkg.allowedHosts.isWhitelisted("12.5.0.1.2.3.4.1")).toEqual(true);
+    });
 
-  test("concatenated", () => {
-    const pkg = new TestPackage(backend);
-    expect(pkg.isWhitelisted("127.0.0.1")).toEqual(true);
-    expect(pkg.isWhitelisted("127.0.2.1")).toEqual(false);
-    pkg.extendAllowedHosts("*foo*bar*.com");
-    expect(pkg.isWhitelisted("127.0.foobar.1")).toEqual(false);
-    expect(pkg.isWhitelisted("127.0.0.1")).toEqual(true);
-    expect(pkg.isWhitelisted("foobar.com")).toEqual(true);
-    expect(pkg.isWhitelisted("https://foo.bar.com")).toEqual(true);
+    test("modified post-initialization", () => {
+      expect(pkg.allowedHosts.isWhitelisted("127.0.0.1")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("127.0.2.1")).toEqual(false);
+      pkg.allowedHosts.set(["*foo*bar*.com"]);
+      expect(pkg.allowedHosts.isWhitelisted("127.0.foobar.1")).toEqual(false);
+      expect(pkg.allowedHosts.isWhitelisted("127.0.0.1")).toEqual(false);
+      expect(pkg.allowedHosts.isWhitelisted("foobar.com")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("https://foo.bar.com")).toEqual(
+        true,
+      );
+    });
+
+    test("concatenated", () => {
+      expect(pkg.allowedHosts.isWhitelisted("127.0.0.1")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("127.0.2.1")).toEqual(false);
+      pkg.allowedHosts.add("*foo*bar*.com");
+      expect(pkg.allowedHosts.isWhitelisted("127.0.foobar.1")).toEqual(false);
+      expect(pkg.allowedHosts.isWhitelisted("127.0.0.1")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("foobar.com")).toEqual(true);
+      expect(pkg.allowedHosts.isWhitelisted("https://foo.bar.com")).toEqual(
+        true,
+      );
+    });
   });
 });

--- a/packages/unmock-core/src/__tests__/corePackage.test.ts
+++ b/packages/unmock-core/src/__tests__/corePackage.test.ts
@@ -25,7 +25,7 @@ describe("tests allowedHosts", () => {
 
   test("with wildcard mid-string", () => {
     const pkg = new TestPackage(backend);
-    pkg.allowedHosts = ["12*.0.*.1"];
+    pkg.setAllowedHosts("12*.0.*.1");
     expect(pkg.isWhitelisted("127.0.foobar.1")).toEqual(true);
     expect(pkg.isWhitelisted("127.0..1")).toEqual(true);
     expect(pkg.isWhitelisted("127.0.1")).toEqual(false);
@@ -36,7 +36,7 @@ describe("tests allowedHosts", () => {
     const pkg = new TestPackage(backend);
     expect(pkg.isWhitelisted("127.0.0.1")).toEqual(true);
     expect(pkg.isWhitelisted("127.0.2.1")).toEqual(false);
-    pkg.allowedHosts = ["*foo*bar*.com"];
+    pkg.setAllowedHosts(["*foo*bar*.com"]);
     expect(pkg.isWhitelisted("127.0.foobar.1")).toEqual(false);
     expect(pkg.isWhitelisted("127.0.0.1")).toEqual(false);
     expect(pkg.isWhitelisted("foobar.com")).toEqual(true);
@@ -47,7 +47,7 @@ describe("tests allowedHosts", () => {
     const pkg = new TestPackage(backend);
     expect(pkg.isWhitelisted("127.0.0.1")).toEqual(true);
     expect(pkg.isWhitelisted("127.0.2.1")).toEqual(false);
-    pkg.allowedHosts = pkg.allowedHosts.concat(["*foo*bar*.com"]);
+    pkg.extendAllowedHosts("*foo*bar*.com");
     expect(pkg.isWhitelisted("127.0.foobar.1")).toEqual(false);
     expect(pkg.isWhitelisted("127.0.0.1")).toEqual(true);
     expect(pkg.isWhitelisted("foobar.com")).toEqual(true);

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -62,14 +62,17 @@ describe("Tests generator", () => {
       options: mockOptions,
     });
     for (let i = 0; i < 50; i++) {
-      expect(
-        createResponse({
-          host: "petstore.swagger.io",
-          method: "post",
-          path: "/v1/pets",
-          protocol: "http",
-        }).statusCode,
-      ).toEqual(201);
+      const resp = createResponse({
+        host: "petstore.swagger.io",
+        method: "post",
+        path: "/v1/pets",
+        protocol: "http",
+      });
+      expect(resp).toBeDefined();
+      if (resp !== undefined) {
+        // Only used for type-checking...
+        expect(resp.statusCode).toEqual(201);
+      }
     }
   });
 
@@ -80,13 +83,18 @@ describe("Tests generator", () => {
     });
     const counters: { [code: number]: number } = { 200: 0, 201: 0 };
     for (let i = 0; i < 100; i++) {
-      const code: number = createResponse({
+      const resp = createResponse({
         host: "petstore.swagger.io",
         method: "post",
         path: "/v1/pets",
         protocol: "http",
-      }).statusCode;
-      counters[code] += 1;
+      });
+      expect(resp).toBeDefined();
+      if (resp !== undefined) {
+        // Only used for type-checking...
+        const code: number = resp.statusCode;
+        counters[code] += 1;
+      }
     }
     expect(counters[200]).toBeGreaterThan(0);
     expect(counters[201]).toBeGreaterThan(0);

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -2,6 +2,13 @@ import fs from "fs";
 import path from "path";
 import { IServiceDefLoader, responseCreatorFactory } from "..";
 
+const mockOptions = {
+  flaky: () => false,
+  isWhitelisted: (_: string) => false,
+  log: (_: string) => undefined,
+  useInProduction: () => false,
+};
+
 const serviceDefLoader: IServiceDefLoader = {
   load: () => Promise.all(serviceDefLoader.loadSync()),
   loadSync: () => {
@@ -30,6 +37,7 @@ describe("Tests generator", () => {
   it("loads all paths in __unmock__", () => {
     const { stateStore } = responseCreatorFactory({
       serviceDefLoader,
+      options: mockOptions,
     });
     stateStore.slack({}); // should pass
     stateStore.petstore({}); // should pass
@@ -39,6 +47,7 @@ describe("Tests generator", () => {
   it("sets a state for swagger api converted to openapi", () => {
     const { stateStore } = responseCreatorFactory({
       serviceDefLoader,
+      options: mockOptions,
     });
     stateStore.slack("/bots.info", { bot: { app_id: "A12345678" } }); // should pass
 

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -61,17 +61,34 @@ describe("Tests generator", () => {
       serviceDefLoader,
       options: mockOptions,
     });
-    // host: string;
-    // method: string;
-    // path: string;
-    // protocol: "http" | "https";
     for (let i = 0; i < 50; i++) {
-      createResponse({
-        host: "petstore.swagger.io",
-        method: "POST",
-        path: "v1/pets",
-        protocol: "http",
-      });
+      expect(
+        createResponse({
+          host: "petstore.swagger.io",
+          method: "post",
+          path: "/v1/pets",
+          protocol: "http",
+        }).statusCode,
+      ).toEqual(201);
     }
+  });
+
+  it("in flaky mode", () => {
+    const { createResponse } = responseCreatorFactory({
+      serviceDefLoader,
+      options: { ...mockOptions, flaky: () => true },
+    });
+    const counters: { [code: number]: number } = { 200: 0, 201: 0 };
+    for (let i = 0; i < 100; i++) {
+      const code: number = createResponse({
+        host: "petstore.swagger.io",
+        method: "post",
+        path: "/v1/pets",
+        protocol: "http",
+      }).statusCode;
+      counters[code] += 1;
+    }
+    expect(counters[200]).toBeGreaterThan(0);
+    expect(counters[201]).toBeGreaterThan(0);
   });
 });

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -55,4 +55,23 @@ describe("Tests generator", () => {
       stateStore.slack("/bots.info", { bot: { app_id: "A123456789" } }),
     ).toThrow("type is incorrect"); // Does not match the specified pattern
   });
+
+  it("in non-flaky mode", () => {
+    const { createResponse } = responseCreatorFactory({
+      serviceDefLoader,
+      options: mockOptions,
+    });
+    // host: string;
+    // method: string;
+    // path: string;
+    // protocol: "http" | "https";
+    for (let i = 0; i < 50; i++) {
+      createResponse({
+        host: "petstore.swagger.io",
+        method: "POST",
+        path: "v1/pets",
+        protocol: "http",
+      });
+    }
+  });
 });

--- a/packages/unmock-core/src/__tests__/transformers.test.ts
+++ b/packages/unmock-core/src/__tests__/transformers.test.ts
@@ -38,7 +38,7 @@ describe("Test text provider", () => {
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
-    expect(p.gen()).toEqual({});
+    expect(p.gen()).toEqual({ "text/plain": null });
   });
 
   it("returns empty object for empty state", () => {
@@ -46,7 +46,7 @@ describe("Test text provider", () => {
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
-    expect(p.gen()).toEqual({});
+    expect(p.gen()).toEqual({ "text/plain": null });
   });
 
   it("returns empty object for empty schema", () => {
@@ -54,14 +54,14 @@ describe("Test text provider", () => {
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
-    expect(p.gen()).toEqual({});
+    expect(p.gen()).toEqual({ "text/plain": null });
   });
 
   it("returns empty object for non-text schema", () => {
     const p = textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
-    expect(p.gen({ type: "array", items: {} })).toEqual({});
+    expect(p.gen({ type: "array", items: {} })).toEqual({ "text/plain": null });
   });
 
   it("returns correct state object for valid input", () => {

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -248,11 +248,7 @@ const generateMockFromTemplate = (
       isFlaky: options.flaky(),
     });
 
-  // At this point, we assume there are no references, and we only need to
-  // handle x-unmock-* within the schemas, modify it according to these
-  // properties + the state -> we can work with jsf out of the box
-
-  // Setup the unmock properties for jsf parsing
+  // Setup the unmock properties for jsf parsing of x-unmock-*
   setupJSFUnmockProperties();
   // Always generate all fields for now
   jsf.option("alwaysFakeOptionals", true);

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -181,7 +181,7 @@ const chooseResponseFromOperation = (
   genOptions: { isFlaky: boolean },
 ): {
   $code: string;
-  template: Schema;
+  template: Schema | undefined;
   headers: Headers | undefined;
 } => {
   const responses = operation.responses;
@@ -215,9 +215,11 @@ const chooseResponseFromOperation = (
 
   const content = deRefedResponse.content;
   if (content === undefined) {
-    throw new Error(
-      `Chosen response (${JSON.stringify(content)}) does not have any content!`,
-    );
+    return {
+      $code: chosenCode,
+      template: undefined,
+      headers: deref(deRefedResponse.headers),
+    };
   }
 
   const chosenMediaType = firstOrRandomOrUndefined(Object.keys(content));

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -10,6 +10,7 @@ import {
   ISerializedResponse,
   IServiceDef,
   IServiceDefLoader,
+  IUnmockOptions,
 } from "./interfaces";
 import { stateFacadeFactory } from "./service";
 import {
@@ -39,8 +40,10 @@ function firstOrRandomOrUndefined<T>(arr: T[]): T | undefined {
 
 export function responseCreatorFactory({
   serviceDefLoader,
+  options,
 }: {
   serviceDefLoader: IServiceDefLoader;
+  options: IUnmockOptions;
 }): { stateStore: StateFacadeType; createResponse: CreateResponse } {
   const serviceDefs: IServiceDef[] = serviceDefLoader.loadSync();
   const parser = new ServiceParser();
@@ -52,7 +55,7 @@ export function responseCreatorFactory({
   return {
     stateStore,
     createResponse: (sreq: ISerializedRequest) =>
-      generateMockFromTemplate(serviceStore.match(sreq)),
+      generateMockFromTemplate(options, serviceStore.match(sreq)),
   };
 }
 
@@ -73,6 +76,7 @@ const getStateForOperation = (
   operation: Operation,
   state: codeToMedia | undefined,
   deref: Dereferencer,
+  genOptions: { isFlaky: boolean },
 ):
   | {
       $code: string;
@@ -88,11 +92,17 @@ const getStateForOperation = (
   const possibleResponseCodes = Object.keys(state).filter((code: string) =>
     operationCodes.includes(code),
   );
-  // if only one response code is set - use that one; otherwise draw at random
-  // TODO - do we want to set sensible defaults?
-  const statusCode = firstOrRandomOrUndefined(possibleResponseCodes);
+
+  const statusCode = chooseResponseCode(
+    possibleResponseCodes,
+    genOptions.isFlaky,
+  );
   if (statusCode === undefined) {
     return undefined;
+  } else if (Array.isArray(statusCode)) {
+    throw new Error(
+      `Too many 2XX responses to choose from in '${operation.description}'!\nTry flaky mode or set a status code`,
+    );
   }
 
   const operationResponse = responses[statusCode as keyof Responses];
@@ -109,7 +119,9 @@ const getStateForOperation = (
   const mediaTypes = Object.keys(state[statusCode]).filter((type: string) =>
     operationContentKeys.includes(type),
   );
-  const mediaType = firstOrRandomOrUndefined(mediaTypes); // Ditto
+  // if only one media type is set - use that one; otherwise draw at random
+  // TODO - do we want to set sensible defaults?
+  const mediaType = firstOrRandomOrUndefined(mediaTypes);
   if (mediaType === undefined) {
     return undefined;
   }
@@ -138,19 +150,48 @@ const tryCatch = (value: any, f: (value: any) => any) => {
   }
 };
 
+const chooseResponseCode = (codes: string[], isFlaky: boolean) => {
+  if (isFlaky) {
+    return firstOrRandomOrUndefined(codes);
+  }
+  if (codes.indexOf("default") > -1) {
+    return "default";
+  }
+  const validCodes = codes.filter(
+    // tslint:disable-next-line: radix
+    (cd: string) => parseInt(cd) > 199 && parseInt(cd) < 300,
+  );
+  if (validCodes.length > 1) {
+    return validCodes;
+  }
+  return validCodes[0];
+};
+
 const chooseResponseFromOperation = (
   operation: Operation,
   deref: Dereferencer,
+  genOptions: { isFlaky: boolean },
 ): {
   $code: string;
   template: Schema;
   headers: Headers | undefined;
 } => {
   const responses = operation.responses;
-  const chosenCode = firstOrRandomOrUndefined(Object.keys(responses));
+  const codes = Object.keys(responses);
+  const chosenCode = chooseResponseCode(codes, genOptions.isFlaky);
   if (chosenCode === undefined) {
+    if (genOptions.isFlaky) {
+      throw new Error(
+        `Could not find any responses in operation '${operation.description}'`,
+      );
+    } else {
+      throw new Error(
+        `No valid default/2XX responses in '${operation.description}'`,
+      );
+    }
+  } else if (Array.isArray(chosenCode)) {
     throw new Error(
-      `Could not find any responses in operation '${operation.description}'`,
+      `Too many 2XX responses to choose from in '${operation.description}'!\nTry flaky mode or set a status code`,
     );
   }
 
@@ -192,6 +233,7 @@ const chooseResponseFromOperation = (
 };
 
 const generateMockFromTemplate = (
+  options: IUnmockOptions,
   matchedService: MatcherResponse,
 ): ISerializedResponse | undefined => {
   if (matchedService === undefined) {
@@ -199,8 +241,12 @@ const generateMockFromTemplate = (
   }
   const { operation, state, service } = matchedService;
   const { template, $code, headers } =
-    getStateForOperation(operation, state, service.dereferencer) ||
-    chooseResponseFromOperation(operation, service.dereferencer);
+    getStateForOperation(operation, state, service.dereferencer, {
+      isFlaky: options.flaky(),
+    }) ||
+    chooseResponseFromOperation(operation, service.dereferencer, {
+      isFlaky: options.flaky(),
+    });
 
   // At this point, we assume there are no references, and we only need to
   // handle x-unmock-* within the schemas, modify it according to these

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -154,9 +154,6 @@ const chooseResponseCode = (codes: string[], isFlaky: boolean) => {
   if (isFlaky) {
     return firstOrRandomOrUndefined(codes);
   }
-  if (codes.indexOf("default") > -1) {
-    return "default";
-  }
   const validCodes = codes.filter(
     // tslint:disable-next-line: radix
     (cd: string) => parseInt(cd) > 199 && parseInt(cd) < 300,
@@ -185,9 +182,7 @@ const chooseResponseFromOperation = (
         `Could not find any responses in operation '${operation.description}'`,
       );
     } else {
-      throw new Error(
-        `No valid default/2XX responses in '${operation.description}'`,
-      );
+      throw new Error(`No valid 2XX responses in '${operation.description}'`);
     }
   } else if (Array.isArray(chosenCode)) {
     throw new Error(

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -71,10 +71,7 @@ const setupJSFUnmockProperties = () => {
   // Handle post-generation references, etc?
 };
 
-const chooseResponseCode = (codes: string[], isFlaky: boolean) => {
-  if (isFlaky) {
-    return firstOrRandomOrUndefined(codes);
-  }
+const chooseResponseCode = (codes: string[]) => {
   if (codes.length === 1) {
     return codes[0];
   }
@@ -112,10 +109,9 @@ const getStateForOperation = (
     return undefined;
   }
 
-  const statusCode = chooseResponseCode(
-    possibleResponseCodes,
-    genOptions.isFlaky,
-  );
+  const statusCode = genOptions.isFlaky
+    ? firstOrRandomOrUndefined(possibleResponseCodes)
+    : chooseResponseCode(possibleResponseCodes);
   if (statusCode === undefined) {
     // We get here if there are no 2XX responses, but there is still more than 1 possible response code
     throw new Error(
@@ -185,7 +181,9 @@ const chooseResponseFromOperation = (
 } => {
   const responses = operation.responses;
   const codes = Object.keys(responses);
-  const chosenCode = chooseResponseCode(codes, genOptions.isFlaky);
+  const chosenCode = genOptions.isFlaky
+    ? firstOrRandomOrUndefined(codes)
+    : chooseResponseCode(codes);
   if (chosenCode === undefined) {
     if (genOptions.isFlaky) {
       throw new Error(

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -71,19 +71,24 @@ export abstract class CorePackage implements IUnmockPackage {
     this.backend.reset();
   }
 
-  public get allowedHosts() {
+  public setAllowedHosts(urls: Array<string | RegExp> | string | RegExp): void {
+    this.whitelist = Array.isArray(urls) ? urls : [urls];
+    this.regexWhitelist = whitelistToRegex(this.whitelist);
+  }
+  public extendAllowedHosts(
+    urls: string | RegExp | Array<string | RegExp>,
+  ): void {
+    Array.isArray(urls)
+      ? this.whitelist.push(...urls)
+      : this.whitelist.push(urls);
+    this.regexWhitelist = whitelistToRegex(this.whitelist);
+  }
+  public getAllowedHosts() {
     return this.whitelist.map((url: string | RegExp) =>
       url instanceof RegExp ? url.source : url,
     );
   }
-  public set allowedHosts(urls: Array<string | RegExp>) {
-    this.whitelist = urls;
-    this.regexWhitelist = whitelistToRegex(this.whitelist);
-  }
   public isWhitelisted(host: string) {
-    if (this.regexWhitelist === undefined) {
-      return false;
-    }
     return this.regexWhitelist.filter(wl => wl.test(host)).length > 0;
   }
 

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -3,8 +3,8 @@ import {
   IAllowedHosts,
   IBackend,
   ILogger,
-  IUnmockPackage,
   IUnmockOptions,
+  IUnmockPackage,
 } from "./interfaces";
 import * as transformers from "./service/state/transformers";
 // top-level exports
@@ -13,6 +13,7 @@ export * from "./generator";
 export const dsl = transformers;
 
 // tslint:disable: max-classes-per-file
+// Classes in this file to avoid unnecessary imports/exports
 
 const whitelistToRegex = (whitelist?: Array<string | RegExp>): RegExp[] =>
   whitelist === undefined

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -4,6 +4,12 @@ export interface ILogger {
   log(message: string): void;
 }
 
+export interface IUnmockOptions extends ILogger {
+  useInProduction(): boolean;
+  isWhitelisted(url: string): boolean;
+  flaky(): boolean;
+}
+
 export interface IMetaData {
   lang?: string;
 }
@@ -24,11 +30,6 @@ export interface IResponseData {
 export interface IBackend {
   initialize(options: IUnmockOptions): any;
   reset(): void;
-}
-
-export interface IUnmockOptions extends ILogger {
-  useInProduction: boolean;
-  isWhitelisted(url: string): boolean;
 }
 
 export interface IUnmockPackage {

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { HTTPMethod, IService } from "./service/interfaces";
+import { IService } from "./service/interfaces";
 
 export interface ILogger {
   log(message: string): void;
@@ -64,7 +64,7 @@ export interface ISerializedRequest {
   body?: string;
   headers?: IIncomingHeaders;
   host: string;
-  method: HTTPMethod;
+  method: string;
   path: string;
   protocol: "http" | "https";
 }

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { IService } from "./service/interfaces";
+import { HTTPMethod, IService } from "./service/interfaces";
 
 export interface ILogger {
   log(message: string): void;
@@ -64,7 +64,7 @@ export interface ISerializedRequest {
   body?: string;
   headers?: IIncomingHeaders;
   host: string;
-  method: string;
+  method: HTTPMethod;
   path: string;
   protocol: "http" | "https";
 }

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -32,7 +32,9 @@ export interface IUnmockOptions extends ILogger {
 }
 
 export interface IUnmockPackage {
-  allowedHosts: Array<string | RegExp>;
+  getAllowedHosts(): string[];
+  setAllowedHosts(urls: Array<string | RegExp> | string | RegExp): void;
+  extendAllowedHosts(urls: Array<string | RegExp> | string | RegExp): void;
   on(): any;
   init(): any;
   initialize(): any;

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -29,16 +29,19 @@ export interface IBackend {
   initialize(options: IUnmockOptions): any;
   reset(): void;
 }
+export interface IAllowedHosts {
+  get(): string[];
+  set(urls: Array<string | RegExp> | string | RegExp): void;
+  add(urls: Array<string | RegExp> | string | RegExp): void;
+  isWhitelisted(url: string): boolean;
+}
 
 export interface IUnmockPackage {
-  getAllowedHosts(): string[];
-  setAllowedHosts(urls: Array<string | RegExp> | string | RegExp): void;
-  extendAllowedHosts(urls: Array<string | RegExp> | string | RegExp): void;
+  allowedHosts: IAllowedHosts;
   on(): any;
   init(): any;
   initialize(): any;
   off(): void;
-  isWhitelisted(url: string): boolean;
   states(): any;
 }
 

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -28,9 +28,12 @@ export const textResponse = (
   gen: (schema: Schema) => generateTextResponse(schema, state),
 });
 
-const generateTextResponse = (schema: Schema, state: string | undefined) => {
+const generateTextResponse = (
+  schema: Schema,
+  state: string | undefined,
+): Record<string, any> => {
   if (state === undefined || schema === undefined || schema.type !== "string") {
-    return {};
+    return { "text/plain": null }; // null is used to indicate failure
   }
   return { ...schema, const: state };
 };

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -58,10 +58,24 @@ export const filterStatesByOperation = (
   // Filter each state by status code and media type present in Operation
   const filtered = states.reduce(
     (stateAcc: codeToMedia[], state: codeToMedia) => {
+      // for every non-matching code, we use the default argument
       const relCodesInState = Object.keys(state).filter((code: string) =>
         statusCodes.includes(code),
       );
       if (relCodesInState.length === 0) {
+        if (Object.keys(state).length > 0) {
+          // Some error codes are not expressed explictily, so we use 'default' instead
+          stateAcc.push(
+            filterByMediaType(
+              ["default"],
+              Object.keys(state).reduce((obj: codeToMedia, code) => {
+                obj.default = { ...obj.default, ...state[code] };
+                return obj;
+              }, {}),
+              mediaTypes,
+            ),
+          );
+        }
         // None match - we can safely ignore this state
         return stateAcc;
       }

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -139,7 +139,7 @@ export const getValidStatesForOperationWithState = (
     code !== undefined
       ? // If $code is defined, we fetch the response even if no other state was set
         validStatesForStateWithCode(
-          resps[String(code) as codeType],
+          resps[String(code) as codeType] || resps.default,
           state,
           code,
           deref,

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -135,10 +135,13 @@ export const getValidStatesForOperationWithState = (
 } => {
   const resps = operation.responses;
   const code = state.top.$code;
+  // If $code is defined, we fetch the response even if no other state was set
+  // If $code is not found, use the default response - "the default MAY be used as a
+  //    default response object for all HTTP codes that are not covered individually by the specification"
+  // (see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responsesObject)
   const { responses, error } =
     code !== undefined
-      ? // If $code is defined, we fetch the response even if no other state was set
-        validStatesForStateWithCode(
+      ? validStatesForStateWithCode(
           resps[String(code) as codeType] || resps.default,
           state,
           code,

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -11,9 +11,10 @@ describe("Node.js interceptor", () => {
     beforeAll(() => {
       nodeInterceptor = new NodeBackend({ servicesDirectory });
       nodeInterceptor.initialize({
+        flaky: () => false,
         isWhitelisted: (_: string) => false,
-        useInProduction: false,
         log: (_: string) => undefined,
+        useInProduction: () => false,
       });
     });
 

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -91,10 +91,10 @@ describe("Node.js interceptor", () => {
       expect(response.data).toBe("bar");
     });
 
-    test("throws when setting textual middleware with DSL with non-existing status code", async () => {
-      expect(() =>
-        states.petstore(dsl.textResponse("foo", { $code: 400 })),
-      ).toThrow("status code '400'");
+    test("uses default response when setting textual response with DSL with non-existing status code", async () => {
+      states.petstore(dsl.textResponse("foo", { $code: 400 }));
+      const response = await axios("http://petstore.swagger.io/v1/pets");
+      expect(response.data).toBe("foo");
     });
   });
 });

--- a/packages/unmock-node/src/__tests__/loaders/resources/petstore/index.yaml
+++ b/packages/unmock-node/src/__tests__/loaders/resources/petstore/index.yaml
@@ -45,7 +45,6 @@ paths:
                       type: string
                     tag:
                       type: string
-                x-unmock-size: 4
         default:
           description: unexpected error
           content:

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -91,7 +91,7 @@ export default class NodeBackend implements IBackend {
    * @returns `states` object, with which one can modify states of various services.
    */
   public initialize(options: IUnmockOptions): any {
-    if (process.env.NODE_ENV === "production" && !options.useInProduction) {
+    if (process.env.NODE_ENV === "production" && !options.useInProduction()) {
       throw new Error("Are you trying to run unmock in production?");
     }
     if (this.mitm !== undefined) {
@@ -111,6 +111,7 @@ export default class NodeBackend implements IBackend {
       servicesDir: this.config.servicesDirectory,
     });
     const { stateStore, createResponse } = responseCreatorFactory({
+      options,
       serviceDefLoader,
     });
 


### PR DESCRIPTION
- Move getter/setter to nested method calls as `unmock.allowedHosts.set` and `unmock.allowedHosts.add`, as Kimmo suggested in #116 and later here.
- Enable `unmock.flaky.on()` and `unmock.flaky.off()` to control which response codes are being used. Similarly, `unmock.useInProduction.on()` and `unmock.useInProduction.off()`
- In non-flaky mode, heuristic is as follows: If only one response code exists, use that one; otherwise, if only a single 2XX code is available, used that one; otherwise - throw (suggest using flaky or setting a status code).
- This goes hand in hand with a small modification per OAS (although, maybe we'd prefer to have it as the "old" way) - where a non-existing status code uses the default response. Hence, setting a status code `400` where it doesn't exist, should return the schema specified under `default`.