### PR TITLE
Move resources in unmock-node tests

### DIFF
--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import path from "path";
 import NodeBackend from "../../backend";
 
-const servicesDirectory = path.join(__dirname, "..", "loaders", "resources");
+const servicesDirectory = path.join(__dirname, "..", "resources");
 
 describe("Node.js interceptor", () => {
   describe("with petstore in place", () => {

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -10,7 +10,7 @@ class StateTestPackage extends CorePackage {
   }
 }
 
-const servicesDirectory = path.join(__dirname, "..", "loaders", "resources");
+const servicesDirectory = path.join(__dirname, "..", "resources");
 
 describe("Node.js interceptor", () => {
   describe("with state requests in place", () => {

--- a/packages/unmock-node/src/__tests__/loaders/fs-service-def-loader.test.ts
+++ b/packages/unmock-node/src/__tests__/loaders/fs-service-def-loader.test.ts
@@ -22,8 +22,10 @@ describe("File system service def loader", () => {
     });
     const serviceDefs: IServiceDef[] = await serviceDefLoader.load();
     expect(serviceDefs).toHaveLength(2);
-    const serviceDef = serviceDefs[0];
-    expect(serviceDef.directoryName).toBe("petstore");
+    expect(serviceDefs.map((def: IServiceDef) => def.directoryName)).toEqual([
+      "petstore",
+      "slack",
+    ]);
   });
 
   it("throws for a non-existing directory", () => {

--- a/packages/unmock-node/src/__tests__/loaders/fs-service-def-loader.test.ts
+++ b/packages/unmock-node/src/__tests__/loaders/fs-service-def-loader.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { IServiceDef } from "unmock-core";
 import { FsServiceDefLoader } from "../../loaders/fs-service-def-loader";
 
-const RESOURCES_DIR = path.join(__dirname, "resources");
+const RESOURCES_DIR = path.join(__dirname, "..", "resources");
 
 describe("File system service def loader", () => {
   it("loads serviceDefs from existing directory", () => {
@@ -10,16 +10,18 @@ describe("File system service def loader", () => {
       servicesDir: RESOURCES_DIR,
     });
     const serviceDefs: IServiceDef[] = serviceDefLoader.loadSync();
-    expect(serviceDefs).toHaveLength(1);
-    const serviceDef = serviceDefs[0];
-    expect(serviceDef.directoryName).toBe("petstore");
+    expect(serviceDefs).toHaveLength(2);
+    expect(serviceDefs.map((def: IServiceDef) => def.directoryName)).toEqual([
+      "petstore",
+      "slack",
+    ]);
   });
   it("loads serviceDefs from existing directory asynchronously", async () => {
     const serviceDefLoader = new FsServiceDefLoader({
       servicesDir: RESOURCES_DIR,
     });
     const serviceDefs: IServiceDef[] = await serviceDefLoader.load();
-    expect(serviceDefs).toHaveLength(1);
+    expect(serviceDefs).toHaveLength(2);
     const serviceDef = serviceDefs[0];
     expect(serviceDef.directoryName).toBe("petstore");
   });

--- a/packages/unmock-node/src/__tests__/resources/petstore/index.yaml
+++ b/packages/unmock-node/src/__tests__/resources/petstore/index.yaml
@@ -30,38 +30,15 @@ paths:
               schema:
                 type: string
           content:
-            application/json:
+            application/json:    
               schema:
-                type: array
-                items:
-                  required:
-                  - id
-                  - name
-                  properties:
-                    id:
-                      type: integer
-                      format: int64
-                    name:
-                      type: string
-                    tag:
-                      type: string
+                $ref: "#/components/schemas/Pets"
         default:
           description: unexpected error
           content:
-            text/plain:
-              schema:
-                type: string
             application/json:
               schema:
-                required:
-                  - code
-                  - message
-                properties:
-                  code:
-                    type: integer
-                    format: int32
-                  message:
-                    type: string
+                $ref: "#/components/schemas/Error"
     post:
       summary: Create a pet
       operationId: createPets
@@ -75,15 +52,7 @@ paths:
           content:
             application/json:
               schema:
-                required:
-                  - code
-                  - message
-                properties:
-                  code:
-                    type: integer
-                    format: int32
-                  message:
-                    type: string
+                $ref: "#/components/schemas/Error"
   /pets/{petId}:
     get:
       summary: Info for a specific pet
@@ -103,30 +72,38 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  required:
-                  - id
-                  - name
-                  properties:
-                    id:
-                      type: integer
-                      format: int64
-                    name:
-                      type: string
-                    tag:
-                      type: string
+                $ref: "#/components/schemas/Pets"
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                required:
-                  - code
-                  - message
-                properties:
-                  code:
-                    type: integer
-                    format: int32
-                  message:
-                    type: string
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/packages/unmock-node/src/__tests__/resources/petstore/index.yaml
+++ b/packages/unmock-node/src/__tests__/resources/petstore/index.yaml
@@ -39,6 +39,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/TextError"
     post:
       summary: Create a pet
       operationId: createPets
@@ -53,6 +56,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/TextError"
   /pets/{petId}:
     get:
       summary: Info for a specific pet
@@ -79,6 +85,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/TextError"
 components:
   schemas:
     Pet:
@@ -107,3 +116,5 @@ components:
           format: int32
         message:
           type: string
+    TextError:
+      type: string

--- a/packages/unmock-node/src/__tests__/resources/slack/spec.yaml
+++ b/packages/unmock-node/src/__tests__/resources/slack/spec.yaml
@@ -1,0 +1,16686 @@
+openapi: 3.0.0
+info:
+  description: One way to interact with the Slack platform is its HTTP RPC-based Web API, a
+    collection of methods requiring OAuth 2.0-based user, bot, or workspace
+    tokens blessed with related OAuth scopes.
+  title: Slack
+  version: 1.0.6
+  x-apisguru-categories:
+    - collaboration
+    - messaging
+  x-logo:
+    url: https://api.apis.guru/v2/cache/logo/http_static.tumblr.com_wvuzcz9_LlKncfhmp_slack_logo_240.png
+  x-origin:
+    - format: swagger
+      url: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
+      version: "2.0"
+  x-preferred: true
+  x-providerName: slack.com
+externalDocs:
+  description: Learn more about the Slack Web API
+  url: https://api.slack.com/web
+paths:
+  /api.test:
+    get:
+      description: Checks API calling code.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/api.test
+      operationId: api_test
+      parameters:
+        - description: example property to return
+          in: query
+          name: foo
+          schema:
+            type: string
+        - description: Error response to return
+          in: query
+          name: error
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Standard success response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: object
+                description: Schema for successful response api.test method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: api.test success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Artificial error response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: object
+                description: Schema for error response api.test method
+                properties:
+                  error:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: api.test error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    args:
+                      error: my_error
+                    error: my_error
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - api
+  /apps.permissions.info:
+    get:
+      description: Returns list of permissions this app has on a team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/apps.permissions.info
+      operationId: apps_permissions_info
+      parameters:
+        - description: "Authentication token. Requires scope: `none`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Standard success response when used with a user token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    info:
+                      app_home:
+                        resources:
+                          ids:
+                            - D0C0NU1Q8
+                            - D0BH95DLH
+                        scopes:
+                          - chat:write
+                          - im:history
+                          - im:read
+                      channel:
+                        resources:
+                          excluded_ids: []
+                          ids:
+                            - C061FA5PB
+                          wildcard: false
+                        scopes:
+                          - channels:read
+                      group:
+                        resources:
+                          ids: []
+                        scopes: []
+                      im:
+                        resources:
+                          ids: []
+                        scopes: []
+                      mpim:
+                        resources:
+                          ids: []
+                        scopes: []
+                      team:
+                        resources:
+                          ids: []
+                        scopes: []
+                    ok: true
+        default:
+          description: Standard failure response when used with an invalid token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions
+        - apps
+  /apps.permissions.request:
+    get:
+      description: Allows an app to request additional scopes
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/apps.permissions.request
+      operationId: apps_permissions_request
+      parameters:
+        - description: A comma separated list of scopes to request for
+          in: query
+          name: scopes
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `none`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Token used to trigger the permissions API
+          in: query
+          name: trigger_id
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Standard success response when used with a user token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from apps.permissions.request
+                  method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: apps.permissions.request schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Standard failure response when trigger_id is invalid
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from apps.permissions.request method
+                properties:
+                  error:
+                    enum:
+                      - invalid_trigger
+                      - trigger_exchanged
+                      - invalid_scope
+                      - invalid_user
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: apps.permissions.request error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_trigger_id
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions
+        - apps
+  /apps.permissions.resources.list:
+    get:
+      description: Returns list of resource grants this app has on a team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/apps.permissions.resources.list
+      operationId: apps_permissions_resources_list
+      parameters:
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `none`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return.
+          in: query
+          name: limit
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Typical successful paginated response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response apps.permissions.resources.list
+                  method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  resources:
+                    items:
+                      properties:
+                        id:
+                          title: An ID for a resource
+                          type: string
+                          x-examples:
+                            - T0DES3UAN
+                            - C0ABC1ABC
+                        type:
+                          title: The type of resource the `id` corresponds to
+                          type: string
+                          x-examples:
+                            - team
+                            - channel
+                            - mpim
+                      type: object
+                    type: array
+                  response_metadata:
+                    additionalProperties: true
+                    properties:
+                      next_cursor:
+                        type: string
+                        x-examples:
+                          - dGVhbTpDMUg5UkVTR0w=
+                    required:
+                      - next_cursor
+                    type: object
+                required:
+                  - ok
+                  - resources
+                title: apps.permissions.resources.list success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    resources:
+                      - id: T0DES3UAN
+                        type: team
+                      - id: D024BFF1M
+                        type: app_home
+                      - id: C024BE91L
+                        type: channel
+                    response_metadata:
+                      next_cursor: dGVhbTpDMUg5UkVTR0w=
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from apps.permissions.resources.list
+                  method
+                properties:
+                  error:
+                    enum:
+                      - invalid_cursor
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: apps.permissions.resources.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_cursor
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions.resources
+        - apps
+  /apps.permissions.scopes.list:
+    get:
+      description: Returns list of scopes this app has on a team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/apps.permissions.scopes.list
+      operationId: apps_permissions_scopes_list
+      parameters:
+        - description: "Authentication token. Requires scope: `none`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical successful paginated response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response api.permissions.scopes.list
+                  method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  scopes:
+                    additionalProperties: true
+                    properties:
+                      app_home:
+                        $ref: "#/components/schemas/objs_scopes"
+                      channel:
+                        $ref: "#/components/schemas/objs_scopes"
+                      group:
+                        $ref: "#/components/schemas/objs_scopes"
+                      im:
+                        $ref: "#/components/schemas/objs_scopes"
+                      mpim:
+                        $ref: "#/components/schemas/objs_scopes"
+                      team:
+                        $ref: "#/components/schemas/objs_scopes"
+                      user:
+                        $ref: "#/components/schemas/objs_scopes"
+                    type: object
+                required:
+                  - ok
+                  - scopes
+                title: api.permissions.scopes.list success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    scopes:
+                      app_home:
+                        - chat:write
+                        - im:history
+                        - im:read
+                      channel:
+                        - channels:history
+                        - chat:write
+                      group:
+                        - chat:write
+                      im:
+                        - chat:write
+                      mpim:
+                        - chat:write
+                      team:
+                        - users:read
+                      user: []
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from apps.permissions.scopes.list
+                  method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: apps.permissions.scopes.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions.scopes
+        - apps
+  /auth.revoke:
+    get:
+      description: Revokes a token.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/auth.revoke
+      operationId: auth_revoke
+      parameters:
+        - description: Setting this parameter to `1` triggers a _testing mode_ where the
+            specified token will not actually be revoked.
+          in: query
+          name: test
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `none`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from auth.revoke method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  revoked:
+                    type: boolean
+                required:
+                  - ok
+                  - revoked
+                title: auth.revoke schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    revoked: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from auth.revoke method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: auth.revoke error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - auth
+  /auth.test:
+    get:
+      description: Checks authentication & identity.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/auth.test
+      operationId: auth_test
+      parameters:
+        - description: "Authentication token. Requires scope: `none`"
+          in: header
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Standard success response when used with a user token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response auth.test method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  team:
+                    type: string
+                  team_id:
+                    $ref: "#/components/schemas/defs_team"
+                  url:
+                    type: string
+                  user:
+                    type: string
+                  user_id:
+                    $ref: "#/components/schemas/defs_user_id"
+                required:
+                  - ok
+                  - url
+                  - team
+                  - user
+                  - team_id
+                  - user_id
+                title: auth.test success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    team: Subarachnoid Workspace
+                    team_id: T12345678
+                    url: https://subarachnoid.slack.com/
+                    user: grace
+                    user_id: W12345678
+        default:
+          description: Standard failure response when used with an invalid token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response auth.test method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - token_revoked
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: auth.test error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - auth
+  /bots.info:
+    get:
+      description: Gets information about a bot user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/bots.info
+      operationId: bots_info
+      parameters:
+        - description: "Authentication token. Requires scope: `users:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Bot user to get info on
+          in: query
+          name: bot
+          schema:
+            type: string
+      responses:
+        "200":
+          description: When successful, returns bot info by bot ID.
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from bots.info method
+                properties:
+                  bot:
+                    additionalProperties: true
+                    properties:
+                      app_id:
+                        $ref: "#/components/schemas/defs_app_id"
+                      deleted:
+                        type: boolean
+                      icons:
+                        additionalProperties: true
+                        properties:
+                          image_36:
+                            format: uri
+                            type: string
+                          image_48:
+                            format: uri
+                            type: string
+                          image_72:
+                            format: uri
+                            type: string
+                        required:
+                          - image_36
+                          - image_48
+                          - image_72
+                        type: object
+                      id:
+                        $ref: "#/components/schemas/defs_bot_id"
+                      name:
+                        type: string
+                      updated:
+                        type: integer
+                      user_id:
+                        $ref: "#/components/schemas/defs_user_id"
+                    required:
+                      - id
+                      - deleted
+                      - name
+                      - updated
+                      - app_id
+                      - icons
+                    type: object
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - bot
+                title: bots.info schema
+                type: object
+              examples:
+                response:
+                  value:
+                    bot:
+                      app_id: A061BLERW
+                      deleted: false
+                      icons:
+                        image_36: https://...
+                        image_48: https://...
+                        image_72: https://...
+                      id: B061F7JQ1
+                      name: commandeer
+                      updated: 1449272004
+                    ok: true
+        default:
+          description: When no bot can be found, it returns an error.
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from bots.info method
+                properties:
+                  error:
+                    enum:
+                      - bot_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: bots.info error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: bot_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - users:read
+      tags:
+        - bots
+  /channels.archive:
+    post:
+      description: Archives a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.archive
+      operationId: channels_archive
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Channel to archive
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from channels.archive method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: channels.archive success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response channels.archive method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - already_archived
+                      - cant_archive_general
+                      - restricted_action
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.archive error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.create:
+    post:
+      description: Creates a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.create
+      operationId: channels_create
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                validate:
+                  description: Whether to return errors on invalid channel name instead of
+                    modifying it to meet the specified criteria.
+                  type: boolean
+                name:
+                  description: Name of channel to create
+                  type: string
+      responses:
+        "200":
+          description: Typical success response resulting in a new channel
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response channels.create method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: channels.create error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1502833204
+                      creator: U061F7AUR
+                      id: C0DEL09A5
+                      is_archived: false
+                      is_channel: true
+                      is_general: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_private: false
+                      is_shared: false
+                      last_read: 0000000000.000000
+                      members:
+                        - U061F7AUR
+                      name: endeavor
+                      name_normalized: endeavor
+                      previous_names: []
+                      purpose:
+                        creator: ""
+                        last_set: 0
+                        value: ""
+                      topic:
+                        creator: ""
+                        last_set: 0
+                        value: ""
+                      unread_count: 0
+                      unread_count_display: 0
+                    ok: true
+        default:
+          description: Example error response when an invalid name is provided
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response channels.create method
+                properties:
+                  error:
+                    enum:
+                      - name_taken
+                      - restricted_action
+                      - no_channel
+                      - invalid_name_required
+                      - invalid_name_punctuation
+                      - invalid_name_maxlength
+                      - invalid_name_specials
+                      - invalid_name
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.create error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    detail: Value passed for `name` contained unallowed special
+                      characters.
+                    error: invalid_name_specials
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.history:
+    get:
+      description: Fetches history of messages and events from a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.history
+      operationId: channels_history
+      parameters:
+        - description: Number of messages to return, between 1 and 1000.
+          in: query
+          name: count
+          schema:
+            type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          schema:
+            type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `channels:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          schema:
+            type: number
+        - description: Channel to fetch history for.
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          schema:
+            type: number
+      responses:
+        "200":
+          description: Typical success response containing the channel's history
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response channels.history method
+                properties:
+                  has_more:
+                    type: boolean
+                  messages:
+                    items:
+                      $ref: "#/components/schemas/objs_message"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - messages
+                  - has_more
+                title: channels.history success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    has_more: false
+                    latest: "1358547726.000003"
+                    messages:
+                      - text: Hello
+                        ts: "1358546515.000008"
+                        type: message
+                        user: U2147483896
+                      - is_starred: true
+                        reactions:
+                          - count: 3
+                            name: space_invader
+                            users:
+                              - U1
+                              - U2
+                              - U3
+                          - count: 5
+                            name: sweet_potato
+                            users:
+                              - U1
+                              - U2
+                              - U3
+                              - U4
+                              - U5
+                        text: World
+                        ts: "1358546515.000007"
+                        type: message
+                        user: U2147483896
+                      - ts: "1358546515.000007"
+                        type: something_else
+                      - attachments:
+                          - fallback: This is an attachment fallback
+                            id: 1
+                            text: Don't get too attached
+                        bot_id: B19LU7CSY
+                        subtype: bot_message
+                        text: Containment unit is 98% full
+                        ts: "1503435956.000247"
+                        type: message
+                        username: ecto1138
+                    ok: true
+        default:
+          description: Error response when the specified channel cannot be found
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response channels.history method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_ts_latest
+                      - invalid_ts_oldest
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.history error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:history
+      tags:
+        - channels
+  /channels.info:
+    get:
+      description: Gets information about a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.info
+      operationId: channels_info
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Set this to `true` to receive the locale for this channel. Defaults
+            to `false`
+          in: query
+          name: include_locale
+          schema:
+            type: boolean
+        - description: Channel to get info on
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response channels.info method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: channels.info success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1466025154
+                      creator: U0G9QF9C6
+                      id: C1H9RESGL
+                      is_archived: false
+                      is_channel: true
+                      is_general: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_private: false
+                      is_shared: false
+                      last_read: "1503435939.000101"
+                      latest:
+                        attachments:
+                          - fallback: This is an attachment fallback
+                            id: 1
+                            text: Don't get too attached
+                        bot_id: B19LU7CSY
+                        subtype: bot_message
+                        text: Containment unit is 98% full
+                        ts: "1503435956.000247"
+                        type: message
+                        username: ecto1138
+                      members:
+                        - U0G9QF9C6
+                        - U1QNSQB9U
+                      name: busting
+                      name_normalized: busting
+                      previous_names:
+                        - dusting
+                      purpose:
+                        creator: U0G9QF9C6
+                        last_set: 1503435128
+                        value: Discuss busting ghosts
+                      topic:
+                        creator: U0G9QF9C6
+                        last_set: 1503435128
+                        value: Spiritual containment strategies
+                      unread_count: 1
+                      unread_count_display: 1
+                    ok: true
+        default:
+          description: Error response when the specified channel cannot be found
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response channels.info method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.info error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:read
+      tags:
+        - channels
+  /channels.invite:
+    post:
+      description: Invites a user to a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.invite
+      operationId: channels_invite
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user:
+                  description: User to invite to channel.
+                  type: string
+                channel:
+                  description: Channel to invite user to.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response channels.invite method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: channels.invite error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1466025154
+                      creator: U0G9QF9C6
+                      id: C1H9RESGL
+                      is_archived: false
+                      is_channel: true
+                      is_general: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_private: false
+                      is_shared: false
+                      last_read: "1503435963.000307"
+                      latest:
+                        subtype: channel_leave
+                        text: <@U1QNSQB9U|protobot> has left the channel
+                        ts: "1503435963.000307"
+                        type: message
+                        user: U1QNSQB9U
+                      members:
+                        - U0G9QF9C6
+                        - U1QNSQB9U
+                      name: busting
+                      name_normalized: busting
+                      previous_names: []
+                      purpose:
+                        creator: U0G9QF9C6
+                        last_set: 1503435128
+                        value: My Purpose
+                      topic:
+                        creator: U0G9QF9C6
+                        last_set: 1503435128
+                        value: My Topic
+                      unread_count: 0
+                      unread_count_display: 0
+                    ok: true
+        default:
+          description: A somewhat typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response channels.invite method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - user_not_found
+                      - cant_invite_self
+                      - not_in_channel
+                      - already_in_channel
+                      - is_archived
+                      - cant_invite
+                      - too_many_users
+                      - ura_max_channels
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.invite error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: cant_invite
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.join:
+    post:
+      description: Joins a channel, creating it if needed.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.join
+      operationId: channels_join
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                validate:
+                  description: Whether to return errors on invalid channel name instead of
+                    modifying it to meet the specified criteria.
+                  type: boolean
+                name:
+                  description: Name of channel to join
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from channels.join method
+                properties:
+                  already_in_channel:
+                    type: boolean
+                  channel:
+                    $ref: "#/components/schemas/objs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: channels.join schema
+                type: object
+              examples:
+                response:
+                  value:
+                    already_in_channel: true
+                    channel:
+                      created: 1466025154
+                      creator: U0G9QF9C6
+                      id: C1H9RESGL
+                      is_archived: false
+                      is_channel: true
+                      is_general: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_private: false
+                      is_shared: false
+                      members:
+                        - U0G9QF9C6
+                        - U1QNSQB9U
+                      name: busting
+                      name_normalized: busting
+                      previous_names: []
+                      purpose:
+                        creator: U0G9QF9C6
+                        last_set: 1503435128
+                        value: My Purpose
+                      topic:
+                        creator: U0G9QF9C6
+                        last_set: 1503435128
+                        value: My Topic
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from channels.join method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - name_taken
+                      - restricted_action
+                      - no_channel
+                      - is_archived
+                      - invalid_name_required
+                      - invalid_name_punctuation
+                      - invalid_name_maxlength
+                      - invalid_name_specials
+                      - invalid_name
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - user_is_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.join error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.kick:
+    post:
+      description: Removes a user from a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.kick
+      operationId: channels_kick
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user:
+                  description: User to remove from channel.
+                  type: string
+                channel:
+                  description: Channel to remove user from.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from channels.kick method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: channels.kick schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from channels.kick method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - user_not_found
+                      - cant_kick_self
+                      - not_in_channel
+                      - cant_kick_from_general
+                      - restricted_action
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - user_is_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.kick error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: not_in_channel
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.leave:
+    post:
+      description: Leaves a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.leave
+      operationId: channels_leave
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Channel to leave
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.list:
+    get:
+      description: Lists all channels in a Slack team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.list
+      operationId: channels_list
+      parameters:
+        - description: Exclude the `members` collection from each `channel`
+          in: query
+          name: exclude_members
+          schema:
+            type: boolean
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `channels:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the users list
+            hasn't been reached.
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Exclude archived channels from the list
+          in: query
+          name: exclude_archived
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Typical cursored success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response channels.list method
+                properties:
+                  channels:
+                    items:
+                      $ref: "#/components/schemas/objs_channel"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channels
+                title: channels.list success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channels:
+                      - created: 1449709280
+                        creator: U0G9QF9C6
+                        id: C0G9QF9GW
+                        is_archived: false
+                        is_channel: true
+                        is_general: false
+                        is_member: true
+                        is_mpim: false
+                        is_org_shared: false
+                        is_private: false
+                        is_shared: false
+                        members:
+                          - U0G9QF9C6
+                          - U0G9WFXNZ
+                        name: random
+                        name_normalized: random
+                        num_members: 2
+                        previous_names: []
+                        purpose:
+                          creator: ""
+                          last_set: 0
+                          value: A place for non-work-related flimflam, faffing,
+                            hodge-podge or jibber-jabber you'd prefer to keep
+                            out of more focused work-related channels.
+                        topic:
+                          creator: U0G9QF9C6
+                          last_set: 1449709352
+                          value: Other stuff
+                      - created: 1449709280
+                        creator: U0G9QF9C6
+                        id: C0G9QKBBL
+                        is_archived: false
+                        is_channel: true
+                        is_general: true
+                        is_member: true
+                        is_mpim: false
+                        is_org_shared: false
+                        is_private: false
+                        is_shared: false
+                        members:
+                          - U0G9QF9C6
+                          - U0G9WFXNZ
+                        name: general
+                        name_normalized: general
+                        num_members: 2
+                        previous_names: []
+                        purpose:
+                          creator: U0G9QF9C6
+                          last_set: 1449709334
+                          value: To talk about anything!
+                        topic:
+                          creator: U0G9QF9C6
+                          last_set: 1449709364
+                          value: Talk about anything!
+                    ok: true
+                    response_metadata:
+                      next_cursor: dGVhbTpDMUg5UkVTR0w=
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response channels.list method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:read
+      tags:
+        - channels
+  /channels.mark:
+    post:
+      description: Sets the read cursor in a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.mark
+      operationId: channels_mark
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                ts:
+                  description: Timestamp of the most recently seen message.
+                  type: number
+                channel:
+                  description: Channel to set reading cursor in.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response channels.mark method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: channels.mark success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response channels.mark method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_timestamp
+                      - not_in_channel
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.mark error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.rename:
+    post:
+      description: Renames a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.rename
+      operationId: channels_rename
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                validate:
+                  description: Whether to return errors on invalid channel name instead of
+                    modifying it to meet the specified criteria.
+                  type: boolean
+                name:
+                  description: New name for channel.
+                  type: string
+                channel:
+                  description: Channel to rename
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from channels.rename method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: channels.rename schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1477445146
+                      creator: U2U85N1RZ
+                      id: C2U875RJN
+                      is_archived: false
+                      is_channel: true
+                      is_general: false
+                      is_member: false
+                      is_mpim: false
+                      is_org_shared: false
+                      is_private: false
+                      is_shared: false
+                      members: []
+                      name: humans-and-bots
+                      name_normalized: humans-and-bots
+                      previous_names:
+                        - humans
+                      purpose:
+                        creator: U2U85N1RZ
+                        last_set: 1509475801
+                        value: the purpose of this channel is to bring people and
+                          robots together in harmony
+                      topic:
+                        creator: U2U85N1RZ
+                        last_set: 1509475775
+                        value: here be robots
+                      unlinked: 0
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from channels.rename method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - not_in_channel
+                      - not_authorized
+                      - invalid_name
+                      - name_taken
+                      - invalid_name_required
+                      - invalid_name_punctuation
+                      - invalid_name_maxlength
+                      - invalid_name_specials
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - user_is_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.rename error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.replies:
+    get:
+      description: Retrieve a thread of messages posted to a channel
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.replies
+      operationId: channels_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message
+          in: query
+          name: thread_ts
+          schema:
+            type: number
+        - description: "Authentication token. Requires scope: `channels:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Channel to fetch thread from
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    has_more: false
+                    messages:
+                      - last_read: "1509484885.000082"
+                        replies:
+                          - ts: "1509484424.000601"
+                            user: U2U85N1RZ
+                          - ts: "1509484885.000082"
+                            user: U2U85N1RZ
+                        reply_count: 2
+                        subscribed: true
+                        text: This is a channel message
+                        thread_ts: "1485913694.000025"
+                        ts: "1485913694.000025"
+                        type: message
+                        unread_count: 0
+                        user: U2X9P5FEL
+                      - parent_user_id: U2X9P5FEL
+                        text: This is a thread reply
+                        thread_ts: "1485913694.000025"
+                        ts: "1509484424.000601"
+                        type: message
+                        user: U2U85N1RZ
+                      - parent_user_id: U2X9P5FEL
+                        text: This is another thread reply
+                        thread_ts: "1485913694.000025"
+                        ts: "1509484885.000082"
+                        type: message
+                        user: U2U85N1RZ
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: thread_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:history
+      tags:
+        - channels
+  /channels.setPurpose:
+    post:
+      description: Sets the purpose for a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.setPurpose
+      operationId: channels_setPurpose
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                purpose:
+                  description: The new purpose
+                  type: string
+                channel:
+                  description: Channel to set the purpose of
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from channels.setPurpose method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  purpose:
+                    type: string
+                required:
+                  - ok
+                  - purpose
+                title: channels.setPurpose schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    purpose: My special purpose
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from channels.setPurpose method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - not_in_channel
+                      - is_archived
+                      - too_long
+                      - user_is_restricted
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: channels.setPurpose error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.setTopic:
+    post:
+      description: Sets the topic for a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.setTopic
+      operationId: channels_setTopic
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                topic:
+                  description: The new topic
+                  type: string
+                channel:
+                  description: Channel to set the topic of
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    topic: To picture topicality
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /channels.unarchive:
+    post:
+      description: Unarchives a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/channels.unarchive
+      operationId: channels_unarchive
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Channel to unarchive
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - channels
+  /chat.delete:
+    post:
+      description: Deletes a message.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/chat.delete
+      operationId: chat_delete
+      parameters:
+        - description: "Authentication token. Requires scope: `chat:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                as_user:
+                  description: Pass true to delete the message as the authed user with
+                    `chat:write:user` scope. [Bot users](/bot-users) in this
+                    context are considered authed users. If unused or false, the
+                    message will be deleted with `chat:write:bot` scope.
+                  type: boolean
+                ts:
+                  description: Timestamp of the message to be deleted.
+                  type: number
+                channel:
+                  description: Channel containing the message to be deleted.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response of chat.delete method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/defs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  ts:
+                    $ref: "#/components/schemas/defs_ts"
+                required:
+                  - ok
+                  - channel
+                  - ts
+                title: chat.delete success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel: C024BE91L
+                    ok: true
+                    ts: "1401383885.000061"
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from chat.delete method
+                properties:
+                  error:
+                    enum:
+                      - message_not_found
+                      - channel_not_found
+                      - cant_delete_message
+                      - compliance_exports_prevent_deletion
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: chat.delete error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: message_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - chat:write:user
+            - chat:write:bot
+      tags:
+        - chat
+  /chat.getPermalink:
+    get:
+      description: Retrieve a permalink URL for a specific extant message
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/chat.getPermalink
+      operationId: chat_getPermalink
+      parameters:
+        - description: "Authentication token. Requires scope: `none`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: A message's `ts` value, uniquely identifying it within a channel
+          in: query
+          name: message_ts
+          schema:
+            type: number
+        - description: The ID of the conversation or channel containing the message
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Standard success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response chat.getPermalink
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/defs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  permalink:
+                    format: uri
+                    type: string
+                required:
+                  - ok
+                  - channel
+                  - permalink
+                title: chat.getPermalink success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel: C1H9RESGA
+                    ok: true
+                    permalink: https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008
+        default:
+          description: Error response when channel cannot be found
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from chat.getPermalink method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - message_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: chat.getPermalink error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - chat
+  /chat.meMessage:
+    post:
+      description: Share a me message into a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/chat.meMessage
+      operationId: chat_meMessage
+      parameters:
+        - description: "Authentication token. Requires scope: `chat:write:user`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                text:
+                  description: Text of the message to send.
+                  type: string
+                channel:
+                  description: Channel to send message to. Can be a public channel, private
+                    group or IM channel. Can be an encoded ID, or a name.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    channel: C024BE7LR
+                    ok: true
+                    ts: "1417671948.000006"
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - chat:write:user
+      tags:
+        - chat
+  /chat.postEphemeral:
+    post:
+      description: Sends an ephemeral message to a user in a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/chat.postEphemeral
+      operationId: chat_postEphemeral
+      parameters:
+        - description: "Authentication token. Requires scope: `chat:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                attachments:
+                  description: A JSON-based array of structured attachments, presented as a
+                    URL-encoded string.
+                  type: string
+                text:
+                  description: Text of the message to send. See below for an explanation of
+                    [formatting](#formatting). This field is usually required,
+                    unless you're providing only `attachments` instead.
+                  type: string
+                link_names:
+                  description: Find and link channel names and usernames.
+                  type: boolean
+                parse:
+                  description: Change how messages are treated. Defaults to `none`. See
+                    [below](#formatting).
+                  type: string
+                user:
+                  description: "`id` of the user who will receive the ephemeral message.
+                    The user should be in the channel specified by the `channel`
+                    argument."
+                  type: string
+                as_user:
+                  description: Pass true to post the message as the authed bot. Defaults to
+                    false.
+                  type: boolean
+                channel:
+                  description: Channel, private group, or IM channel to send message to.
+                    Can be an encoded ID, or a name.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from chat.postEphemeral method
+                properties:
+                  message_ts:
+                    $ref: "#/components/schemas/defs_ts"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - message_ts
+                title: chat.postEphemeral success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    message_ts: "1502210682.580145"
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from chat.postEphemeral method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - is_archived
+                      - msg_too_long
+                      - no_text
+                      - restricted_action
+                      - too_many_attachments
+                      - user_not_in_channel
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: chat.postEphemeral error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: user_not_in_channel
+                    ok: false
+      security:
+        - slackAuth:
+            - chat:write:user
+            - chat:write:bot
+      tags:
+        - chat
+  /chat.postMessage:
+    post:
+      description: Sends a message to a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/chat.postMessage
+      operationId: chat_postMessage
+      parameters:
+        - description: "Authentication token. Requires scope: `chat:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                username:
+                  description: Set your bot's user name. Must be used in conjunction with
+                    `as_user` set to false, otherwise ignored. See
+                    [authorship](#authorship) below.
+                  type: string
+                thread_ts:
+                  description: Provide another message's `ts` value to make this message a
+                    reply. Avoid using a reply's `ts` value; use its parent
+                    instead.
+                  type: number
+                attachments:
+                  description: A JSON-based array of structured attachments, presented as a
+                    URL-encoded string.
+                  type: string
+                unfurl_links:
+                  description: Pass true to enable unfurling of primarily text-based
+                    content.
+                  type: boolean
+                text:
+                  description: Text of the message to send. See below for an explanation of
+                    [formatting](#formatting). This field is usually required,
+                    unless you're providing only `attachments` instead. Provide
+                    no more than 40,000 characters or [risk
+                    truncation](/changelog/2018-04-truncating-really-long-messages).
+                  type: string
+                unfurl_media:
+                  description: Pass false to disable unfurling of media content.
+                  type: boolean
+                parse:
+                  description: Change how messages are treated. Defaults to `none`. See
+                    [below](#formatting).
+                  type: string
+                as_user:
+                  description: Pass true to post the message as the authed user, instead of
+                    as a bot. Defaults to false. See [authorship](#authorship)
+                    below.
+                  type: boolean
+                mrkdwn:
+                  description: Disable Slack markup parsing by setting to `false`. Enabled
+                    by default.
+                  type: boolean
+                icon_emoji:
+                  description: Emoji to use as the icon for this message. Overrides
+                    `icon_url`. Must be used in conjunction with `as_user` set
+                    to `false`, otherwise ignored. See [authorship](#authorship)
+                    below.
+                  type: string
+                link_names:
+                  description: Find and link channel names and usernames.
+                  type: boolean
+                icon_url:
+                  description: URL to an image to use as the icon for this message. Must be
+                    used in conjunction with `as_user` set to false, otherwise
+                    ignored. See [authorship](#authorship) below.
+                  type: string
+                channel:
+                  description: Channel, private group, or IM channel to send message to.
+                    Can be an encoded ID, or a name. See [below](#channels) for
+                    more details.
+                  type: string
+                reply_broadcast:
+                  description: Used in conjunction with `thread_ts` and indicates whether
+                    reply should be made visible to everyone in the channel or
+                    conversation. Defaults to `false`.
+                  type: boolean
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response of chat.postMessage method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/defs_channel"
+                  message:
+                    $ref: "#/components/schemas/objs_message"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  ts:
+                    $ref: "#/components/schemas/defs_ts"
+                required:
+                  - ok
+                  - channel
+                  - ts
+                  - message
+                title: chat.postMessage success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel: C1H9RESGL
+                    message:
+                      attachments:
+                        - fallback: This is an attachment's fallback
+                          id: 1
+                          text: This is an attachment
+                      bot_id: B19LU7CSY
+                      subtype: bot_message
+                      text: Here's a message for you
+                      ts: "1503435956.000247"
+                      type: message
+                      username: ecto1
+                    ok: true
+                    ts: "1503435956.000247"
+        default:
+          description: Typical error response if too many attachments are included
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response chat.postMessage method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - not_in_channel
+                      - is_archived
+                      - msg_too_long
+                      - no_text
+                      - too_many_attachments
+                      - rate_limited
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: chat.postMessage error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: too_many_attachments
+                    ok: false
+      security:
+        - slackAuth:
+            - chat:write:user
+            - chat:write:bot
+      tags:
+        - chat
+  /chat.unfurl:
+    post:
+      description: Provide custom unfurl behavior for user-posted URLs
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/chat.unfurl
+      operationId: chat_unfurl
+      parameters:
+        - description: "Authentication token. Requires scope: `links:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user_auth_message:
+                  description: Provide a simply-formatted string to send as an ephemeral
+                    message to the user as invitation to authenticate further
+                    and enable full unfurling behavior
+                  type: string
+                user_auth_required:
+                  description: Set to `true` or `1` to indicate the user must install your
+                    Slack app to trigger unfurls for this domain
+                  type: boolean
+                unfurls:
+                  description: URL-encoded JSON map with keys set to URLs featured in the
+                    the message, pointing to their unfurl message attachments.
+                  type: string
+                ts:
+                  description: Timestamp of the message to add unfurl behavior to.
+                  type: string
+                user_auth_url:
+                  description: Send users to this custom URL where they will complete
+                    authentication in your app to fully trigger unfurling. Value
+                    should be properly URL-encoded.
+                  type: string
+                channel:
+                  description: Channel ID of the message
+                  type: string
+      responses:
+        "200":
+          description: Typical, minimal success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from chat.unfurl method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: chat.unfurl success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from chat.unfurl method
+                properties:
+                  error:
+                    enum:
+                      - cannot_unfurl_url
+                      - cannot_find_service
+                      - missing_unfurls
+                      - cannot_prompt
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: chat.unfurl error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: cannot_unfurl_url
+                    ok: false
+      security:
+        - slackAuth:
+            - links:write
+      tags:
+        - chat
+  /chat.update:
+    post:
+      description: Updates a message.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/chat.update
+      operationId: chat_update
+      parameters:
+        - description: "Authentication token. Requires scope: `chat:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                attachments:
+                  description: A JSON-based array of structured attachments, presented as a
+                    URL-encoded string. This field is required when not
+                    presenting `text`.
+                  type: string
+                text:
+                  description: New text for the message, using the [default formatting
+                    rules](/docs/formatting). It's not required when presenting
+                    `attachments`.
+                  type: string
+                ts:
+                  description: Timestamp of the message to be updated.
+                  type: number
+                parse:
+                  description: Change how messages are treated. Defaults to `client`,
+                    unlike `chat.postMessage`. See [below](#formatting).
+                  type: string
+                as_user:
+                  description: Pass true to update the message as the authed user. [Bot
+                    users](/bot-users) in this context are considered authed
+                    users.
+                  type: boolean
+                link_names:
+                  description: Find and link channel names and usernames. Defaults to
+                    `none`. See [below](#formatting).
+                  type: boolean
+                channel:
+                  description: Channel containing the message to be updated.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response of chat.update method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/defs_channel"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  text:
+                    title: Updated message text
+                    type: string
+                  ts:
+                    $ref: "#/components/schemas/defs_ts"
+                required:
+                  - ok
+                  - channel
+                  - ts
+                  - text
+                title: chat.update success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel: C024BE91L
+                    ok: true
+                    text: Updated text you carefully authored
+                    ts: "1401383885.000061"
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response chat.update method
+                properties:
+                  error:
+                    enum:
+                      - message_not_found
+                      - cant_update_message
+                      - channel_not_found
+                      - edit_window_closed
+                      - msg_too_long
+                      - too_many_attachments
+                      - rate_limited
+                      - no_text
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - request_timeout
+                      - invalid_json
+                      - json_not_object
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: chat.update error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: cant_update_message
+                    ok: false
+      security:
+        - slackAuth:
+            - chat:write:user
+            - chat:write:bot
+      tags:
+        - chat
+  /conversations.archive:
+    post:
+      description: Archives a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.archive
+      operationId: conversations_archive
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: ID of conversation to archive
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response conversations.archive method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: conversations.archive success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.archive method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - not_supported
+                      - channel_not_found
+                      - already_archived
+                      - cant_archive_general
+                      - restricted_action
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.archive error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.close:
+    post:
+      description: Closes a direct message or multi-person direct message.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.close
+      operationId: conversations_close
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Conversation to close.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response conversations.close method
+                properties:
+                  already_closed:
+                    type: boolean
+                  no_op:
+                    type: boolean
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: conversations.close success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.close method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - channel_not_found
+                      - user_does_not_own_channel
+                      - missing_scope
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.close error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.create:
+    post:
+      description: Initiates a public or private channel-based conversation
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.create
+      operationId: conversations_create
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Name of the public or private channel to create
+                  type: string
+                is_private:
+                  description: Create a private channel instead of a public one
+                  type: boolean
+      responses:
+        "200":
+          description: If successful, the command returns a rather stark [conversation
+            object](/types/conversation)
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response conversations.create method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: conversations.create success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1504554479
+                      creator: U0123456
+                      id: C0EAQDV4Z
+                      is_archived: false
+                      is_channel: true
+                      is_ext_shared: false
+                      is_general: false
+                      is_group: false
+                      is_im: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_shared: false
+                      last_read: 0000000000.000000
+                      name: endeavor
+                      name_normalized: endeavor
+                      pending_shared: []
+                      previous_names: []
+                      priority: 0
+                      purpose:
+                        creator: ""
+                        last_set: 0
+                        value: ""
+                      topic:
+                        creator: ""
+                        last_set: 0
+                        value: ""
+                      unlinked: 0
+                      unread_count: 0
+                      unread_count_display: 0
+                    ok: true
+        default:
+          description: Typical error response when name already in use
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.create method
+                properties:
+                  detail:
+                    type: string
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - name_taken
+                      - restricted_action
+                      - no_channel
+                      - invalid_name_required
+                      - invalid_name_punctuation
+                      - invalid_name_maxlength
+                      - invalid_name_specials
+                      - invalid_name
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.create error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: name_taken
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.history:
+    get:
+      description: Fetches a conversation's history of messages and events.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.history
+      operationId: conversations_history
+      parameters:
+        - description: Include messages with latest or oldest timestamp in results only
+            when either timestamp is specified.
+          in: query
+          name: inclusive
+          schema:
+            type: boolean
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `conversations:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the users list
+            hasn't been reached.
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          schema:
+            type: number
+        - description: Conversation ID to fetch history for.
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          schema:
+            type: number
+      responses:
+        "200":
+          description: Typical success response containing a channel's messages
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.history
+                  method
+                properties:
+                  has_more:
+                    type: boolean
+                  messages:
+                    items:
+                      $ref: "#/components/schemas/objs_message"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  pin_count:
+                    type: integer
+                required:
+                  - ok
+                  - messages
+                  - has_more
+                  - pin_count
+                title: conversations.history success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    has_more: true
+                    messages:
+                      - text: I find you punny and would like to smell your nose
+                          letter
+                        ts: "1512085950.000216"
+                        type: message
+                        user: U012AB3CDE
+                      - text: What, you want to smell my shoes better?
+                        ts: "1512104434.000490"
+                        type: message
+                        user: U061F7AUR
+                    ok: true
+                    pin_count: 0
+                    response_metadata:
+                      next_cursor: bmV4dF90czoxNTEyMDg1ODYxMDAwNTQz
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.history method
+                properties:
+                  error:
+                    enum:
+                      - missing_scope
+                      - channel_not_found
+                      - invalid_ts_latest
+                      - invalid_ts_oldest
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.history error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:history
+            - groups:history
+            - im:history
+            - mpim:history
+      tags:
+        - conversations
+  /conversations.info:
+    get:
+      description: Retrieve information about a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.info
+      operationId: conversations_info
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Conversation ID to learn more about
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: Set this to `true` to receive the locale for this conversation.
+            Defaults to `false`
+          in: query
+          name: include_locale
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Typical success response for a public channel. (Also, a response
+            from a private channel and a multi-party IM is very similar to this
+            example.)
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response conversations.info
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: conversations.info success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1449252889
+                      creator: W012A3BCD
+                      id: C012AB3CD
+                      is_archived: false
+                      is_channel: true
+                      is_ext_shared: false
+                      is_general: true
+                      is_group: false
+                      is_im: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_read_only: false
+                      is_shared: false
+                      last_read: "1502126650.228446"
+                      locale: en-US
+                      name: general
+                      name_normalized: general
+                      num_members: 23
+                      pending_shared: []
+                      previous_names:
+                        - specifics
+                        - abstractions
+                        - etc
+                      purpose:
+                        creator: W012A3BCD
+                        last_set: 1449709364
+                        value: This part of the workspace is for fun. Make fun here.
+                      topic:
+                        creator: W012A3BCD
+                        last_set: 1449709364
+                        value: For public discussion of generalities
+                      unlinked: 0
+                    ok: true
+        default:
+          description: Typical error response when a channel cannot be found
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.info method
+                properties:
+                  error:
+                    enum:
+                      - missing_scope
+                      - channel_not_found
+                      - team_added_to_org
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.info error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:read
+            - groups:read
+            - im:read
+            - mpim:read
+      tags:
+        - conversations
+  /conversations.invite:
+    post:
+      description: Invites users to a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.invite
+      operationId: conversations_invite
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                users:
+                  description: A comma separated list of user IDs. Up to 30 users may be
+                    listed.
+                  type: string
+                channel:
+                  description: The ID of the public or private channel to invite user(s) to.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response when an invitation is extended
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.invite method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: conversations.invite error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1449252889
+                      creator: W012A3BCD
+                      id: C012AB3CD
+                      is_archived: false
+                      is_channel: true
+                      is_ext_shared: false
+                      is_general: true
+                      is_group: false
+                      is_im: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_read_only: false
+                      is_shared: false
+                      last_read: "1502126650.228446"
+                      locale: en-US
+                      name: general
+                      name_normalized: general
+                      num_members: 23
+                      pending_shared: []
+                      previous_names:
+                        - specifics
+                        - abstractions
+                        - etc
+                      purpose:
+                        creator: W012A3BCD
+                        last_set: 1449709364
+                        value: This part of the workspace is for fun. Make fun here.
+                      topic:
+                        creator: W012A3BCD
+                        last_set: 1449709364
+                        value: For public discussion of generalities
+                      unlinked: 0
+                    ok: true
+        default:
+          description: Typical error response when an invite is attempted on a conversation
+            type that does not support it
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.invite method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - channel_not_found
+                      - user_not_found
+                      - cant_invite_self
+                      - not_in_channel
+                      - already_in_channel
+                      - is_archived
+                      - cant_invite
+                      - too_many_users
+                      - ura_max_channels
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  errors:
+                    items:
+                      additionalProperties: true
+                      properties:
+                        error:
+                          enum:
+                            - method_not_supported_for_channel_type
+                            - missing_scope
+                            - channel_not_found
+                            - user_not_found
+                            - cant_invite_self
+                            - not_in_channel
+                            - already_in_channel
+                            - is_archived
+                            - cant_invite
+                            - too_many_users
+                            - ura_max_channels
+                            - not_authed
+                            - invalid_auth
+                            - account_inactive
+                            - user_is_bot
+                            - user_is_restricted
+                            - user_is_ultra_restricted
+                            - invalid_arg_name
+                            - invalid_array_arg
+                            - invalid_charset
+                            - invalid_form_data
+                            - invalid_post_type
+                            - missing_post_type
+                            - invalid_json
+                            - json_not_object
+                            - request_timeout
+                            - upgrade_required
+                            - team_added_to_org
+                            - missing_charset
+                            - superfluous_charset
+                          type: string
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_false"
+                        user:
+                          $ref: "#/components/schemas/defs_user_id"
+                      required:
+                        - ok
+                        - error
+                      type: object
+                    minItems: 1
+                    title: errors is returned when an error associates an user
+                    type: array
+                    uniqueItems: true
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                title: conversations.invite error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: method_not_supported_for_channel_type
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.join:
+    post:
+      description: Joins an existing conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.join
+      operationId: conversations_join
+      parameters:
+        - description: "Authentication token. Requires scope: `channels:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: ID of conversation to join
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.join method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  response_metadata:
+                    properties:
+                      warnings:
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                    title: Response metadata
+                    type: object
+                  warning:
+                    type: string
+                required:
+                  - ok
+                  - channel
+                title: conversations.join success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1449252889
+                      creator: U061F7AUR
+                      id: C061EG9SL
+                      is_archived: false
+                      is_channel: true
+                      is_ext_shared: false
+                      is_general: true
+                      is_group: false
+                      is_im: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_shared: false
+                      name: general
+                      name_normalized: general
+                      pending_shared: []
+                      previous_names: []
+                      purpose:
+                        creator: ""
+                        last_set: 0
+                        value: For widget discussion
+                      topic:
+                        creator: ""
+                        last_set: 0
+                        value: Which widget do you worry about?
+                      unlinked: 0
+                    ok: true
+                    response_metadata:
+                      warnings:
+                        - already_in_channel
+                    warning: already_in_channel
+        default:
+          description: Typical error response if the conversation is archived and cannot be
+            joined
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.join method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - channel_not_found
+                      - is_archived
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.join error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: is_archived
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+      tags:
+        - conversations
+  /conversations.kick:
+    post:
+      description: Removes a user from a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.kick
+      operationId: conversations_kick
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user:
+                  description: User ID to be removed.
+                  type: string
+                channel:
+                  description: ID of conversation to remove user from.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response conversations.kick method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: conversations.kick success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response when you attempt to kick yourself from a
+            channel
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response conversations.kick method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - channel_not_found
+                      - user_not_found
+                      - cant_kick_self
+                      - not_in_channel
+                      - cant_kick_from_general
+                      - restricted_action
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.kick error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: cant_kick_self
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.leave:
+    post:
+      description: Leaves a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.leave
+      operationId: conversations_leave
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Conversation to leave
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.leave method
+                properties:
+                  not_in_channel:
+                    enum:
+                      - true
+                    type: boolean
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: conversations.leave success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response when attempting to leave a workspace's
+            "general" channel
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.leave method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - last_member
+                      - missing_scope
+                      - channel_not_found
+                      - is_archived
+                      - cant_leave_general
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.leave error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: cant_leave_general
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.list:
+    get:
+      description: Lists all channels in a Slack team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.list
+      operationId: conversations_list
+      parameters:
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `conversations:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the list hasn't
+            been reached. Must be an integer no larger than 1000.
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Set to `true` to exclude archived channels from the list
+          in: query
+          name: exclude_archived
+          schema:
+            type: boolean
+        - description: Mix and match channel types by providing a comma-separated list of
+            any combination of `public_channel`, `private_channel`, `mpim`, `im`
+          in: query
+          name: types
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response with only public channels
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.list method
+                properties:
+                  channels:
+                    items:
+                      $ref: "#/components/schemas/objs_conversation"
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  response_metadata:
+                    additionalProperties: true
+                    properties:
+                      next_cursor:
+                        type: string
+                    required:
+                      - next_cursor
+                    type: object
+                required:
+                  - ok
+                  - channels
+                title: conversations.list success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channels:
+                      - created: 1449252889
+                        creator: U012A3CDE
+                        id: C012AB3CD
+                        is_archived: false
+                        is_channel: true
+                        is_ext_shared: false
+                        is_general: true
+                        is_group: false
+                        is_im: false
+                        is_member: true
+                        is_mpim: false
+                        is_org_shared: false
+                        is_pending_ext_shared: false
+                        is_private: false
+                        is_shared: false
+                        name: general
+                        name_normalized: general
+                        num_members: 4
+                        pending_shared: []
+                        previous_names: []
+                        purpose:
+                          creator: ""
+                          last_set: 0
+                          value: This channel is for team-wide communication and
+                            announcements. All team members are in this channel.
+                        topic:
+                          creator: ""
+                          last_set: 0
+                          value: Company-wide announcements and work-based matters
+                        unlinked: 0
+                      - created: 1449252889
+                        creator: U061F7AUR
+                        id: C061EG9T2
+                        is_archived: false
+                        is_channel: true
+                        is_ext_shared: false
+                        is_general: false
+                        is_group: false
+                        is_im: false
+                        is_member: true
+                        is_mpim: false
+                        is_org_shared: false
+                        is_pending_ext_shared: false
+                        is_private: false
+                        is_shared: false
+                        name: random
+                        name_normalized: random
+                        num_members: 4
+                        pending_shared: []
+                        previous_names: []
+                        purpose:
+                          creator: ""
+                          last_set: 0
+                          value: A place for non-work-related flimflam, faffing,
+                            hodge-podge or jibber-jabber you'd prefer to keep
+                            out of more focused work-related channels.
+                        topic:
+                          creator: ""
+                          last_set: 0
+                          value: Non-work banter and water cooler conversation
+                        unlinked: 0
+                    ok: true
+                    response_metadata:
+                      next_cursor: dGVhbTpDMDYxRkE1UEI=
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.list method
+                properties:
+                  error:
+                    enum:
+                      - missing_scope
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:read
+            - groups:read
+            - im:read
+            - mpim:read
+      tags:
+        - conversations
+  /conversations.members:
+    get:
+      description: Retrieve members of a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.members
+      operationId: conversations_members
+      parameters:
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `conversations:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the users list
+            hasn't been reached.
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: ID of the conversation to retrieve members for
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical paginated success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response conversations.members method
+                properties:
+                  members:
+                    items:
+                      $ref: "#/components/schemas/defs_user_id"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  response_metadata:
+                    additionalProperties: true
+                    properties:
+                      next_cursor:
+                        type: string
+                    required:
+                      - next_cursor
+                    type: object
+                required:
+                  - ok
+                  - members
+                  - response_metadata
+                title: conversations.members success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    members:
+                      - U023BECGF
+                      - U061F7AUR
+                      - W012A3CDE
+                    ok: true
+                    response_metadata:
+                      next_cursor: e3VzZXJfaWQ6IFcxMjM0NTY3fQ==
+        default:
+          description: Typical error response when an invalid cursor is provided
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response conversations.members method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_limit
+                      - invalid_cursor
+                      - fetch_members_failed
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: conversations.members error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_cursor
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:read
+            - groups:read
+            - im:read
+            - mpim:read
+      tags:
+        - conversations
+  /conversations.open:
+    post:
+      description: Opens or resumes a direct message or multi-person direct message.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.open
+      operationId: conversations_open
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                return_im:
+                  description: Boolean, indicates you want the full IM channel definition
+                    in the response.
+                  type: boolean
+                users:
+                  description: Comma separated lists of users. If only one user is
+                    included, this creates a 1:1 DM.  The ordering of the users
+                    is preserved whenever a multi-person direct message is
+                    returned. Supply a `channel` when not supplying `users`.
+                  type: string
+                channel:
+                  description: Resume a conversation by supplying an `im` or `mpim`'s ID.
+                    Or provide the `users` field instead.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.open method
+                  when opening channels, ims, mpims
+                properties:
+                  already_open:
+                    type: boolean
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  no_op:
+                    type: boolean
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: conversations.open success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      id: D069C7QFK
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.open method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - user_not_found
+                      - user_not_visible
+                      - user_disabled
+                      - users_list_not_supplied
+                      - not_enough_users
+                      - too_many_users
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - channel_not_found
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: conversations.open error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.rename:
+    post:
+      description: Renames a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.rename
+      operationId: conversations_rename
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: New name for conversation.
+                  type: string
+                channel:
+                  description: ID of conversation to rename
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.rename method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: conversations.rename success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      created: 1449252889
+                      creator: W012A3BCD
+                      id: C012AB3CD
+                      is_archived: false
+                      is_channel: true
+                      is_ext_shared: false
+                      is_general: true
+                      is_group: false
+                      is_im: false
+                      is_member: true
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_read_only: false
+                      is_shared: false
+                      last_read: "1502126650.228446"
+                      locale: en-US
+                      name: general
+                      name_normalized: general
+                      num_members: 23
+                      pending_shared: []
+                      previous_names:
+                        - specifics
+                        - abstractions
+                        - etc
+                      purpose:
+                        creator: W012A3BCD
+                        last_set: 1449709364
+                        value: This part of the workspace is for fun. Make fun here.
+                      topic:
+                        creator: W012A3BCD
+                        last_set: 1449709364
+                        value: For public discussion of generalities
+                      unlinked: 0
+                    ok: true
+        default:
+          description: Typical error response when the calling user is not a member of the
+            conversation
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.rename method
+                properties:
+                  error:
+                    enum:
+                      - user_is_restricted
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - channel_not_found
+                      - not_in_channel
+                      - not_authorized
+                      - invalid_name
+                      - name_taken
+                      - invalid_name_required
+                      - invalid_name_punctuation
+                      - invalid_name_maxlength
+                      - invalid_name_specials
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.rename error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: not_in_channel
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.replies:
+    get:
+      description: Retrieve a thread of messages posted to a conversation
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.replies
+      operationId: conversations_replies
+      parameters:
+        - description: Include messages with latest or oldest timestamp in results only
+            when either timestamp is specified.
+          in: query
+          name: inclusive
+          schema:
+            type: boolean
+        - description: Unique identifier of a thread's parent message.
+          in: query
+          name: ts
+          schema:
+            type: number
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `conversations:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the users list
+            hasn't been reached.
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          schema:
+            type: number
+        - description: Conversation ID to fetch thread from.
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          schema:
+            type: number
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.replies
+                  method
+                properties:
+                  has_more:
+                    type: boolean
+                  messages:
+                    items:
+                      items:
+                        anyOf:
+                          - additionalProperties: true
+                            properties:
+                              last_read:
+                                $ref: "#/components/schemas/defs_ts"
+                              replies:
+                                items:
+                                  additionalProperties: true
+                                  properties:
+                                    ts:
+                                      $ref: "#/components/schemas/defs_ts"
+                                    user:
+                                      $ref: "#/components/schemas/defs_user_id"
+                                  required:
+                                    - user
+                                    - ts
+                                  type: object
+                                type: array
+                              reply_count:
+                                type: integer
+                              source_team:
+                                $ref: "#/components/schemas/defs_team"
+                              subscribed:
+                                type: boolean
+                              team:
+                                $ref: "#/components/schemas/defs_team"
+                              text:
+                                type: string
+                              thread_ts:
+                                $ref: "#/components/schemas/defs_ts"
+                              ts:
+                                $ref: "#/components/schemas/defs_ts"
+                              type:
+                                type: string
+                              unread_count:
+                                type: integer
+                              user:
+                                $ref: "#/components/schemas/defs_user_id"
+                              user_profile:
+                                $ref: "#/components/schemas/objs_user_profile_short"
+                              user_team:
+                                $ref: "#/components/schemas/defs_team"
+                            required:
+                              - type
+                              - user
+                              - text
+                              - thread_ts
+                              - reply_count
+                              - replies
+                              - subscribed
+                              - ts
+                            type: object
+                          - additionalProperties: true
+                            properties:
+                              is_starred:
+                                type: boolean
+                              parent_user_id:
+                                $ref: "#/components/schemas/defs_user_id"
+                              source_team:
+                                $ref: "#/components/schemas/defs_team"
+                              team:
+                                $ref: "#/components/schemas/defs_team"
+                              text:
+                                type: string
+                              thread_ts:
+                                $ref: "#/components/schemas/defs_ts"
+                              ts:
+                                $ref: "#/components/schemas/defs_ts"
+                              type:
+                                type: string
+                              user:
+                                $ref: "#/components/schemas/defs_user_id"
+                              user_profile:
+                                $ref: "#/components/schemas/objs_user_profile_short"
+                              user_team:
+                                $ref: "#/components/schemas/defs_team"
+                            required:
+                              - type
+                              - user
+                              - text
+                              - thread_ts
+                              - parent_user_id
+                              - ts
+                            type: object
+                    type: array
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - messages
+                title: conversations.replies success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    has_more: true
+                    messages:
+                      - last_read: "1484678597.521003"
+                        replies:
+                          - ts: "1483037603.017503"
+                            user: U061F7AUR
+                          - ts: "1483051909.018632"
+                            user: U061F7AUR
+                          - ts: "1483125339.020269"
+                            user: U061F7AUR
+                        reply_count: 3
+                        subscribed: true
+                        text: island
+                        thread_ts: "1482960137.003543"
+                        ts: "1482960137.003543"
+                        type: message
+                        unread_count: 0
+                        user: U061F7AUR
+                      - parent_user_id: U061F7AUR
+                        text: one island
+                        thread_ts: "1482960137.003543"
+                        ts: "1483037603.017503"
+                        type: message
+                        user: U061F7AUR
+                      - parent_user_id: U061F7AUR
+                        text: two island
+                        thread_ts: "1482960137.003543"
+                        ts: "1483051909.018632"
+                        type: message
+                        user: U061F7AUR
+                      - parent_user_id: U061F7AUR
+                        text: three for the land
+                        thread_ts: "1482960137.003543"
+                        ts: "1483125339.020269"
+                        type: message
+                        user: U061F7AUR
+                    ok: true
+                    response_metadata:
+                      next_cursor: bmV4dF90czoxNDg0Njc4MjkwNTE3MDkx
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.replies method
+                properties:
+                  error:
+                    enum:
+                      - missing_scope
+                      - channel_not_found
+                      - thread_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.replies error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: thread_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:history
+            - groups:history
+            - im:history
+            - mpim:history
+      tags:
+        - conversations
+  /conversations.setPurpose:
+    post:
+      description: Sets the purpose for a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.setPurpose
+      operationId: conversations_setPurpose
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                purpose:
+                  description: A new, specialer purpose
+                  type: string
+                channel:
+                  description: Conversation to set the purpose of
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.setPurpose
+                  method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: conversations.setPurpose success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.setPurpose method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - channel_not_found
+                      - not_in_channel
+                      - is_archived
+                      - too_long
+                      - user_is_restricted
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.setPurpose error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.setTopic:
+    post:
+      description: Sets the topic for a conversation.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.setTopic
+      operationId: conversations_setTopic
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                topic:
+                  description: The new topic string. Does not support formatting or
+                    linkification.
+                  type: string
+                channel:
+                  description: Conversation to set the topic of
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.setTopic
+                  method
+                properties:
+                  channel:
+                    $ref: "#/components/schemas/objs_conversation"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: conversations.setTopic success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.setTopic method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - channel_not_found
+                      - not_in_channel
+                      - is_archived
+                      - too_long
+                      - user_is_restricted
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.setTopic error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /conversations.unarchive:
+    post:
+      description: Reverses conversation archival.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/conversations.unarchive
+      operationId: conversations_unarchive
+      parameters:
+        - description: "Authentication token. Requires scope: `conversations:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: ID of conversation to unarchive
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from conversations.unarchive
+                  method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: conversations.unarchive success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from conversations.unarchive method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - channel_not_found
+                      - not_archived
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_restricted
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - team_added_to_org
+                      - missing_charset
+                      - superfluous_charset
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: conversations.unarchive error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:write
+            - groups:write
+            - im:write
+            - mpim:write
+      tags:
+        - conversations
+  /dialog.open:
+    get:
+      description: Open a dialog with a user
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/dialog.open
+      operationId: dialog_open
+      parameters:
+        - description: "Authentication token. Requires scope: `none`"
+          in: header
+          name: token
+          schema:
+            type: string
+        - description: The dialog definition. This must be a JSON-encoded string.
+          in: query
+          name: dialog
+          schema:
+            type: string
+        - description: Exchange a trigger to post to the user.
+          in: query
+          name: trigger_id
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response is quite minimal.
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response, before getting to any possible validation
+            errors.
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: missing_trigger
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - dialog
+  /dnd.endDnd:
+    post:
+      description: Ends the current user's Do Not Disturb session immediately.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/dnd.endDnd
+      operationId: dnd_endDnd
+      parameters:
+        - description: "Authentication token. Requires scope: `dnd:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - dnd:write
+      tags:
+        - dnd
+  /dnd.endSnooze:
+    post:
+      description: Ends the current user's snooze mode immediately.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/dnd.endSnooze
+      operationId: dnd_endSnooze
+      parameters:
+        - description: "Authentication token. Requires scope: `dnd:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - dnd:write
+      tags:
+        - dnd
+  /dnd.info:
+    get:
+      description: Retrieves a user's current Do Not Disturb status.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/dnd.info
+      operationId: dnd_info
+      parameters:
+        - description: "Authentication token. Requires scope: `dnd:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: User to fetch status for (defaults to current user)
+          in: query
+          name: user
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - dnd:read
+      tags:
+        - dnd
+  /dnd.setSnooze:
+    post:
+      description: Turns on Do Not Disturb mode for the current user, or changes its
+        duration.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/dnd.setSnooze
+      operationId: dnd_setSnooze
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                num_minutes:
+                  description: Number of minutes, from now, to snooze until.
+                  type: integer
+                token:
+                  description: "Authentication token. Requires scope: `dnd:write`"
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - dnd:write
+      tags:
+        - dnd
+  /dnd.teamInfo:
+    get:
+      description: Retrieves the Do Not Disturb status for users on a team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/dnd.teamInfo
+      operationId: dnd_teamInfo
+      parameters:
+        - description: "Authentication token. Requires scope: `dnd:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Comma-separated list of users to fetch Do Not Disturb status for
+          in: query
+          name: users
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from dnd.teamInfo method
+                properties:
+                  cached:
+                    type: boolean
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  users:
+                    additionalProperties: true
+                    type: object
+                required:
+                  - ok
+                  - users
+                title: dnd.teamInfo success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    users:
+                      U023BECGF:
+                        dnd_enabled: true
+                        next_dnd_end_ts: 1450423800
+                        next_dnd_start_ts: 1450387800
+                      W058CJVAA:
+                        dnd_enabled: false
+                        next_dnd_end_ts: 1
+                        next_dnd_start_ts: 1
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from dnd.teamInfo method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: dnd.teamInfo error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - dnd:read
+      tags:
+        - dnd
+  /emoji.list:
+    get:
+      description: Lists custom emoji for a team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/emoji.list
+      operationId: emoji_list
+      parameters:
+        - description: "Authentication token. Requires scope: `emoji:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - emoji:read
+      tags:
+        - emoji
+  /files.comments.add:
+    post:
+      description: Add a comment to an existing file.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.comments.add
+      operationId: files_comments_add
+      parameters:
+        - description: "Authentication token. Requires scope: `files:write:user`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                comment:
+                  description: Text of the comment to add.
+                  type: string
+                file:
+                  description: File to add a comment to.
+                  type: string
+      responses:
+        "200":
+          description: Standard success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response files.comments.add method
+                properties:
+                  comment:
+                    $ref: "#/components/schemas/objs_comment"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - comment
+                title: files.comments.add schema
+                type: object
+              examples:
+                response:
+                  value:
+                    comment:
+                      channel: C1234467890
+                      comment: Everyone should take a moment to read this file.
+                      created: 1356032811
+                      id: Fc1234567890
+                      timestamp: 1356032811
+                      user: U1234567890
+                    ok: true
+        default:
+          description: Artificial error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from files.comments.add method
+                properties:
+                  error:
+                    enum:
+                      - file_not_found
+                      - file_deleted
+                      - no_comment
+                      - cant_add
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: files.comments.add error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: file_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - files:write:user
+      tags:
+        - files.comments
+        - files
+  /files.comments.delete:
+    post:
+      description: Deletes an existing comment on a file.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.comments.delete
+      operationId: files_comments_delete
+      parameters:
+        - description: "Authentication token. Requires scope: `files:write:user`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  description: The comment to delete.
+                  type: string
+                file:
+                  description: File to delete a comment from.
+                  type: string
+      responses:
+        "200":
+          description: Standard success response is very simple
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response files.comments.delete method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: files.comments.delete schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Standard failure response when used with an invalid token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response files.comments.delete method
+                properties:
+                  error:
+                    enum:
+                      - cant_delete
+                      - comment_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: files.comments.delete error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: file_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - files:write:user
+      tags:
+        - files.comments
+        - files
+  /files.comments.edit:
+    post:
+      description: Edit an existing file comment.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.comments.edit
+      operationId: files_comments_edit
+      parameters:
+        - description: "Authentication token. Requires scope: `files:write:user`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                comment:
+                  description: Text of the comment to edit.
+                  type: string
+                id:
+                  description: The comment to edit.
+                  type: string
+                file:
+                  description: File containing the comment to edit.
+                  type: string
+      responses:
+        "200":
+          description: Standard success response when used with a user token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response files.comments.edit method
+                properties:
+                  comment:
+                    $ref: "#/components/schemas/objs_comment"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - comment
+                title: files.comments.edit schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    team: Subarachnoid Workspace
+                    team_id: T12345678
+                    url: https://subarachnoid.slack.com/
+                    user: grace
+                    user_id: W12345678
+        default:
+          description: Standard failure response when used with an invalid token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response files.comments.edit method
+                properties:
+                  error:
+                    enum:
+                      - cant_edit
+                      - comment_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: files.comments.edit error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - files:write:user
+      tags:
+        - files.comments
+        - files
+  /files.delete:
+    post:
+      description: Deletes a file.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.delete
+      operationId: files_delete
+      parameters:
+        - description: "Authentication token. Requires scope: `files:write:user`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: ID of file to delete.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response files.delete method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: files.delete schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response files.delete method
+                properties:
+                  error:
+                    enum:
+                      - file_not_found
+                      - file_deleted
+                      - cant_delete_file
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: files.delete error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - files:write:user
+      tags:
+        - files
+  /files.info:
+    get:
+      description: Gets information about a team file.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.info
+      operationId: files_info
+      parameters:
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `files:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Specify a file by providing its ID.
+          in: query
+          name: file
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from files.info method
+                properties:
+                  comments:
+                    $ref: "#/components/schemas/objs_comments"
+                  file:
+                    $ref: "#/components/schemas/objs_file"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  paging:
+                    $ref: "#/components/schemas/objs_paging"
+                required:
+                  - ok
+                  - file
+                  - comments
+                  - paging
+                title: files.info schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from files.info method
+                properties:
+                  error:
+                    enum:
+                      - file_not_found
+                      - file_deleted
+                      - timezone_count_failed
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: files.info error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - files:read
+      tags:
+        - files
+  /files.list:
+    get:
+      description: Lists & filters team files.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.list
+      operationId: files_list
+      parameters:
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: Filter files appearing in a specific channel, indicated by its ID.
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: Filter files created before this timestamp (inclusive).
+          in: query
+          name: ts_to
+          schema:
+            type: number
+        - description: Filter files created after this timestamp (inclusive).
+          in: query
+          name: ts_from
+          schema:
+            type: number
+        - description: "Authentication token. Requires scope: `files:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Filter files created by a single user.
+          in: query
+          name: user
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: string
+        - description: >-
+            Filter files by type:
+
+
+            * `all` - All files
+
+            * `spaces` - Posts
+
+            * `snippets` - Snippets
+
+            * `images` - Image files
+
+            * `gdocs` - Google docs
+
+            * `zips` - Zip files
+
+            * `pdfs` - PDF files
+
+
+            You can pass multiple values in the types argument, like `types=spaces,snippets`.The default value is `all`, which does not filter the list.
+          in: query
+          name: types
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from files.list method
+                properties:
+                  files:
+                    items:
+                      $ref: "#/components/schemas/objs_file"
+                    minItems: 0
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  paging:
+                    $ref: "#/components/schemas/objs_paging"
+                required:
+                  - ok
+                  - files
+                  - paging
+                title: files.list schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from files.list method
+                properties:
+                  error:
+                    enum:
+                      - user_not_found
+                      - unknown_type
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: files.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - files:read
+      tags:
+        - files
+  /files.revokePublicURL:
+    post:
+      description: Revokes public/external sharing access for a file
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.revokePublicURL
+      operationId: files_revokePublicURL
+      parameters:
+        - description: "Authentication token. Requires scope: `files:write:user`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: File to revoke
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - files:write:user
+      tags:
+        - files
+  /files.sharedPublicURL:
+    post:
+      description: Enables a file for public/external sharing.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.sharedPublicURL
+      operationId: files_sharedPublicURL
+      parameters:
+        - description: "Authentication token. Requires scope: `files:write:user`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: File to share
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - files:write:user
+      tags:
+        - files
+  /files.upload:
+    post:
+      description: Uploads or creates a file.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/files.upload
+      operationId: files_upload
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channels:
+                  description: Comma-separated list of channel names or IDs where the file
+                    will be shared.
+                  type: string
+                title:
+                  description: Title of file.
+                  type: string
+                initial_comment:
+                  description: Initial comment to add to file.
+                  type: string
+                filetype:
+                  description: A [file type](/types/file#file_types) identifier.
+                  type: string
+                filename:
+                  description: Filename of file.
+                  type: string
+                content:
+                  description: File contents via a POST variable. If omitting this
+                    parameter, you must provide a `file`.
+                  type: string
+                token:
+                  description: "Authentication token. Requires scope: `files:write:user`"
+                  type: string
+                file:
+                  description: File contents via `multipart/form-data`. If omitting this
+                    parameter, you must submit `content`.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response files.upload method
+                properties:
+                  file:
+                    $ref: "#/components/schemas/objs_file"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - file
+                title: files.upload schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response files.upload method
+                properties:
+                  error:
+                    enum:
+                      - posting_to_general_channel_denied
+                      - invalid_channel
+                      - file_uploads_disabled
+                      - file_uploads_except_images_disabled
+                      - storage_limit_reached
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: files.upload error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - files:write:user
+      tags:
+        - files
+  /groups.archive:
+    post:
+      description: Archives a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.archive
+      operationId: groups_archive
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Private channel to archive
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from groups.archive method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: groups.archive schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from groups.archive method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - already_archived
+                      - group_contains_others
+                      - restricted_action
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.archive error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.create:
+    post:
+      description: Creates a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.create
+      operationId: groups_create
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                validate:
+                  description: Whether to return errors on invalid channel name instead of
+                    modifying it to meet the specified criteria.
+                  type: boolean
+                name:
+                  description: Name of private channel to create
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response groups.create method
+                properties:
+                  group:
+                    $ref: "#/components/schemas/objs_group"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - group
+                title: groups.create success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response groups.create method
+                properties:
+                  error:
+                    enum:
+                      - no_channel
+                      - restricted_action
+                      - name_taken
+                      - invalid_name_required
+                      - invalid_name_punctuation
+                      - invalid_name_maxlength
+                      - invalid_name_specials
+                      - invalid_name
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.create error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.createChild:
+    post:
+      description: Clones and archives a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.createChild
+      operationId: groups_createChild
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: "Authentication token. Requires scope: `groups:write`"
+                  type: string
+                channel:
+                  description: Private channel to clone and archive.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.history:
+    get:
+      description: Fetches history of messages and events from a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.history
+      operationId: groups_history
+      parameters:
+        - description: Number of messages to return, between 1 and 1000.
+          in: query
+          name: count
+          schema:
+            type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          schema:
+            type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `groups:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          schema:
+            type: number
+        - description: Private channel to fetch history for.
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          schema:
+            type: number
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response groups.history method
+                properties:
+                  has_more:
+                    type: boolean
+                  messages:
+                    items:
+                      $ref: "#/components/schemas/objs_message"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - messages
+                  - has_more
+                title: groups.history success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    has_more: false
+                    latest: "1358547726.000003"
+                    messages:
+                      - text: Hello
+                        ts: "1358546515.000008"
+                        type: message
+                        user: U2147483896
+                      - is_starred: true
+                        text: World
+                        ts: "1358546515.000007"
+                        type: message
+                        user: U2147483896
+                      - ts: "1358546515.000007"
+                        type: something_else
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response groups.history method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_ts_latest
+                      - invalid_ts_oldest
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.history error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:history
+      tags:
+        - groups
+  /groups.info:
+    get:
+      description: Gets information about a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.info
+      operationId: groups_info
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Set this to `true` to receive the locale for this group. Defaults to
+            `false`
+          in: query
+          name: include_locale
+          schema:
+            type: boolean
+        - description: Private channel to get info on
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response groups.info method
+                properties:
+                  group:
+                    $ref: "#/components/schemas/objs_group"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - group
+                title: groups.info success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response groups.info method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.info error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:read
+      tags:
+        - groups
+  /groups.invite:
+    post:
+      description: Invites a user to a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.invite
+      operationId: groups_invite
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user:
+                  description: User to invite.
+                  type: string
+                channel:
+                  description: Private channel to invite user to.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response groups.invite method
+                properties:
+                  group:
+                    $ref: "#/components/schemas/objs_group"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - group
+                title: groups.invite success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response groups.invite method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - user_not_found
+                      - cant_invite_self
+                      - is_archived
+                      - cant_invite
+                      - ura_max_channels
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - user_is_bot
+                      - user_is_ultra_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.invite error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.kick:
+    post:
+      description: Removes a user from a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.kick
+      operationId: groups_kick
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user:
+                  description: User to remove from private channel.
+                  type: string
+                channel:
+                  description: Private channel to remove user from.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from groups.kick method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: groups.kick schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from groups.kick method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - user_not_found
+                      - cant_kick_self
+                      - not_in_group
+                      - restricted_action
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - user_is_restricted
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.kick error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.leave:
+    post:
+      description: Leaves a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.leave
+      operationId: groups_leave
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Private channel to leave
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.list:
+    get:
+      description: Lists private channels that the calling user has access to.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.list
+      operationId: groups_list
+      parameters:
+        - description: Exclude the `members` from each `group`
+          in: query
+          name: exclude_members
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `groups:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Don't return archived private channels.
+          in: query
+          name: exclude_archived
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response groups.list method
+                properties:
+                  groups:
+                    items:
+                      $ref: "#/components/schemas/objs_group"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - groups
+                title: groups.list success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response groups.list method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:read
+      tags:
+        - groups
+  /groups.mark:
+    post:
+      description: Sets the read cursor in a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.mark
+      operationId: groups_mark
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                ts:
+                  description: Timestamp of the most recently seen message.
+                  type: number
+                channel:
+                  description: Private channel to set reading cursor in.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from groups.mark method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: groups.mark success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from groups.mark method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_timestamp
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.mark error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.open:
+    post:
+      description: Opens a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.open
+      operationId: groups_open
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Private channel to open.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.rename:
+    post:
+      description: Renames a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.rename
+      operationId: groups_rename
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                validate:
+                  description: Whether to return errors on invalid channel name instead of
+                    modifying it to meet the specified criteria.
+                  type: boolean
+                name:
+                  description: New name for private channel.
+                  type: string
+                channel:
+                  description: Private channel to rename
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.replies:
+    get:
+      description: Retrieve a thread of messages posted to a private channel
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.replies
+      operationId: groups_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message
+          in: query
+          name: thread_ts
+          schema:
+            type: number
+        - description: "Authentication token. Requires scope: `groups:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Private channel to fetch thread from
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    messages:
+                      - text: Hello
+                        ts: "1358546515.000008"
+                        type: message
+                        user: U2147483896
+                      - is_starred: true
+                        text: World
+                        ts: "1358546515.000007"
+                        type: message
+                        user: U2147483896
+                      - ts: "1358546515.000007"
+                        type: something_else
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:history
+      tags:
+        - groups
+  /groups.setPurpose:
+    post:
+      description: Sets the purpose for a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.setPurpose
+      operationId: groups_setPurpose
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                purpose:
+                  description: The new purpose
+                  type: string
+                channel:
+                  description: Private channel to set the purpose of
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from groups.setPurpose method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  purpose:
+                    type: string
+                required:
+                  - ok
+                  - purpose
+                title: groups.setPurpose schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from groups.setPurpose method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - is_archived
+                      - too_long
+                      - user_is_restricted
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.setPurpose error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.setTopic:
+    post:
+      description: Sets the topic for a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.setTopic
+      operationId: groups_setTopic
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                topic:
+                  description: The new topic
+                  type: string
+                channel:
+                  description: Private channel to set the topic of
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from groups.setTopic method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  topic:
+                    type: string
+                required:
+                  - ok
+                  - topic
+                title: groups.setTopic schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from groups.setTopic method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - is_archived
+                      - too_long
+                      - user_is_restricted
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: groups.setTopic error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /groups.unarchive:
+    post:
+      description: Unarchives a private channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/groups.unarchive
+      operationId: groups_unarchive
+      parameters:
+        - description: "Authentication token. Requires scope: `groups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Private channel to unarchive
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - groups:write
+      tags:
+        - groups
+  /im.close:
+    post:
+      description: Close a direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/im.close
+      operationId: im_close
+      parameters:
+        - description: "Authentication token. Requires scope: `im:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: Direct message channel to close.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - im:write
+      tags:
+        - im
+  /im.history:
+    get:
+      description: Fetches history of messages and events from direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/im.history
+      operationId: im_history
+      parameters:
+        - description: Number of messages to return, between 1 and 1000.
+          in: query
+          name: count
+          schema:
+            type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          schema:
+            type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `im:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          schema:
+            type: number
+        - description: Direct message channel to fetch history for.
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          schema:
+            type: number
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from im.history method
+                properties:
+                  has_more:
+                    type: boolean
+                  messages:
+                    items:
+                      $ref: "#/components/schemas/objs_message"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - messages
+                  - has_more
+                title: im.history success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    has_more: false
+                    latest: "1358547726.000003"
+                    messages:
+                      - text: Hello
+                        ts: "1358546515.000008"
+                        type: message
+                        user: U2147483896
+                      - is_starred: true
+                        text: World
+                        ts: "1358546515.000007"
+                        type: message
+                        user: U2147483896
+                      - ts: "1358546515.000007"
+                        type: something_else
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from im.history method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_ts_latest
+                      - invalid_ts_oldest
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  needed:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                  provided:
+                    type: string
+                required:
+                  - ok
+                  - error
+                title: im.history error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - im:history
+      tags:
+        - im
+  /im.list:
+    get:
+      description: Lists direct message channels for the calling user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/im.list
+      operationId: im_list
+      parameters:
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `im:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the users list
+            hasn't been reached.
+          in: query
+          name: limit
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response im.list method
+                properties:
+                  ims:
+                    items:
+                      $ref: "#/components/schemas/objs_im"
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - ims
+                title: im.list success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ims:
+                      - created: 1449709280
+                        id: D0G9QPY56
+                        is_im: true
+                        is_org_shared: false
+                        is_user_deleted: false
+                        user: USLACKBOT
+                      - created: 1466692204
+                        id: D1KL59A72
+                        is_im: true
+                        is_org_shared: false
+                        is_user_deleted: false
+                        user: U0G9QF9C6
+                      - created: 1449722883
+                        id: D0G9XPFH9
+                        is_im: true
+                        is_org_shared: false
+                        is_user_deleted: false
+                        user: U0G9WFXNZ
+                      - created: 1452098023
+                        id: D0HRHJSF7
+                        is_im: true
+                        is_org_shared: false
+                        is_user_deleted: false
+                        user: W0HRJL7CK
+                      - created: 1465834222
+                        id: D1GD7CHC0
+                        is_im: true
+                        is_org_shared: false
+                        is_user_deleted: true
+                        user: U1GDBDGR3
+                      - created: 1468274703
+                        id: D1QMF76M9
+                        is_im: true
+                        is_org_shared: false
+                        is_user_deleted: false
+                        user: U1QNSQB9U
+                      - created: 1502210225
+                        id: D6K48KKRN
+                        is_im: true
+                        is_org_shared: false
+                        is_user_deleted: false
+                        user: U6KR7BVFW
+                    ok: true
+                    response_metadata:
+                      next_cursor: aW1faWQ6RDBCSDk1RExI=
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from im.list method
+                properties:
+                  error:
+                    enum:
+                      - invalid_cursor
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: im.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - im:read
+      tags:
+        - im
+  /im.mark:
+    post:
+      description: Sets the read cursor in a direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/im.mark
+      operationId: im_mark
+      parameters:
+        - description: "Authentication token. Requires scope: `im:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                ts:
+                  description: Timestamp of the most recently seen message.
+                  type: number
+                channel:
+                  description: Direct message channel to set reading cursor in.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response im.mark method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: im.mark success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response im.mark method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_timestamp
+                      - not_in_channel
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: im.mark error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - im:write
+      tags:
+        - im
+  /im.open:
+    post:
+      description: Opens a direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/im.open
+      operationId: im_open
+      parameters:
+        - description: "Authentication token. Requires scope: `im:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                return_im:
+                  description: Boolean, indicates you want the full IM channel definition
+                    in the response.
+                  type: boolean
+                user:
+                  description: User to open a direct message channel with.
+                  type: string
+                include_locale:
+                  description: Set this to `true` to receive the locale for this im.
+                    Defaults to `false`
+                  type: boolean
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from im.open method
+                properties:
+                  already_open:
+                    type: boolean
+                  channel:
+                    additionalProperties: true
+                    properties:
+                      created:
+                        type: string
+                      id:
+                        $ref: "#/components/schemas/defs_dm_id"
+                      is_im:
+                        type: boolean
+                      is_open:
+                        type: boolean
+                      last_read:
+                        $ref: "#/components/schemas/defs_ts"
+                      latest:
+                        $ref: "#/components/schemas/objs_message"
+                      unread_count:
+                        type: number
+                      unread_count_display:
+                        type: number
+                      user:
+                        $ref: "#/components/schemas/defs_user_id"
+                    required:
+                      - id
+                    type: object
+                  no_op:
+                    type: boolean
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - channel
+                title: im.open success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      id: D947RLWRX
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from im.open method
+                properties:
+                  error:
+                    enum:
+                      - user_not_found
+                      - user_not_visible
+                      - user_disabled
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: im.open error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - im:write
+      tags:
+        - im
+  /im.replies:
+    get:
+      description: Retrieve a thread of messages posted to a direct message conversation
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/im.replies
+      operationId: im_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message
+          in: query
+          name: thread_ts
+          schema:
+            type: number
+        - description: "Authentication token. Requires scope: `im:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Direct message channel to fetch thread from
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    messages:
+                      - text: Hello
+                        ts: "1358546515.000008"
+                        type: message
+                        user: U2147483896
+                      - is_starred: true
+                        text: World
+                        ts: "1358546515.000007"
+                        type: message
+                        user: U2147483896
+                      - ts: "1358546515.000007"
+                        type: something_else
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - im:history
+      tags:
+        - im
+  /migration.exchange:
+    get:
+      description: For Enterprise Grid workspaces, map local user IDs to global user IDs
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/migration.exchange
+      operationId: migration_exchange
+      parameters:
+        - description: "Authentication token. Requires scope: `tokens.basic`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Specify `true` to convert `W` global user IDs to workspace-specific
+            `U` IDs. Defaults to `false`.
+          in: query
+          name: to_old
+          schema:
+            type: boolean
+        - description: A comma-separated list of user ids, up to 400 per request
+          in: query
+          name: users
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response when mappings exist for the specified user
+            IDs
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from migration.exchange method
+                properties:
+                  enterprise_id:
+                    title: The enterprise grid organization ID containing the
+                      workspace/team.
+                    type: string
+                  invalid_user_ids:
+                    items:
+                      type: string
+                    title: A list of User IDs that cannot be mapped or found
+                    type: array
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  team_id:
+                    $ref: "#/components/schemas/defs_team"
+                  user_id_map:
+                    additionalProperties: true
+                    title: A mapping of provided user IDs with mapped user IDs
+                    type: object
+                required:
+                  - ok
+                  - team_id
+                  - enterprise_id
+                title: migration.exchange success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    enterprise_id: E1KQTNXE1
+                    invalid_user_ids:
+                      - U21ABZZXX
+                    ok: true
+                    team_id: T1KR7PE1W
+                    user_id_map:
+                      U06UBSUN5: W06M56XJM
+                      U06UBSVB3: W06PUUDLY
+                      U06UBSVDX: W06PUUDMW
+                      U06UEB62U: W06PTT6GH
+                      W06UAZ65Q: W06UAZ65Q
+        default:
+          description: Typical error response when there are no mappings to provide
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from migration.exchange method
+                properties:
+                  error:
+                    enum:
+                      - not_enterprise_team
+                      - too_many_users
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: migration.exchange error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: not_enterprise_team
+                    ok: false
+      security:
+        - slackAuth:
+            - tokens.basic
+      tags:
+        - migration
+  /mpim.close:
+    post:
+      description: Closes a multiparty direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/mpim.close
+      operationId: mpim_close
+      parameters:
+        - description: "Authentication token. Requires scope: `mpim:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                channel:
+                  description: MPIM to close.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - mpim:write
+      tags:
+        - mpim
+  /mpim.history:
+    get:
+      description: Fetches history of messages and events from a multiparty direct message.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/mpim.history
+      operationId: mpim_history
+      parameters:
+        - description: Number of messages to return, between 1 and 1000.
+          in: query
+          name: count
+          schema:
+            type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          schema:
+            type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `mpim:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          schema:
+            type: number
+        - description: Multiparty direct message to fetch history for.
+          in: query
+          name: channel
+          schema:
+            type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          schema:
+            type: number
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    has_more: false
+                    latest: "1358547726.000003"
+                    messages:
+                      - text: Hello
+                        ts: "1358546515.000008"
+                        type: message
+                        user: U2147483896
+                      - is_starred: true
+                        text: World
+                        ts: "1358546515.000007"
+                        type: message
+                        user: U2147483896
+                      - ts: "1358546515.000007"
+                        type: something_else
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - mpim:history
+      tags:
+        - mpim
+  /mpim.list:
+    get:
+      description: Lists multiparty direct message channels for the calling user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/mpim.list
+      operationId: mpim_list
+      parameters:
+        - description: "Authentication token. Requires scope: `mpim:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - mpim:read
+      tags:
+        - mpim
+  /mpim.mark:
+    post:
+      description: Sets the read cursor in a multiparty direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/mpim.mark
+      operationId: mpim_mark
+      parameters:
+        - description: "Authentication token. Requires scope: `mpim:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                ts:
+                  description: Timestamp of the most recently seen message.
+                  type: number
+                channel:
+                  description: multiparty direct message channel to set reading cursor in.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from mpim.mark method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: mpim.mark schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from mpim.mark method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - invalid_timestamp
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: mpim.mark error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - mpim:write
+      tags:
+        - mpim
+  /mpim.open:
+    post:
+      description: This method opens a multiparty direct message.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/mpim.open
+      operationId: mpim_open
+      parameters:
+        - description: "Authentication token. Requires scope: `mpim:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                users:
+                  description: Comma separated lists of users.  The ordering of the users
+                    is preserved whenever a MPIM group is returned.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from mpim.open method
+                properties:
+                  group:
+                    $ref: "#/components/schemas/objs_group"
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - group
+                title: mpim.open success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channel:
+                      id: D024BFF1M
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from mpim.open method
+                properties:
+                  error:
+                    enum:
+                      - users_list_not_supplied
+                      - not_enough_users
+                      - too_many_users
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: mpim.open error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - mpim:write
+      tags:
+        - mpim
+  /mpim.replies:
+    get:
+      description: Retrieve a thread of messages posted to a direct message conversation
+        from a multiparty direct message.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/mpim.replies
+      operationId: mpim_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message.
+          in: query
+          name: thread_ts
+          schema:
+            type: number
+        - description: "Authentication token. Requires scope: `mpim:history`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Multiparty direct message channel to fetch thread from.
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    messages:
+                      - text: Hello
+                        ts: "1358546515.000008"
+                        type: message
+                        user: U2147483896
+                      - is_starred: true
+                        text: World
+                        ts: "1358546515.000007"
+                        type: message
+                        user: U2147483896
+                      - ts: "1358546515.000007"
+                        type: something_else
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - mpim:history
+      tags:
+        - mpim
+  /oauth.access:
+    get:
+      description: Exchanges a temporary OAuth verifier code for an access token.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/oauth.access
+      operationId: oauth_access
+      parameters:
+        - description: Issued when you created your application.
+          in: query
+          name: client_secret
+          schema:
+            type: string
+        - description: The `code` param returned via the OAuth callback.
+          in: query
+          name: code
+          schema:
+            type: string
+        - description: Request the user to add your app only to a single channel.
+          in: query
+          name: single_channel
+          schema:
+            type: boolean
+        - description: Issued when you created your application.
+          in: query
+          name: client_id
+          schema:
+            type: string
+        - description: This must match the originally submitted URI (if one was sent).
+          in: query
+          name: redirect_uri
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful user token negotiation for a single scope
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    access_token: xoxp-XXXXXXXX-XXXXXXXX-XXXXX
+                    scope: groups:write
+                    team_id: TXXXXXXXXX
+                    team_name: Wyld Stallyns LLC
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_client_id
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - oauth
+  /oauth.token:
+    get:
+      description: Exchanges a temporary OAuth verifier code for a workspace token.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/oauth.token
+      operationId: oauth_token
+      parameters:
+        - description: Issued when you created your application.
+          in: query
+          name: client_secret
+          schema:
+            type: string
+        - description: The `code` param returned via the OAuth callback.
+          in: query
+          name: code
+          schema:
+            type: string
+        - description: Request the user to add your app only to a single channel.
+          in: query
+          name: single_channel
+          schema:
+            type: boolean
+        - description: Issued when you created your application.
+          in: query
+          name: client_id
+          schema:
+            type: string
+        - description: This must match the originally submitted URI (if one was sent).
+          in: query
+          name: redirect_uri
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success example using a workspace app produces a very different kind
+            of response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    access_token: xoxa-access-token-string
+                    app_id: A012345678
+                    app_user_id: U0AB12ABC
+                    authorizing_user_id: U0HTT3Q0G
+                    installer_user_id: U061F7AUR
+                    ok: true
+                    permissions:
+                      - resource_id: 0
+                        resource_type: channel
+                        scopes:
+                          - channels:read
+                          - chat:write:user
+                    single_channel_id: C061EG9T2
+                    team_id: T061EG9Z9
+                    team_name: Subarachnoid Workspace
+                    token_type: app
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_client_id
+                    ok: false
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - oauth
+  /pins.add:
+    post:
+      description: Pins an item to a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/pins.add
+      operationId: pins_add
+      parameters:
+        - description: "Authentication token. Requires scope: `pins:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file_comment:
+                  description: File comment to pin.
+                  type: string
+                timestamp:
+                  description: Timestamp of the message to pin.
+                  type: number
+                file:
+                  description: File to pin.
+                  type: string
+                channel:
+                  description: Channel to pin the item in.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from pins.add method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: pins.add schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from pins.add method
+                properties:
+                  error:
+                    enum:
+                      - bad_timestamp
+                      - file_not_found
+                      - file_comment_not_found
+                      - message_not_found
+                      - channel_not_found
+                      - no_item_specified
+                      - already_pinned
+                      - permission_denied
+                      - file_not_shared
+                      - not_pinnable
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: pins.add error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: channel_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - pins:write
+      tags:
+        - pins
+  /pins.list:
+    get:
+      description: Lists items pinned to a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/pins.list
+      operationId: pins_list
+      parameters:
+        - description: "Authentication token. Requires scope: `pins:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Channel to get pinned items for.
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                description: Schema for successful response from pins.list method
+                items:
+                  anyOf:
+                    - additionalProperties: true
+                      properties:
+                        items:
+                          items:
+                            anyOf:
+                              - additionalProperties: true
+                                properties:
+                                  comment:
+                                    $ref: "#/components/schemas/objs_comment"
+                                  created:
+                                    type: integer
+                                  created_by:
+                                    $ref: "#/components/schemas/defs_user_id"
+                                  file:
+                                    $ref: "#/components/schemas/objs_file"
+                                  type:
+                                    enum:
+                                      - file_comment
+                                    type: string
+                                title: File Comment Pin
+                                type: object
+                              - additionalProperties: true
+                                properties:
+                                  created:
+                                    type: integer
+                                  created_by:
+                                    $ref: "#/components/schemas/defs_user_id"
+                                  file:
+                                    $ref: "#/components/schemas/objs_file"
+                                  type:
+                                    enum:
+                                      - file
+                                    type: string
+                                title: File Pin
+                                type: object
+                              - additionalProperties: true
+                                properties:
+                                  channel:
+                                    $ref: "#/components/schemas/defs_channel"
+                                  created:
+                                    type: integer
+                                  created_by:
+                                    $ref: "#/components/schemas/defs_user_id"
+                                  message:
+                                    $ref: "#/components/schemas/objs_message"
+                                  type:
+                                    enum:
+                                      - message
+                                    type: string
+                                title: Message Pin
+                                type: object
+                          type: array
+                          uniqueItems: true
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                      required:
+                        - ok
+                        - items
+                      type: object
+                    - additionalProperties: true
+                      properties:
+                        count:
+                          type: integer
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                      required:
+                        - ok
+                        - count
+                      type: object
+                title: pins.list success schema
+              examples:
+                response:
+                  value:
+                    items:
+                      - channel: C2U86NC6H
+                        created: 1508881078
+                        created_by: U2U85N1RZ
+                        message:
+                          permalink: https://hitchhikers.slack.com/archives/C2U86NC6H/p1508197641000151
+                          pinned_to:
+                            - C2U86NC6H
+                          text: What is the meaning of life?
+                          ts: "1508197641.000151"
+                          type: message
+                          user: U2U85N1RZ
+                        type: message
+                      - channel: C2U86NC6H
+                        created: 1508880991
+                        created_by: U2U85N1RZ
+                        message:
+                          permalink: https://hitchhikers.slack.com/archives/C2U86NC6H/p1508284197000015
+                          pinned_to:
+                            - C2U86NC6H
+                          text: The meaning of life, the universe, and everything is
+                            42.
+                          ts: "1503289197.000015"
+                          type: message
+                          user: U2U85N1RZ
+                        type: message
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from pins.list method
+                properties:
+                  error:
+                    enum:
+                      - channel_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: pins.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - pins:read
+      tags:
+        - pins
+  /pins.remove:
+    post:
+      description: Un-pins an item from a channel.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/pins.remove
+      operationId: pins_remove
+      parameters:
+        - description: "Authentication token. Requires scope: `pins:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file_comment:
+                  description: File comment to un-pin.
+                  type: string
+                timestamp:
+                  description: Timestamp of the message to un-pin.
+                  type: number
+                file:
+                  description: File to un-pin.
+                  type: string
+                channel:
+                  description: Channel where the item is pinned to.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from pins.remove method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: pins.remove schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from pins.remove method
+                properties:
+                  error:
+                    enum:
+                      - bad_timestamp
+                      - file_not_found
+                      - file_comment_not_found
+                      - message_not_found
+                      - no_item_specified
+                      - not_pinned
+                      - permission_denied
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_typ
+                      - missing_post_typ
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeou
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: pins.remove error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: no_pin
+                    ok: false
+      security:
+        - slackAuth:
+            - pins:write
+      tags:
+        - pins
+  /reactions.add:
+    post:
+      description: Adds a reaction to an item.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reactions.add
+      operationId: reactions_add
+      parameters:
+        - description: "Authentication token. Requires scope: `reactions:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Reaction (emoji) name.
+                  type: string
+                file_comment:
+                  description: File comment to add reaction to.
+                  type: string
+                timestamp:
+                  description: Timestamp of the message to add reaction to.
+                  type: number
+                file:
+                  description: File to add reaction to.
+                  type: string
+                channel:
+                  description: Channel where the message to add reaction to was posted.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from reactions.add method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: reactions.add schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from reactions.add method
+                properties:
+                  error:
+                    enum:
+                      - bad_timestamp
+                      - file_not_found
+                      - file_comment_not_found
+                      - message_not_found
+                      - no_item_specified
+                      - invalid_name
+                      - already_reacted
+                      - too_many_emoji
+                      - too_many_reactions
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: reactions.add error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: already_reacted
+                    ok: false
+      security:
+        - slackAuth:
+            - reactions:write
+      tags:
+        - reactions
+  /reactions.get:
+    get:
+      description: Gets reactions for an item.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reactions.get
+      operationId: reactions_get
+      parameters:
+        - description: If true always return the complete reaction list.
+          in: query
+          name: full
+          schema:
+            type: boolean
+        - description: File comment to get reactions for.
+          in: query
+          name: file_comment
+          schema:
+            type: string
+        - description: Timestamp of the message to get reactions for.
+          in: query
+          name: timestamp
+          schema:
+            type: number
+        - description: "Authentication token. Requires scope: `reactions:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: File to get reactions for.
+          in: query
+          name: file
+          schema:
+            type: string
+        - description: Channel where the message to get reactions for was posted.
+          in: query
+          name: channel
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                description: Schema for successful response from reactions.get method
+                items:
+                  anyOf:
+                    - additionalProperties: true
+                      properties:
+                        channel:
+                          $ref: "#/components/schemas/defs_channel"
+                        message:
+                          $ref: "#/components/schemas/objs_message"
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                        type:
+                          enum:
+                            - message
+                          type: string
+                      required:
+                        - ok
+                        - type
+                        - channel
+                        - message
+                    - additionalProperties: true
+                      properties:
+                        file:
+                          $ref: "#/components/schemas/objs_file"
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                        type:
+                          enum:
+                            - file
+                          type: string
+                      required:
+                        - ok
+                        - type
+                        - file
+                    - additionalProperties: true
+                      properties:
+                        comment:
+                          $ref: "#/components/schemas/objs_comment"
+                        file:
+                          $ref: "#/components/schemas/objs_file"
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                        type:
+                          enum:
+                            - file_comment
+                          type: string
+                      required:
+                        - ok
+                        - type
+                        - file
+                        - comment
+                title: reactions.get success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    file:
+                      channels:
+                        - C2U7V2YA2
+                      comments_count: 1
+                      created: 1507850315
+                      groups: []
+                      id: F7H0D7ZA4
+                      ims: []
+                      name: computer.gif
+                      reactions:
+                        - count: 1
+                          name: stuck_out_tongue_winking_eye
+                          users:
+                            - U2U85N1RV
+                      timestamp: 1507850315
+                      title: computer.gif
+                      user: U2U85N1RV
+                    ok: true
+                    type: file
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from reactions.get method
+                properties:
+                  error:
+                    enum:
+                      - bad_timestamp
+                      - file_not_found
+                      - file_comment_not_found
+                      - message_not_found
+                      - no_item_specified
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: reactions.get error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - reactions:read
+      tags:
+        - reactions
+  /reactions.list:
+    get:
+      description: Lists reactions made by a user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reactions.list
+      operationId: reactions_list
+      parameters:
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `reactions:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: If true always return the complete reaction list.
+          in: query
+          name: full
+          schema:
+            type: boolean
+        - description: Show reactions made by this user. Defaults to the authed user.
+          in: query
+          name: user
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from reactions.list method
+                properties:
+                  items:
+                    items:
+                      items:
+                        anyOf:
+                          - additionalProperties: true
+                            properties:
+                              channel:
+                                $ref: "#/components/schemas/defs_channel"
+                              message:
+                                $ref: "#/components/schemas/objs_message"
+                              type:
+                                enum:
+                                  - message
+                                type: string
+                            required:
+                              - type
+                              - channel
+                              - message
+                            type: object
+                          - additionalProperties: true
+                            properties:
+                              file:
+                                $ref: "#/components/schemas/objs_file"
+                              type:
+                                enum:
+                                  - file
+                                type: string
+                            required:
+                              - type
+                              - file
+                            type: object
+                          - additionalProperties: true
+                            properties:
+                              comment:
+                                $ref: "#/components/schemas/objs_comment"
+                              file:
+                                $ref: "#/components/schemas/objs_file"
+                              type:
+                                enum:
+                                  - file_comment
+                                type: string
+                            required:
+                              - type
+                              - file
+                              - comment
+                            type: object
+                    type: array
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  paging:
+                    $ref: "#/components/schemas/objs_paging"
+                required:
+                  - ok
+                  - items
+                title: reactions.list schema
+                type: object
+              examples:
+                response:
+                  value:
+                    items:
+                      - channel: C3UKJTQAC
+                        message:
+                          bot_id: B4VLRLMKJ
+                          reactions:
+                            - count: 1
+                              name: robot_face
+                              users:
+                                - U2U85N1RV
+                          subtype: bot_message
+                          text: "Hello from Python! :tada:"
+                          ts: "1507849573.000090"
+                          username: Shipit Notifications
+                        type: message
+                      - comment:
+                          comment: This is a file comment
+                          created: 1508286096
+                          id: Fc7LP08P1U
+                          reactions:
+                            - count: 1
+                              name: white_check_mark
+                              users:
+                                - U2U85N1RV
+                          timestamp: 1508286096
+                          type: file_comment
+                          user: U2U85N1RV
+                        file:
+                          channels:
+                            - C2U7V2YA2
+                          comments_count: 1
+                          created: 1507850315
+                          reactions:
+                            - count: 1
+                              name: stuck_out_tongue_winking_eye
+                              users:
+                                - U2U85N1RV
+                          title: computer.gif
+                          user: U2U85N1RV
+                          username: ""
+                      - file:
+                          channels:
+                            - C2U7V2YA2
+                          comments_count: 1
+                          created: 1507850315
+                          id: F7H0D7ZA4
+                          name: computer.gif
+                          reactions:
+                            - count: 1
+                              name: stuck_out_tongue_winking_eye
+                              users:
+                                - U2U85N1RV
+                          size: 1639034
+                          title: computer.gif
+                          user: U2U85N1RV
+                          username: ""
+                        type: file
+                    ok: true
+                    paging:
+                      count: 100
+                      page: 1
+                      pages: 1
+                      total: 3
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from reactions.list method
+                properties:
+                  error:
+                    enum:
+                      - user_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactiv
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: reactions.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - reactions:read
+      tags:
+        - reactions
+  /reactions.remove:
+    post:
+      description: Removes a reaction from an item.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reactions.remove
+      operationId: reactions_remove
+      parameters:
+        - description: "Authentication token. Requires scope: `reactions:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Reaction (emoji) name.
+                  type: string
+                file_comment:
+                  description: File comment to remove reaction from.
+                  type: string
+                timestamp:
+                  description: Timestamp of the message to remove reaction from.
+                  type: number
+                file:
+                  description: File to remove reaction from.
+                  type: string
+                channel:
+                  description: Channel where the message to remove reaction from was posted.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from reactions.remove method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: reactions.remove schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from reactions.remove method
+                properties:
+                  error:
+                    enum:
+                      - bad_timestamp
+                      - file_not_found
+                      - file_comment_not_found
+                      - message_not_found
+                      - no_item_specified
+                      - invalid_name
+                      - no_reaction
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: reactions.remove error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: no_reaction
+                    ok: false
+      security:
+        - slackAuth:
+            - reactions:write
+      tags:
+        - reactions
+  /reminders.add:
+    post:
+      description: Creates a reminder.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reminders.add
+      operationId: reminders_add
+      parameters:
+        - description: "Authentication token. Requires scope: `reminders:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                text:
+                  description: The content of the reminder
+                  type: string
+                user:
+                  description: The user who will receive the reminder. If no user is
+                    specified, the reminder will go to user who created it.
+                  type: string
+                time:
+                  description: 'When this reminder should happen: the Unix timestamp (up to
+                    five years from now), the number of seconds until the
+                    reminder (if within 24 hours), or a natural language
+                    description (Ex. "in 15 minutes," or "every Thursday")'
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - reminders:write
+      tags:
+        - reminders
+  /reminders.complete:
+    post:
+      description: Marks a reminder as complete.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reminders.complete
+      operationId: reminders_complete
+      parameters:
+        - description: "Authentication token. Requires scope: `reminders:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                reminder:
+                  description: The ID of the reminder to be marked as complete
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - reminders:write
+      tags:
+        - reminders
+  /reminders.delete:
+    post:
+      description: Deletes a reminder.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reminders.delete
+      operationId: reminders_delete
+      parameters:
+        - description: "Authentication token. Requires scope: `reminders:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                reminder:
+                  description: The ID of the reminder
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - reminders:write
+      tags:
+        - reminders
+  /reminders.info:
+    get:
+      description: Gets information about a reminder.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reminders.info
+      operationId: reminders_info
+      parameters:
+        - description: "Authentication token. Requires scope: `reminders:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The ID of the reminder
+          in: query
+          name: reminder
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - reminders:read
+      tags:
+        - reminders
+  /reminders.list:
+    get:
+      description: Lists all reminders created by or for a given user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/reminders.list
+      operationId: reminders_list
+      parameters:
+        - description: "Authentication token. Requires scope: `reminders:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - reminders:read
+      tags:
+        - reminders
+  /rtm.connect:
+    get:
+      description: Starts a Real Time Messaging session.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/rtm.connect
+      operationId: rtm_connect
+      parameters:
+        - description: Only deliver presence events when requested by subscription. See
+            [presence subscriptions](/docs/presence-and-status#subscriptions).
+          in: query
+          name: presence_sub
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `rtm:stream`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Batch presence deliveries via subscription. Enabling changes the
+            shape of `presence_change` events. See [batch
+            presence](/docs/presence-and-status#batching).
+          in: query
+          name: batch_presence_aware
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from rtm.connect method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  self:
+                    additionalProperties: true
+                    properties:
+                      id:
+                        $ref: "#/components/schemas/defs_user_id"
+                      name:
+                        type: string
+                    required:
+                      - id
+                      - name
+                    type: object
+                  team:
+                    additionalProperties: true
+                    properties:
+                      domain:
+                        type: string
+                      id:
+                        $ref: "#/components/schemas/defs_team"
+                      name:
+                        type: string
+                    required:
+                      - id
+                      - name
+                      - domain
+                    type: object
+                  url:
+                    format: uri
+                    type: string
+                required:
+                  - ok
+                  - url
+                  - team
+                  - self
+                title: rtm.connect schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    self:
+                      id: U4X318ZMZ
+                      name: robotoverlord
+                    team:
+                      domain: slackdemo
+                      id: T2U81E2FP
+                      name: SlackDemo
+                    url: wss://...
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from rtm.connect method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: rtm.connect error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - rtm:stream
+      tags:
+        - rtm
+  /rtm.start:
+    get:
+      description: Starts a Real Time Messaging session.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/rtm.start
+      operationId: rtm_start
+      parameters:
+        - description: Exclude latest timestamps for channels, groups, mpims, and ims.
+            Automatically sets `no_unreads` to `1`
+          in: query
+          name: no_latest
+          schema:
+            type: boolean
+        - description: Return timestamp only for latest message object of each channel
+            (improves performance).
+          in: query
+          name: simple_latest
+          schema:
+            type: boolean
+        - description: Set this to `true` to receive the locale for users and channels.
+            Defaults to `false`
+          in: query
+          name: include_locale
+          schema:
+            type: boolean
+        - description: Only deliver presence events when requested by subscription. See
+            [presence subscriptions](/docs/presence-and-status#subscriptions).
+          in: query
+          name: presence_sub
+          schema:
+            type: boolean
+        - description: Skip unread counts for each channel (improves performance).
+          in: query
+          name: no_unreads
+          schema:
+            type: boolean
+        - description: Batch presence deliveries via subscription. Enabling changes the
+            shape of `presence_change` events. See [batch
+            presence](/docs/presence-and-status#batching).
+          in: query
+          name: batch_presence_aware
+          schema:
+            type: boolean
+        - description: Returns MPIMs to the client in the API response.
+          in: query
+          name: mpim_aware
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `rtm:stream`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from rtm.start method
+                properties:
+                  bots:
+                    items: {}
+                    type: array
+                  cache_ts:
+                    type: integer
+                  cache_ts_version:
+                    type: string
+                  cache_version:
+                    type: string
+                  can_manage_shared_channels:
+                    type: boolean
+                  channels:
+                    items:
+                      $ref: "#/components/schemas/objs_conversation"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  dead_pig:
+                    type: boolean
+                  dnd:
+                    $ref: "#/components/schemas/objs_dnd"
+                  groups:
+                    description: Group objects present for rtm.start. Can be null when
+                      there are no groups
+                    items:
+                      items:
+                        anyOf:
+                          - nullable: true
+                          - $ref: "#/components/schemas/objs_conversation"
+                    type: array
+                    uniqueItems: true
+                  ims:
+                    items:
+                      $ref: "#/components/schemas/objs_conversation"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  latest_event_ts:
+                    type: string
+                  mpims:
+                    description: Mpim objects present for rtm.start. Can be null when there
+                      are no mpims
+                    items:
+                      items:
+                        anyOf:
+                          - nullable: true
+                          - $ref: "#/components/schemas/objs_conversation"
+                    type: array
+                    uniqueItems: true
+                  non_threadable_channels:
+                    items: {}
+                    type: array
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  read_only_channels:
+                    items: {}
+                    type: array
+                  self:
+                    additionalProperties: true
+                    properties:
+                      created:
+                        type: integer
+                      id:
+                        type: string
+                      manual_presence:
+                        type: string
+                      name:
+                        type: string
+                      prefs:
+                        $ref: "#/components/schemas/prefs_prefs"
+                    required:
+                      - created
+                      - id
+                      - manual_presence
+                      - prefs
+                    type: object
+                  subteams:
+                    additionalProperties: true
+                    properties:
+                      all:
+                        items: {}
+                        type: array
+                      self:
+                        items: {}
+                        type: array
+                    required:
+                      - all
+                      - self
+                    type: object
+                  team:
+                    $ref: "#/components/schemas/objs_team"
+                  thread_only_channels:
+                    items: {}
+                    type: array
+                  url:
+                    format: uri
+                    type: string
+                  users:
+                    items:
+                      $ref: "#/components/schemas/objs_user"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                required:
+                  - ok
+                  - bots
+                  - cache_ts
+                  - cache_ts_version
+                  - can_manage_shared_channels
+                  - channels
+                  - groups
+                  - dnd
+                  - ims
+                  - latest_event_ts
+                  - non_threadable_channels
+                  - read_only_channels
+                  - self
+                  - subteams
+                  - thread_only_channels
+                  - team
+                  - url
+                  - users
+                title: rtm.start success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from rtm.start method
+                properties:
+                  error:
+                    enum:
+                      - migration_in_progress
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: rtm.start error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - rtm:stream
+      tags:
+        - rtm
+  /search.all:
+    get:
+      description: Searches for messages and files matching a query.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/search.all
+      operationId: search_all
+      parameters:
+        - description: Change sort direction to ascending (`asc`) or descending (`desc`).
+          in: query
+          name: sort_dir
+          schema:
+            type: string
+        - description: Search query. May contains booleans, etc.
+          in: query
+          name: query
+          schema:
+            type: string
+        - description: Return matches sorted by either `score` or `timestamp`.
+          in: query
+          name: sort
+          schema:
+            type: string
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `search:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Pass a value of `true` to enable query highlight markers (see below).
+          in: query
+          name: highlight
+          schema:
+            type: boolean
+        - in: query
+          name: page
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    files:
+                      matches:
+                        - channels: []
+                          comments_count: 1
+                          created: 1508804330
+                          display_as_bot: false
+                          editable: false
+                          external_type: ""
+                          filetype: png
+                          groups: []
+                          id: F7PKF1NR7
+                          image_exif_rotation: 1
+                          ims: []
+                          initial_comment:
+                            comment: Sure! Here's the workflow diagram!
+                            created: 1508804330
+                            id: Fc7NLL52E7
+                            is_intro: true
+                            timestamp: 1508804330
+                            user: U2U85N1RZ
+                          is_external: false
+                          is_public: true
+                          mimetype: image/png
+                          mode: hosted
+                          name: slack workflow diagram.png
+                          original_h: 117
+                          original_w: 128
+                          permalink: https://example.slack.com/files/U2U85N1RZ/F7PKF1NR7/slack_workflow_diagram.png
+                          permalink_public: https://slack-files.com/T2U81E2FZ-F7PKF1NR7-bea9143f18
+                          pretty_type: PNG
+                          public_url_shared: false
+                          score: "0.99982661240974"
+                          size: 35705
+                          thumb_160: https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_160.png
+                          thumb_360: https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_360.png
+                          thumb_360_h: 117
+                          thumb_360_w: 128
+                          thumb_64: https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_64.png
+                          thumb_80: https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_80.png
+                          timestamp: 1508804330
+                          title: slack workflow diagram
+                          top_file: false
+                          url_private: https://files.slack.com/files-pri/T2U81E2FZ-F7PKF1NR7/slack_workflow_diagram.png
+                          url_private_download: https://files.slack.com/files-pri/T2U81E2FZ-F7PKF1NR7/download/slack_workflow_diagram.png
+                          user: U2U85N1RZ
+                          username: amy
+                      pagination:
+                        first: 1
+                        last: 1
+                        page: 1
+                        page_count: 1
+                        per_page: 20
+                        total_count: 1
+                      paging:
+                        count: 20
+                        page: 1
+                        pages: 1
+                        total: 1
+                      total: 1
+                    messages:
+                      matches:
+                        - channel:
+                            id: C2U86NC6M
+                            is_ext_shared: false
+                            is_mpim: false
+                            is_org_shared: false
+                            is_pending_ext_shared: false
+                            is_private: false
+                            is_shared: false
+                            name: general
+                            pending_shared: []
+                          iid: 35692677-e60e-43d9-ac45-1987cea88975
+                          next:
+                            iid: 6f510ea1-e1d3-4f3f-bdb9-f9c6f6e9d609
+                            text: Thanks!
+                            ts: "1508804378.000219"
+                            type: message
+                            user: U2U85HJ7R
+                            username: john
+                          permalink: https://example.slack.com/archives/C2U86NC6M/p1508804330000296
+                          previous:
+                            iid: aba8603c-0543-4fb2-9118-a5ac85f3d138
+                            text: Can you send me the Slack workflow diagram?
+                            ts: "1508804301.000026"
+                            type: message
+                            user: U2U85HJ7R
+                            username: john
+                          team: T2U81E2FZ
+                          text: "uploaded a file:
+                            <https://example.slack.com/files/U2U85N1RZ/F7PKF1NR\
+                            7/slack_workflow_diagram.png|slack workflow diagram>
+                            and commented: Sure! Here's the workflow diagram!"
+                          ts: "1508804330.000296"
+                          type: message
+                          user: U2U85N1RZ
+                          username: amy
+                      pagination:
+                        first: 1
+                        last: 1
+                        page: 1
+                        page_count: 1
+                        per_page: 20
+                        total_count: 1
+                      paging:
+                        count: 20
+                        page: 1
+                        pages: 1
+                        total: 1
+                      total: 1
+                    ok: true
+                    posts:
+                      matches: []
+                      total: 0
+                    query: diagram
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: missing_scope
+                    needed: search:read
+                    ok: false
+                    provided: identify,bot:basic
+      security:
+        - slackAuth:
+            - search:read
+      tags:
+        - search
+  /search.files:
+    get:
+      description: Searches for files matching a query.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/search.files
+      operationId: search_files
+      parameters:
+        - description: Change sort direction to ascending (`asc`) or descending (`desc`).
+          in: query
+          name: sort_dir
+          schema:
+            type: string
+        - description: Search query.
+          in: query
+          name: query
+          schema:
+            type: string
+        - description: Return matches sorted by either `score` or `timestamp`.
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Pass a value of `true` to enable query highlight markers (see below).
+          in: query
+          name: highlight
+          schema:
+            type: boolean
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `search:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    files:
+                      matches:
+                        - channels: []
+                          comments_count: 1
+                          created: 1507850315
+                          deanimate_gif: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_deanimate_gif.png
+                          display_as_bot: false
+                          editable: false
+                          external_type: ""
+                          filetype: gif
+                          groups: []
+                          id: F7H0D7ZBB
+                          image_exif_rotation: 1
+                          ims: []
+                          is_external: false
+                          is_public: true
+                          mimetype: image/gif
+                          mode: hosted
+                          name: computer.gif
+                          original_h: 313
+                          original_w: 500
+                          permalink: https://eventsdemo.slack.com/files/U2U85N1RZ/F7H0D7ZBB/computer.gif
+                          permalink_public: https://slack-files.com/T2U81E2BB-F7H0D7ZBB-85b7f5557e
+                          pretty_type: GIF
+                          public_url_shared: false
+                          reactions:
+                            - count: 1
+                              name: stuck_out_tongue_winking_eye
+                              users:
+                                - U2U85N1RZ
+                          score: "0.38899223746309"
+                          size: 1639034
+                          thumb_160: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_160.png
+                          thumb_360: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_360.png
+                          thumb_360_gif: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_360.gif
+                          thumb_360_h: 225
+                          thumb_360_w: 360
+                          thumb_480: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_480.png
+                          thumb_480_gif: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_480.gif
+                          thumb_480_h: 300
+                          thumb_480_w: 480
+                          thumb_64: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_64.png
+                          thumb_80: https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_80.png
+                          timestamp: 1507850315
+                          title: computer.gif
+                          top_file: false
+                          url_private: https://files.slack.com/files-pri/T2U81E2BB-F7H0D7ZBB/computer.gif
+                          url_private_download: https://files.slack.com/files-pri/T2U81E2BB-F7H0D7ZBB/download/computer.gif
+                          user: U2U85N1RZ
+                          username: ""
+                      pagination:
+                        first: 1
+                        last: 3
+                        page: 1
+                        page_count: 1
+                        per_page: 20
+                        total_count: 3
+                      paging:
+                        count: 20
+                        page: 1
+                        pages: 1
+                        total: 3
+                      total: 3
+                    ok: true
+                    query: computer.gif
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: No query passed
+                    ok: false
+      security:
+        - slackAuth:
+            - search:read
+      tags:
+        - search
+  /search.messages:
+    get:
+      description: Searches for messages matching a query.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/search.messages
+      operationId: search_messages
+      parameters:
+        - description: Change sort direction to ascending (`asc`) or descending (`desc`).
+          in: query
+          name: sort_dir
+          schema:
+            type: string
+        - description: Search query.
+          in: query
+          name: query
+          schema:
+            type: string
+        - description: Return matches sorted by either `score` or `timestamp`.
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Pass the number of results you want per "page". Maximum of `100`.
+          in: query
+          name: count
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `search:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Pass a value of `true` to enable query highlight markers (see below).
+          in: query
+          name: highlight
+          schema:
+            type: boolean
+        - in: query
+          name: page
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    messages:
+                      matches:
+                        - channel:
+                            id: C12345678
+                            is_ext_shared: false
+                            is_mpim: false
+                            is_org_shared: false
+                            is_pending_ext_shared: false
+                            is_private: false
+                            is_shared: false
+                            name: general
+                            pending_shared: []
+                          iid: cb64bdaa-c1e8-4631-8a91-0f78080113e9
+                          permalink: https://hitchhikers.slack.com/archives/C12345678/p1508284197000015
+                          team: T12345678
+                          text: The meaning of life the universe and everything is
+                            42.
+                          ts: "1508284197.000015"
+                          type: message
+                          user: U2U85N1RV
+                          username: roach
+                        - channel:
+                            id: C12345678
+                            is_ext_shared: false
+                            is_mpim: false
+                            is_org_shared: false
+                            is_pending_ext_shared: false
+                            is_private: false
+                            is_shared: false
+                            name: random
+                            pending_shared: []
+                          iid: 9a00d3c9-bd2d-45b0-988b-6cff99ae2a90
+                          permalink: https://hitchhikers.slack.com/archives/C12345678/p1508795665000236
+                          team: T12345678
+                          text: The meaning of life the universe and everything is
+                            101010
+                          ts: "1508795665.000236"
+                          type: message
+                          user: ""
+                          username: robot overlord
+                      pagination:
+                        first: 1
+                        last: 2
+                        page: 1
+                        page_count: 1
+                        per_page: 20
+                        total_count: 2
+                      paging:
+                        count: 20
+                        page: 1
+                        pages: 1
+                        total: 2
+                      total: 2
+                    ok: true
+                    query: The meaning of life the universe and everything
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: No query passed
+                    ok: false
+      security:
+        - slackAuth:
+            - search:read
+      tags:
+        - search
+  /stars.add:
+    post:
+      description: Adds a star to an item.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/stars.add
+      operationId: stars_add
+      parameters:
+        - description: "Authentication token. Requires scope: `stars:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file_comment:
+                  description: File comment to add star to.
+                  type: string
+                timestamp:
+                  description: Timestamp of the message to add star to.
+                  type: number
+                channel:
+                  description: Channel to add star to, or channel where the message to add
+                    star to was posted (used with `timestamp`).
+                  type: string
+                file:
+                  description: File to add star to.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - stars:write
+      tags:
+        - stars
+  /stars.list:
+    get:
+      description: Lists stars for a user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/stars.list
+      operationId: stars_list
+      parameters:
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `stars:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - stars:read
+      tags:
+        - stars
+  /stars.remove:
+    post:
+      description: Removes a star from an item.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/stars.remove
+      operationId: stars_remove
+      parameters:
+        - description: "Authentication token. Requires scope: `stars:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file_comment:
+                  description: File comment to remove star from.
+                  type: string
+                timestamp:
+                  description: Timestamp of the message to remove star from.
+                  type: number
+                channel:
+                  description: Channel to remove star from, or channel where the message to
+                    remove star from was posted (used with `timestamp`).
+                  type: string
+                file:
+                  description: File to remove star from.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - stars:write
+      tags:
+        - stars
+  /team.accessLogs:
+    get:
+      description: Gets the access logs for the current team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/team.accessLogs
+      operationId: team_accessLogs
+      parameters:
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `admin`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: string
+        - description: End of time range of logs to include in results (inclusive).
+          in: query
+          name: before
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - admin
+      tags:
+        - team
+  /team.billableInfo:
+    get:
+      description: Gets billable users information for the current team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/team.billableInfo
+      operationId: team_billableInfo
+      parameters:
+        - description: "Authentication token. Requires scope: `admin`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: A user to retrieve the billable information for. Defaults to all
+            users.
+          in: query
+          name: user
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - admin
+      tags:
+        - team
+  /team.info:
+    get:
+      description: Gets information about the current team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/team.info
+      operationId: team_info
+      parameters:
+        - description: "Authentication token. Requires scope: `team:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from team.info method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  team:
+                    $ref: "#/components/schemas/objs_team"
+                required:
+                  - ok
+                  - team
+                title: team.info schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    team:
+                      domain: example
+                      email_domain: example.com
+                      enterprise_id: E1234A12AB
+                      enterprise_name: Umbrella Corporation
+                      icon:
+                        image_102: https://...
+                        image_132: https://...
+                        image_34: https://...
+                        image_44: https://...
+                        image_68: https://...
+                        image_88: https://...
+                        image_default: true
+                      id: T12345
+                      name: My Team
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from team.info method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revokedno_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: team.info error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - team:read
+      tags:
+        - team
+  /team.integrationLogs:
+    get:
+      description: Gets the integration logs for the current team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/team.integrationLogs
+      operationId: team_integrationLogs
+      parameters:
+        - in: query
+          name: count
+          schema:
+            type: string
+        - description: Filter logs with this change type. Defaults to all logs.
+          in: query
+          name: change_type
+          schema:
+            type: string
+        - description: Filter logs to this Slack app. Defaults to all logs.
+          in: query
+          name: app_id
+          schema:
+            type: integer
+        - description: "Authentication token. Requires scope: `admin`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Filter logs generated by this user’s actions. Defaults to all logs.
+          in: query
+          name: user
+          schema:
+            type: string
+        - description: Filter logs to this service. Defaults to all logs.
+          in: query
+          name: service_id
+          schema:
+            type: integer
+        - in: query
+          name: page
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - admin
+      tags:
+        - team
+  /team.profile.get:
+    get:
+      description: Retrieve a team's profile.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/team.profile.get
+      operationId: team_profile_get
+      parameters:
+        - description: "Authentication token. Requires scope: `users.profile:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Filter by visibility.
+          in: query
+          name: visibility
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from team.profile.get method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  profile:
+                    additionalProperties: true
+                    properties:
+                      fields:
+                        items:
+                          $ref: "#/components/schemas/objs_team_profile_field"
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                    required:
+                      - fields
+                    type: object
+                required:
+                  - ok
+                  - profile
+                title: team.profile.get success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    profile:
+                      fields:
+                        - hint: Enter the extension to reach your desk
+                          id: Xf06054AAA
+                          is_hidden: 1
+                          label: Phone extension
+                          ordering: 0
+                          type: text
+                        - hint: When you were born
+                          id: Xf06054BBB
+                          label: Date of birth
+                          ordering: 1
+                          type: date
+                        - hint: Enter a link to your Facebook profile
+                          id: Xf06054CCC
+                          label: Facebook
+                          ordering: 2
+                          type: link
+                        - hint: Hogwarts, obviously
+                          id: Xf06054DDD
+                          label: House
+                          ordering: 3
+                          possible_values:
+                            - Gryffindor
+                            - Hufflepuff
+                            - Ravenclaw
+                            - Slytherin
+                          type: options_list
+                        - hint: Office location (LDAP)
+                          id: Xf06054EEE
+                          label: Location
+                          options:
+                            is_protected: 1
+                          ordering: 4
+                          type: text
+                        - hint: The boss
+                          id: Xf06054FFF
+                          label: Manager
+                          ordering: 5
+                          type: user
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from team.profile.get method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_typ
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeou
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: team.profile.get error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - users.profile:read
+      tags:
+        - team.profile
+        - team
+  /usergroups.create:
+    post:
+      description: Create a User Group
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/usergroups.create
+      operationId: usergroups_create
+      parameters:
+        - description: "Authentication token. Requires scope: `usergroups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                handle:
+                  description: A mention handle. Must be unique among channels, users and
+                    User Groups.
+                  type: string
+                name:
+                  description: A name for the User Group. Must be unique among User Groups.
+                  type: string
+                channels:
+                  description: A comma separated string of encoded channel IDs for which
+                    the User Group uses as a default.
+                  type: string
+                include_count:
+                  description: Include the number of users in each User Group.
+                  type: boolean
+                description:
+                  description: A short description of the User Group.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - usergroups:write
+      tags:
+        - usergroups
+  /usergroups.disable:
+    post:
+      description: Disable an existing User Group
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/usergroups.disable
+      operationId: usergroups_disable
+      parameters:
+        - description: "Authentication token. Requires scope: `usergroups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                include_count:
+                  description: Include the number of users in the User Group.
+                  type: boolean
+                usergroup:
+                  description: The encoded ID of the User Group to disable.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - usergroups:write
+      tags:
+        - usergroups
+  /usergroups.enable:
+    post:
+      description: Enable a User Group
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/usergroups.enable
+      operationId: usergroups_enable
+      parameters:
+        - description: "Authentication token. Requires scope: `usergroups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                include_count:
+                  description: Include the number of users in the User Group.
+                  type: boolean
+                usergroup:
+                  description: The encoded ID of the User Group to enable.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - usergroups:write
+      tags:
+        - usergroups
+  /usergroups.list:
+    get:
+      description: List all User Groups for a team
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/usergroups.list
+      operationId: usergroups_list
+      parameters:
+        - description: Include the list of users for each User Group.
+          in: query
+          name: include_users
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `usergroups:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Include the number of users in each User Group.
+          in: query
+          name: include_count
+          schema:
+            type: boolean
+        - description: Include disabled User Groups.
+          in: query
+          name: include_disabled
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    usergroups:
+                      - auto_type: admin
+                        created_by: USLACKBOT
+                        date_create: 1446598059
+                        date_delete: 0
+                        date_update: 1446670362
+                        description: A group of all Administrators on your team.
+                        handle: admins
+                        id: S0614TZR7
+                        is_external: false
+                        is_usergroup: true
+                        name: Team Admins
+                        prefs:
+                          channels: []
+                          groups: []
+                        team_id: T060RNRCH
+                        updated_by: U060RNRCZ
+                        user_count: "2"
+                      - auto_type: owner
+                        created_by: USLACKBOT
+                        date_create: 1446678371
+                        date_delete: 0
+                        date_update: 1446678371
+                        description: A group of all Owners on your team.
+                        handle: owners
+                        id: S06158AV7
+                        is_external: false
+                        is_usergroup: true
+                        name: Team Owners
+                        prefs:
+                          channels: []
+                          groups: []
+                        team_id: T060RNRCH
+                        updated_by: USLACKBOT
+                        user_count: "1"
+                      - created_by: U060RNRCZ
+                        date_create: 1446746793
+                        date_delete: 1446748865
+                        date_update: 1446747767
+                        description: Marketing gurus, PR experts and product advocates.
+                        handle: marketing-team
+                        id: S0615G0KT
+                        is_external: false
+                        is_usergroup: true
+                        name: Marketing Team
+                        prefs:
+                          channels: []
+                          groups: []
+                        team_id: T060RNRCH
+                        updated_by: U060RNRCZ
+                        user_count: "0"
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - usergroups:read
+      tags:
+        - usergroups
+  /usergroups.update:
+    post:
+      description: Update an existing User Group
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/usergroups.update
+      operationId: usergroups_update
+      parameters:
+        - description: "Authentication token. Requires scope: `usergroups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                handle:
+                  description: A mention handle. Must be unique among channels, users and
+                    User Groups.
+                  type: string
+                description:
+                  description: A short description of the User Group.
+                  type: string
+                channels:
+                  description: A comma separated string of encoded channel IDs for which
+                    the User Group uses as a default.
+                  type: string
+                include_count:
+                  description: Include the number of users in the User Group.
+                  type: boolean
+                usergroup:
+                  description: The encoded ID of the User Group to update.
+                  type: string
+                name:
+                  description: A name for the User Group. Must be unique among User Groups.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    usergroup:
+                      created_by: U060R4BJ4
+                      date_create: 1447096577
+                      date_delete: 0
+                      date_update: 1447102109
+                      description: Marketing gurus, PR experts and product advocates.
+                      handle: marketing-team
+                      id: S0616NG6M
+                      is_external: false
+                      is_usergroup: true
+                      name: Marketing Team
+                      prefs:
+                        channels: []
+                        groups: []
+                      team_id: T060R4BHN
+                      updated_by: U060R4BJ4
+                      user_count: 1
+                      users:
+                        - U060R4BJ4
+                        - U060RNRCZ
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - usergroups:write
+      tags:
+        - usergroups
+  /usergroups.users.list:
+    get:
+      description: List all users in a User Group
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/usergroups.users.list
+      operationId: usergroups_users_list
+      parameters:
+        - description: "Authentication token. Requires scope: `usergroups:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Allow results that involve disabled User Groups.
+          in: query
+          name: include_disabled
+          schema:
+            type: boolean
+        - description: The encoded ID of the User Group to update.
+          in: query
+          name: usergroup
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Standard success response when used with a user token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    users:
+                      - U060R4BJ4
+                      - W123A4BC5
+        default:
+          description: Standard failure response when used with an invalid token
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - usergroups:read
+      tags:
+        - usergroups.users
+        - usergroups
+  /usergroups.users.update:
+    post:
+      description: Update the list of users for a User Group
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/usergroups.users.update
+      operationId: usergroups_users_update
+      parameters:
+        - description: "Authentication token. Requires scope: `usergroups:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                include_count:
+                  description: Include the number of users in the User Group.
+                  type: boolean
+                users:
+                  description: A comma separated string of encoded user IDs that represent
+                    the entire list of users for the User Group.
+                  type: string
+                usergroup:
+                  description: The encoded ID of the User Group to update.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    usergroup:
+                      created_by: U060R4BJ4
+                      date_create: 1447096577
+                      date_delete: 0
+                      date_update: 1447102109
+                      description: Marketing gurus, PR experts and product advocates.
+                      handle: marketing-team
+                      id: S0616NG6M
+                      is_external: false
+                      is_usergroup: true
+                      name: Marketing Team
+                      prefs:
+                        channels: []
+                        groups: []
+                      team_id: T060R4BHN
+                      updated_by: U060R4BJ4
+                      user_count: 1
+                      users:
+                        - U060R4BJ4
+                        - U060RNRCZ
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - usergroups:write
+      tags:
+        - usergroups.users
+        - usergroups
+  /users.conversations:
+    get:
+      description: List conversations the calling user may access.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.conversations
+      operationId: users_conversations
+      parameters:
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `conversations:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the list hasn't
+            been reached. Must be an integer no larger than 1000.
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Browse conversations by a specific user ID's membership. Non-public
+            channels are restricted to those where the calling user shares
+            membership.
+          in: query
+          name: user
+          schema:
+            type: string
+        - description: Set to `true` to exclude archived channels from the list
+          in: query
+          name: exclude_archived
+          schema:
+            type: boolean
+        - description: Mix and match channel types by providing a comma-separated list of
+            any combination of `public_channel`, `private_channel`, `mpim`, `im`
+          in: query
+          name: types
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response with only public channels. Note how
+            `num_members` and `is_member` are not returned like typical
+            `conversations` objects.
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from users.conversations
+                  method. Returned conversation objects do not include
+                  `num_members` or `is_member`
+                properties:
+                  channels:
+                    items:
+                      $ref: "#/components/schemas/objs_conversation"
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  response_metadata:
+                    additionalProperties: true
+                    properties:
+                      next_cursor:
+                        type: string
+                    required:
+                      - next_cursor
+                    type: object
+                required:
+                  - ok
+                  - channels
+                title: users.conversations success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    channels:
+                      - created: 1449252889
+                        creator: U012A3CDE
+                        id: C012AB3CD
+                        is_archived: false
+                        is_channel: true
+                        is_ext_shared: false
+                        is_general: true
+                        is_group: false
+                        is_im: false
+                        is_mpim: false
+                        is_org_shared: false
+                        is_pending_ext_shared: false
+                        is_private: false
+                        is_shared: false
+                        name: general
+                        name_normalized: general
+                        pending_shared: []
+                        previous_names: []
+                        purpose:
+                          creator: ""
+                          last_set: 0
+                          value: This channel is for team-wide communication and
+                            announcements. All team members are in this channel.
+                        topic:
+                          creator: ""
+                          last_set: 0
+                          value: Company-wide announcements and work-based matters
+                        unlinked: 0
+                      - created: 1449252889
+                        creator: U061F7AUR
+                        id: C061EG9T2
+                        is_archived: false
+                        is_channel: true
+                        is_ext_shared: false
+                        is_general: false
+                        is_group: false
+                        is_im: false
+                        is_mpim: false
+                        is_org_shared: false
+                        is_pending_ext_shared: false
+                        is_private: false
+                        is_shared: false
+                        name: random
+                        name_normalized: random
+                        pending_shared: []
+                        previous_names: []
+                        purpose:
+                          creator: ""
+                          last_set: 0
+                          value: A place for non-work-related flimflam, faffing,
+                            hodge-podge or jibber-jabber you'd prefer to keep
+                            out of more focused work-related channels.
+                        topic:
+                          creator: ""
+                          last_set: 0
+                          value: Non-work banter and water cooler conversation
+                        unlinked: 0
+                    ok: true
+                    response_metadata:
+                      next_cursor: dGVhbTpDMDYxRkE1UEI=
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from users.conversations method
+                properties:
+                  error:
+                    enum:
+                      - method_not_supported_for_channel_type
+                      - missing_scope
+                      - invalid_types
+                      - invalid_cursor
+                      - invalid_limit
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.conversations error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - channels:read
+            - groups:read
+            - im:read
+            - mpim:read
+      tags:
+        - users
+  /users.deletePhoto:
+    post:
+      description: Delete the user profile photo
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.deletePhoto
+      operationId: users_deletePhoto
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  description: "Authentication token. Requires scope: `users.profile:write`"
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - users.profile:write
+      tags:
+        - users
+  /users.getPresence:
+    get:
+      description: Gets user presence information.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.getPresence
+      operationId: users_getPresence
+      parameters:
+        - description: "Authentication token. Requires scope: `users:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: User to get presence info on. Defaults to the authed user.
+          in: query
+          name: user
+          schema:
+            type: string
+      responses:
+        "200":
+          description: When requesting information for a different user, this method just
+            returns the current presence (either `active` or `away`).
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Generated from users.getPresence with shasum
+                  e7251aec575d8863f9e0eb38663ae9dc26655f65
+                properties:
+                  auto_away:
+                    type: boolean
+                  connection_count:
+                    type: integer
+                  last_activity:
+                    type: integer
+                  manual_away:
+                    type: boolean
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  online:
+                    type: boolean
+                  presence:
+                    type: string
+                required:
+                  - ok
+                  - presence
+                title: "API method: users.getPresence"
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    presence: active
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: object
+                description: Schema for error response users.getPresence method
+                properties:
+                  error:
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.counts error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - users:read
+      tags:
+        - users
+  /users.identity:
+    get:
+      description: Get a user's identity.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.identity
+      operationId: users_identity
+      parameters:
+        - description: "Authentication token. Requires scope: `identity.basic`"
+          in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "You will receive at a minimum the following information:"
+          content:
+            application/json:
+              schema:
+                description: Schema for successful response from users.identity method
+                items:
+                  anyOf:
+                    - additionalProperties: true
+                      description: Schema for 'identity.basic' scope
+                      properties:
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                        team:
+                          additionalProperties: true
+                          properties:
+                            id:
+                              $ref: "#/components/schemas/defs_team"
+                          required:
+                            - id
+                          type: object
+                        user:
+                          additionalProperties: true
+                          properties:
+                            id:
+                              $ref: "#/components/schemas/defs_user_id"
+                            name:
+                              type: string
+                          required:
+                            - name
+                            - id
+                          type: object
+                      required:
+                        - ok
+                        - user
+                        - team
+                      type: object
+                    - additionalProperties: true
+                      description: Schema for 'identity.basic,identity.email' scopes
+                      properties:
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                        team:
+                          additionalProperties: true
+                          properties:
+                            id:
+                              $ref: "#/components/schemas/defs_team"
+                          required:
+                            - id
+                          type: object
+                        user:
+                          additionalProperties: true
+                          properties:
+                            email:
+                              format: email
+                              type: string
+                            id:
+                              $ref: "#/components/schemas/defs_user_id"
+                            name:
+                              type: string
+                          required:
+                            - name
+                            - id
+                            - email
+                          type: object
+                      required:
+                        - ok
+                        - user
+                        - team
+                      type: object
+                    - additionalProperties: true
+                      description: Schema for 'identity.basic,identity.avatar' scopes
+                      properties:
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                        team:
+                          additionalProperties: true
+                          properties:
+                            id:
+                              $ref: "#/components/schemas/defs_team"
+                          required:
+                            - id
+                          type: object
+                        user:
+                          additionalProperties: true
+                          properties:
+                            id:
+                              $ref: "#/components/schemas/defs_user_id"
+                            image_192:
+                              format: url
+                              type: string
+                            image_24:
+                              format: url
+                              type: string
+                            image_32:
+                              format: url
+                              type: string
+                            image_48:
+                              format: url
+                              type: string
+                            image_512:
+                              format: url
+                              type: string
+                            image_72:
+                              format: url
+                              type: string
+                            name:
+                              type: string
+                          required:
+                            - name
+                            - id
+                            - image_24
+                            - image_32
+                            - image_48
+                            - image_72
+                            - image_192
+                            - image_512
+                          type: object
+                      required:
+                        - ok
+                        - user
+                        - team
+                      type: object
+                    - additionalProperties: true
+                      description: Schema for 'identity.basic,identity.team' scopes
+                      properties:
+                        ok:
+                          $ref: "#/components/schemas/defs_ok_true"
+                        team:
+                          additionalProperties: true
+                          properties:
+                            domain:
+                              type: string
+                            id:
+                              $ref: "#/components/schemas/defs_team"
+                            image_102:
+                              format: url
+                              type: string
+                            image_132:
+                              format: url
+                              type: string
+                            image_230:
+                              format: url
+                              type: string
+                            image_34:
+                              format: url
+                              type: string
+                            image_44:
+                              format: url
+                              type: string
+                            image_68:
+                              format: url
+                              type: string
+                            image_88:
+                              format: url
+                              type: string
+                            image_default:
+                              type: boolean
+                            name:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - domain
+                            - image_34
+                            - image_44
+                            - image_68
+                            - image_88
+                            - image_102
+                            - image_132
+                            - image_230
+                            - image_default
+                          type: object
+                        user:
+                          additionalProperties: true
+                          properties:
+                            id:
+                              $ref: "#/components/schemas/defs_user_id"
+                            name:
+                              type: string
+                          required:
+                            - name
+                            - id
+                          type: object
+                      required:
+                        - ok
+                        - user
+                        - team
+                      type: object
+                title: users.identity schema
+              examples:
+                response:
+                  value:
+                    ok: true
+                    team:
+                      id: T0G9PQBBK
+                    user:
+                      id: U0G9QF9C6
+                      name: Sonny Whether
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from users.identity method
+                properties:
+                  error:
+                    enum:
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.identity error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: account_inactive
+                    ok: false
+      security:
+        - slackAuth:
+            - identity.basic
+      tags:
+        - users
+  /users.info:
+    get:
+      description: Gets information about a user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.info
+      operationId: users_info
+      parameters:
+        - description: Set this to `true` to receive the locale for this user. Defaults to
+            `false`
+          in: query
+          name: include_locale
+          schema:
+            type: boolean
+        - description: "Authentication token. Requires scope: `users:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: User to get info on
+          in: query
+          name: user
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from users.info method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  user:
+                    $ref: "#/components/schemas/objs_user"
+                required:
+                  - ok
+                  - user
+                title: users.info success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    user:
+                      color: 9f69e7
+                      deleted: false
+                      has_2fa: false
+                      id: W012A3CDE
+                      is_admin: true
+                      is_app_user: false
+                      is_bot: false
+                      is_owner: false
+                      is_primary_owner: false
+                      is_restricted: false
+                      is_ultra_restricted: false
+                      name: spengler
+                      profile:
+                        avatar_hash: ge3b51ca72de
+                        display_name: spengler
+                        display_name_normalized: spengler
+                        email: spengler@ghostbusters.example.com
+                        image_192: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_24: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_32: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_48: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_512: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_72: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        real_name: Egon Spengler
+                        real_name_normalized: Egon Spengler
+                        status_emoji: ":books:"
+                        status_text: Print is dead
+                        team: T012AB3C4
+                      real_name: Egon Spengler
+                      team_id: T012AB3C4
+                      tz: America/Los_Angeles
+                      tz_label: Pacific Daylight Time
+                      tz_offset: -25200
+                      updated: 1502138686
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from users.info method
+                properties:
+                  error:
+                    enum:
+                      - user_not_found
+                      - user_not_visible
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.info error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: user_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - users:read
+      tags:
+        - users
+  /users.list:
+    get:
+      description: Lists all users in a Slack team.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.list
+      operationId: users_list
+      parameters:
+        - description: Deprecated. Whether to include presence data in the output. Defaults
+            to `false`. Setting this to `true` reduces performance, especially
+            with large teams.
+          in: query
+          name: presence
+          schema:
+            type: boolean
+        - description: Paginate through collections of data by setting the `cursor`
+            parameter to a `next_cursor` attribute returned by a previous
+            request's `response_metadata`. Default value fetches the first
+            "page" of the collection. See [pagination](/docs/pagination) for
+            more detail.
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - description: "Authentication token. Requires scope: `users:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: The maximum number of items to return. Fewer than the requested
+            number of items may be returned, even if the end of the users list
+            hasn't been reached.
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Set this to `true` to receive the locale for users. Defaults to
+            `false`
+          in: query
+          name: include_locale
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from users.list method
+                properties:
+                  cache_ts:
+                    type: integer
+                  members:
+                    items:
+                      $ref: "#/components/schemas/objs_user"
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                  - members
+                  - cache_ts
+                title: users.list schema
+                type: object
+              examples:
+                response:
+                  value:
+                    cache_ts: 1498777272
+                    members:
+                      - color: 9f69e7
+                        deleted: false
+                        has_2fa: false
+                        id: W012A3CDE
+                        is_admin: true
+                        is_app_user: false
+                        is_bot: false
+                        is_owner: false
+                        is_primary_owner: false
+                        is_restricted: false
+                        is_ultra_restricted: false
+                        name: spengler
+                        profile:
+                          avatar_hash: ge3b51ca72de
+                          display_name: spengler
+                          display_name_normalized: spengler
+                          email: spengler@ghostbusters.example.com
+                          image_192: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                          image_24: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                          image_32: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                          image_48: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                          image_512: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                          image_72: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                          real_name: Egon Spengler
+                          real_name_normalized: Egon Spengler
+                          status_emoji: ":books:"
+                          status_text: Print is dead
+                          team: T012AB3C4
+                        real_name: spengler
+                        team_id: T012AB3C4
+                        tz: America/Los_Angeles
+                        tz_label: Pacific Daylight Time
+                        tz_offset: -25200
+                        updated: 1502138686
+                      - color: 9f69e7
+                        deleted: false
+                        has_2fa: false
+                        id: W07QCRPA4
+                        is_admin: true
+                        is_bot: false
+                        is_owner: false
+                        is_primary_owner: false
+                        is_restricted: false
+                        is_ultra_restricted: false
+                        name: glinda
+                        profile:
+                          avatar_hash: 8fbdd10b41c6
+                          display_name: Glinda the Fairly Good
+                          display_name_normalized: Glinda the Fairly Good
+                          email: glenda@south.oz.coven
+                          first_name: Glinda
+                          image_1024: https://a.slack-edge.com...png
+                          image_192: https://a.slack-edge.com...png
+                          image_24: https://a.slack-edge.com...png
+                          image_32: https://a.slack-edge.com...png
+                          image_48: https://a.slack-edge.com...png
+                          image_512: https://a.slack-edge.com...png
+                          image_72: https://a.slack-edge.com...png
+                          image_original: https://a.slack-edge.com...png
+                          last_name: Southgood
+                          phone: ""
+                          real_name: Glinda Southgood
+                          real_name_normalized: Glinda Southgood
+                          skype: ""
+                          title: Glinda the Good
+                        real_name: Glinda Southgood
+                        team_id: T0G9PQBBK
+                        tz: America/Los_Angeles
+                        tz_label: Pacific Daylight Time
+                        tz_offset: -25200
+                        updated: 1480527098
+                    ok: true
+                    response_metadata:
+                      next_cursor: dXNlcjpVMEc5V0ZYTlo=
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from users.list method
+                properties:
+                  error:
+                    enum:
+                      - invalid_cursor
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.list error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_cursor
+                    ok: false
+      security:
+        - slackAuth:
+            - users:read
+      tags:
+        - users
+  /users.lookupByEmail:
+    get:
+      description: Find a user with an email address.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.lookupByEmail
+      operationId: users_lookupByEmail
+      parameters:
+        - description: "Authentication token. Requires scope: `users:read.email`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: An email address belonging to a user in the workspace
+          in: query
+          name: email
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from users.lookupByEmail method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  user:
+                    $ref: "#/components/schemas/objs_user"
+                required:
+                  - ok
+                  - user
+                title: users.lookupByEmail success schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    user:
+                      color: 9f69e7
+                      deleted: false
+                      has_2fa: false
+                      id: W012A3CDE
+                      is_admin: true
+                      is_app_user: false
+                      is_bot: false
+                      is_owner: false
+                      is_primary_owner: false
+                      is_restricted: false
+                      is_ultra_restricted: false
+                      name: spengler
+                      profile:
+                        avatar_hash: ge3b51ca72de
+                        display_name: spengler
+                        display_name_normalized: spengler
+                        email: spengler@ghostbusters.example.com
+                        image_192: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_24: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_32: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_48: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_512: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        image_72: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                        real_name: Egon Spengler
+                        real_name_normalized: Egon Spengler
+                        status_emoji: ":books:"
+                        status_text: Print is dead
+                        team: T012AB3C4
+                      real_name: Egon Spengler
+                      team_id: T012AB3C4
+                      tz: America/Los_Angeles
+                      tz_label: Pacific Daylight Time
+                      tz_offset: -25200
+                      updated: 1502138686
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from users.lookupByEmail method
+                properties:
+                  error:
+                    enum:
+                      - users_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - no_permission
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.lookupByEmail error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: users_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - users:read.email
+      tags:
+        - users
+  /users.profile.get:
+    get:
+      description: Retrieves a user's profile information.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.profile.get
+      operationId: users_profile_get
+      parameters:
+        - description: "Authentication token. Requires scope: `users.profile:read`"
+          in: query
+          name: token
+          schema:
+            type: string
+        - description: Include labels for each ID in custom profile fields
+          in: query
+          name: include_labels
+          schema:
+            type: boolean
+        - description: User to retrieve profile info for
+          in: query
+          name: user
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from users.profile.get method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  profile:
+                    $ref: "#/components/schemas/objs_user_profile"
+                required:
+                  - ok
+                  - profile
+                title: users.profile.get schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    profile:
+                      avatar_hash: ge3b51ca72de
+                      display_name: spengler
+                      display_name_normalized: spengler
+                      email: spengler@ghostbusters.example.com
+                      image_192: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_24: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_32: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_48: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_512: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_72: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      real_name: Egon Spengler
+                      real_name_normalized: Egon Spengler
+                      status_emoji: ":books:"
+                      status_text: Print is dead
+                      team: T012AB3C4
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from users.profile.get method
+                properties:
+                  error:
+                    enum:
+                      - user_not_found
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.profile.get error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: user_not_found
+                    ok: false
+      security:
+        - slackAuth:
+            - users.profile:read
+      tags:
+        - users.profile
+        - users
+  /users.profile.set:
+    post:
+      description: Set the profile information for a user.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.profile.set
+      operationId: users_profile_set
+      parameters:
+        - description: "Authentication token. Requires scope: `users.profile:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                profile:
+                  description: Collection of key:value pairs presented as a URL-encoded
+                    JSON hash.
+                  type: string
+                user:
+                  description: ID of user to change. This argument may only be specified by
+                    team admins on paid teams.
+                  type: string
+                value:
+                  description: Value to set a single key to. Usable only if `profile` is
+                    not passed.
+                  type: string
+                name:
+                  description: Name of a single key to set. Usable only if `profile` is not
+                    passed.
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for successful response from users.profile.set method
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                  profile:
+                    $ref: "#/components/schemas/objs_user_profile"
+                  username:
+                    type: string
+                required:
+                  - ok
+                  - username
+                  - profile
+                title: users.profile.set schema
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+                    profile:
+                      avatar_hash: ge3b51ca72de
+                      display_name: spengler
+                      display_name_normalized: spengler
+                      email: spengler@ghostbusters.example.com
+                      image_192: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_24: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_32: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_48: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_512: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      image_72: https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg
+                      real_name: Egon Spengler
+                      real_name_normalized: Egon Spengler
+                      status_emoji: ":books:"
+                      status_text: Print is dead
+                      team: T012AB3C4
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Schema for error response from users.profile.set method
+                properties:
+                  error:
+                    enum:
+                      - reserved_name
+                      - invalid_profile
+                      - profile_set_failed
+                      - not_admin
+                      - not_app_admin
+                      - cannot_update_admin_user
+                      - not_authed
+                      - invalid_auth
+                      - account_inactive
+                      - token_revoked
+                      - no_permission
+                      - org_login_required
+                      - user_is_bot
+                      - invalid_arg_name
+                      - invalid_array_arg
+                      - invalid_charset
+                      - invalid_form_data
+                      - invalid_post_type
+                      - missing_post_type
+                      - team_added_to_org
+                      - invalid_json
+                      - json_not_object
+                      - request_timeout
+                      - upgrade_required
+                      - fatal_error
+                    type: string
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_false"
+                required:
+                  - ok
+                  - error
+                title: users.profile.set error schema
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_profile
+                    ok: false
+      security:
+        - slackAuth:
+            - users.profile:write
+      tags:
+        - users.profile
+        - users
+  /users.setActive:
+    post:
+      description: Marked a user as active. Deprecated and non-functional.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.setActive
+      operationId: users_setActive
+      parameters:
+        - description: "Authentication token. Requires scope: `users:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - users:write
+      tags:
+        - users
+  /users.setPhoto:
+    post:
+      description: Set the user profile photo
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.setPhoto
+      operationId: users_setPhoto
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                image:
+                  description: File contents via `multipart/form-data`.
+                  type: string
+                crop_w:
+                  description: Width/height of crop box (always square)
+                  type: integer
+                token:
+                  description: "Authentication token. Requires scope: `users.profile:write`"
+                  type: string
+                crop_y:
+                  description: Y coordinate of top-left corner of crop box
+                  type: integer
+                crop_x:
+                  description: X coordinate of top-left corner of crop box
+                  type: integer
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - users.profile:write
+      tags:
+        - users
+  /users.setPresence:
+    post:
+      description: Manually sets user presence.
+      externalDocs:
+        description: API method documentation
+        url: https://api.slack.com/methods/users.setPresence
+      operationId: users_setPresence
+      parameters:
+        - description: "Authentication token. Requires scope: `users:write`"
+          in: header
+          name: token
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                presence:
+                  description: Either `auto` or `away`
+                  type: string
+      responses:
+        "200":
+          description: Typical success response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default success template
+                type: object
+              examples:
+                response:
+                  value:
+                    ok: true
+        default:
+          description: Typical error response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Verbose schema not yet ready for this method.
+                properties:
+                  ok:
+                    $ref: "#/components/schemas/defs_ok_true"
+                required:
+                  - ok
+                title: Default error template
+                type: object
+              examples:
+                response:
+                  value:
+                    error: invalid_auth
+                    ok: false
+      security:
+        - slackAuth:
+            - users:write
+      tags:
+        - users
+servers:
+  - url: https://slack.com/api
+components:
+  securitySchemes:
+    slackAuth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://slack.com/oauth/authorize
+          tokenUrl: https://slack.com/api/oauth.access
+          scopes:
+            admin: admin
+            bot: Bot user scope
+            channels:history: channels:history
+            channels:read: channels:read
+            channels:write: channels:write
+            chat:write: chat:write
+            chat:write:bot: Author messages as a bot
+            chat:write:user: chat:write:user
+            conversations:history: conversations:history
+            conversations:read: conversations:read
+            conversations:write: conversations:write
+            dnd:read: dnd:read
+            dnd:write: dnd:write
+            emoji:read: emoji:read
+            files:read: files:read
+            files:write:user: files:write:user
+            groups:history: groups:history
+            groups:read: groups:read
+            groups:write: groups:write
+            identity.basic: identity.basic
+            im:history: im:history
+            im:read: im:read
+            im:write: im:write
+            links:write: links:write
+            mpim:history: mpim:history
+            mpim:read: mpim:read
+            mpim:write: mpim:write
+            none: No scope required
+            pins:read: pins:read
+            pins:write: pins:write
+            reactions:read: reactions:read
+            reactions:write: reactions:write
+            reminders:read: reminders:read
+            reminders:write: reminders:write
+            rtm:stream: rtm:stream
+            search:read: search:read
+            stars:read: stars:read
+            stars:write: stars:write
+            team:read: team:read
+            tokens.basic: tokens.basic
+            usergroups:read: usergroups:read
+            usergroups:write: usergroups:write
+            users.profile:read: users.profile:read
+            users.profile:write: users.profile:write
+            users:read: users:read
+            users:read.email: users:read.email
+            users:write: users:write
+  schemas:
+    defs_app_id:
+      pattern: ^A[A-Z0-9]{8}$
+      title: App ID
+      type: string
+    defs_bot_id:
+      pattern: ^B[A-Z0-9]{8}$
+      title: Bot User ID
+      type: string
+    defs_channel:
+      pattern: ^[CGD][A-Z0-9]{8}$
+      title: Channel-like conversation ID
+      type: string
+    defs_channel_id:
+      pattern: ^[C][A-Z0-9]{8}$
+      title: Channel ID
+      type: string
+    defs_channel_name:
+      title: Name of a channel
+      type: string
+    defs_comment_id:
+      pattern: ^Fc[A-Z0-9]{8}$
+      title: File Comment ID
+      type: string
+    defs_dm_id:
+      pattern: ^[D][A-Z0-9]{8}$
+      title: Direct Message Channel ID
+      type: string
+    defs_file_id:
+      pattern: ^[F][A-Z0-9]{8}$
+      title: File ID
+      type: string
+    defs_group_id:
+      pattern: ^[G][A-Z0-9]{8}$
+      title: Private Channel ID
+      type: string
+    defs_invite_id:
+      title: Invite ID for an external shared channel
+      type: integer
+    defs_ok_false:
+      enum:
+        - false
+      title: default failure response
+      type: boolean
+    defs_ok_true:
+      enum:
+        - true
+      title: default success response
+      type: boolean
+    defs_pinned_info:
+      additionalProperties:
+        additionalProperties: true
+        properties:
+          pinned_by:
+            $ref: "#/components/schemas/defs_user_id"
+          pinned_ts:
+            type: integer
+        required:
+          - pinned_by
+          - pinned_ts
+        type: object
+      title: Info for a pinned item
+      type: object
+    defs_room_id:
+      pattern: ^[R][A-Z0-9]{8}$
+      title: Room ID for a slack call
+      type: string
+    defs_team:
+      pattern: ^[T][A-Z0-9]{8}$
+      title: Team ID
+      type: string
+    defs_topic_purpose_creator:
+      pattern: ^[UW][A-Z0-9]{8}$|^$
+      title: User ID or empty string, used for topic and purpose creation
+      type: string
+    defs_ts:
+      pattern: ^\d{10}\.\d{6}$
+      title: Timestamp in format 0123456789.012345
+      type: string
+    defs_user_id:
+      pattern: ^[UW][A-Z0-9]{8}$
+      title: User ID
+      type: string
+    objs_channel:
+      additionalProperties: true
+      properties:
+        accepted_user:
+          $ref: "#/components/schemas/defs_user_id"
+        created:
+          type: integer
+        creator:
+          $ref: "#/components/schemas/defs_user_id"
+        id:
+          $ref: "#/components/schemas/defs_channel_id"
+        is_archived:
+          type: boolean
+        is_channel:
+          type: boolean
+        is_general:
+          type: boolean
+        is_member:
+          type: boolean
+        is_moved:
+          type: integer
+        is_mpim:
+          type: boolean
+        is_org_shared:
+          type: boolean
+        is_pending_ext_shared:
+          type: boolean
+        is_private:
+          type: boolean
+        is_read_only:
+          type: boolean
+        is_shared:
+          type: boolean
+        last_read:
+          $ref: "#/components/schemas/defs_ts"
+        latest:
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/objs_message"
+              - nullable: true
+        members:
+          items:
+            $ref: "#/components/schemas/defs_user_id"
+          minItems: 0
+          type: array
+          uniqueItems: true
+        name:
+          type: string
+        name_normalized:
+          type: string
+        num_members:
+          type: integer
+        pending_shared:
+          items:
+            $ref: "#/components/schemas/defs_team"
+          minItems: 0
+          type: array
+          uniqueItems: true
+        previous_names:
+          items:
+            $ref: "#/components/schemas/defs_channel_name"
+          minItems: 0
+          type: array
+          uniqueItems: true
+        priority:
+          type: integer
+        purpose:
+          additionalProperties: true
+          properties:
+            creator:
+              $ref: "#/components/schemas/defs_topic_purpose_creator"
+            last_set:
+              type: integer
+            value:
+              type: string
+          required:
+            - value
+            - creator
+            - last_set
+          type: object
+        topic:
+          additionalProperties: true
+          properties:
+            creator:
+              $ref: "#/components/schemas/defs_topic_purpose_creator"
+            last_set:
+              type: integer
+            value:
+              type: string
+          required:
+            - value
+            - creator
+            - last_set
+          type: object
+        unlinked:
+          title: Field to determine whether a channel has ever been
+            shared/disconnected in the past
+          type: integer
+        unread_count:
+          type: integer
+        unread_count_display:
+          type: integer
+      required:
+        - id
+        - name
+        - created
+        - creator
+        - is_channel
+        - is_org_shared
+        - is_private
+        - is_mpim
+        - is_shared
+        - name_normalized
+        - members
+        - topic
+        - purpose
+      title: Channel Object
+      type: object
+    objs_comment:
+      additionalProperties: true
+      properties:
+        comment:
+          type: string
+        created:
+          type: integer
+        id:
+          $ref: "#/components/schemas/defs_comment_id"
+        is_intro:
+          type: boolean
+        pinned_info:
+          $ref: "#/components/schemas/defs_pinned_info"
+        pinned_to:
+          items:
+            $ref: "#/components/schemas/defs_channel"
+          type: array
+        reactions:
+          items:
+            $ref: "#/components/schemas/objs_reaction"
+          type: array
+        timestamp:
+          type: integer
+        user:
+          type: string
+      title: File Comment Object
+      type: object
+    objs_comments:
+      items: {}
+      title: file comments object
+      type: array
+    objs_conversation:
+      items:
+        anyOf:
+          - additionalProperties: true
+            properties:
+              accepted_user:
+                $ref: "#/components/schemas/defs_user_id"
+              created:
+                type: integer
+              creator:
+                $ref: "#/components/schemas/defs_user_id"
+              display_counts:
+                additionalProperties: true
+                properties:
+                  display_counts:
+                    type: integer
+                  guest_counts:
+                    type: integer
+                required:
+                  - display_counts
+                  - guest_counts
+                type: object
+              has_pins:
+                type: boolean
+              id:
+                $ref: "#/components/schemas/defs_channel"
+              is_archived:
+                type: boolean
+              is_channel:
+                type: boolean
+              is_ext_shared:
+                type: boolean
+              is_general:
+                type: boolean
+              is_group:
+                type: boolean
+              is_im:
+                type: boolean
+              is_member:
+                type: boolean
+              is_moved:
+                type: integer
+              is_mpim:
+                enum:
+                  - false
+                type: boolean
+              is_open:
+                type: boolean
+              is_org_shared:
+                type: boolean
+              is_pending_ext_shared:
+                type: boolean
+              is_private:
+                type: boolean
+              is_read_only:
+                type: boolean
+              is_shared:
+                type: boolean
+              last_read:
+                $ref: "#/components/schemas/defs_ts"
+              latest:
+                items:
+                  anyOf:
+                    - $ref: "#/components/schemas/objs_message"
+                    - nullable: true
+              members:
+                items:
+                  $ref: "#/components/schemas/defs_user_id"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              name:
+                type: string
+              name_normalized:
+                type: string
+              num_members:
+                type: integer
+              pending_shared:
+                items:
+                  $ref: "#/components/schemas/defs_team"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              pin_count:
+                type: integer
+              previous_names:
+                items:
+                  $ref: "#/components/schemas/defs_channel_name"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              priority:
+                type: integer
+              purpose:
+                additionalProperties: true
+                properties:
+                  creator:
+                    $ref: "#/components/schemas/defs_topic_purpose_creator"
+                  last_set:
+                    type: integer
+                  value:
+                    type: string
+                required:
+                  - value
+                  - creator
+                  - last_set
+                type: object
+              shared_team_ids:
+                items:
+                  $ref: "#/components/schemas/defs_team"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              shares:
+                items:
+                  additionalProperties: true
+                  properties:
+                    accepted_user:
+                      $ref: "#/components/schemas/defs_user_id"
+                    is_active:
+                      type: boolean
+                    team:
+                      $ref: "#/components/schemas/objs_team"
+                    user:
+                      $ref: "#/components/schemas/defs_user_id"
+                  required:
+                    - team
+                    - user
+                    - accepted_user
+                    - is_active
+                  type: object
+                minItems: 0
+                type: array
+                uniqueItems: true
+              timezone_count:
+                type: integer
+              topic:
+                additionalProperties: true
+                properties:
+                  creator:
+                    $ref: "#/components/schemas/defs_topic_purpose_creator"
+                  last_set:
+                    type: integer
+                  value:
+                    type: string
+                required:
+                  - value
+                  - creator
+                  - last_set
+                type: object
+              unlinked:
+                title: Field to determine whether a channel has ever been
+                  shared/disconnected in the past
+                type: integer
+              unread_count:
+                type: integer
+              unread_count_display:
+                type: integer
+              user:
+                $ref: "#/components/schemas/defs_user_id"
+            required:
+              - id
+              - name
+              - created
+              - creator
+              - is_archived
+              - is_channel
+              - is_general
+              - is_mpim
+              - is_group
+              - is_org_shared
+              - is_im
+              - is_shared
+              - is_private
+              - name_normalized
+              - topic
+              - purpose
+            title: Conversation object
+            type: object
+          - additionalProperties: true
+            properties:
+              accepted_user:
+                $ref: "#/components/schemas/defs_user_id"
+              created:
+                type: integer
+              creator:
+                $ref: "#/components/schemas/defs_user_id"
+              display_counts:
+                additionalProperties: true
+                properties:
+                  display_counts:
+                    type: integer
+                  guest_counts:
+                    type: integer
+                required:
+                  - display_counts
+                  - guest_counts
+                type: object
+              id:
+                $ref: "#/components/schemas/defs_channel"
+              is_archived:
+                type: boolean
+              is_channel:
+                type: boolean
+              is_ext_shared:
+                type: boolean
+              is_general:
+                type: boolean
+              is_group:
+                type: boolean
+              is_im:
+                type: boolean
+              is_member:
+                type: boolean
+              is_moved:
+                type: integer
+              is_mpim:
+                enum:
+                  - true
+                type: boolean
+              is_open:
+                type: boolean
+              is_org_shared:
+                type: boolean
+              is_pending_ext_shared:
+                type: boolean
+              is_private:
+                type: boolean
+              is_read_only:
+                type: boolean
+              is_shared:
+                type: boolean
+              last_read:
+                $ref: "#/components/schemas/defs_ts"
+              latest:
+                items:
+                  anyOf:
+                    - $ref: "#/components/schemas/objs_message"
+                    - nullable: true
+              members:
+                items:
+                  $ref: "#/components/schemas/defs_user_id"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              name:
+                type: string
+              name_normalized:
+                type: string
+              num_members:
+                type: integer
+              pending_shared:
+                items:
+                  $ref: "#/components/schemas/defs_team"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              pin_count:
+                type: string
+              previous_names:
+                items:
+                  $ref: "#/components/schemas/defs_channel_name"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              priority:
+                type: integer
+              purpose:
+                additionalProperties: true
+                properties:
+                  creator:
+                    $ref: "#/components/schemas/defs_topic_purpose_creator"
+                  last_set:
+                    type: integer
+                  value:
+                    type: string
+                required:
+                  - value
+                  - creator
+                  - last_set
+                type: object
+              shared_team_ids:
+                items:
+                  $ref: "#/components/schemas/defs_team"
+                minItems: 0
+                type: array
+                uniqueItems: true
+              shares:
+                items:
+                  additionalProperties: true
+                  properties:
+                    accepted_user:
+                      $ref: "#/components/schemas/defs_user_id"
+                    is_active:
+                      type: boolean
+                    team:
+                      $ref: "#/components/schemas/objs_team"
+                    user:
+                      $ref: "#/components/schemas/defs_user_id"
+                  required:
+                    - team
+                    - user
+                    - accepted_user
+                    - is_active
+                  type: object
+                minItems: 0
+                type: array
+                uniqueItems: true
+              timezone_count:
+                type: integer
+              topic:
+                additionalProperties: true
+                properties:
+                  creator:
+                    $ref: "#/components/schemas/defs_topic_purpose_creator"
+                  last_set:
+                    type: integer
+                  value:
+                    type: string
+                required:
+                  - value
+                  - creator
+                  - last_set
+                type: object
+              unlinked:
+                title: Field to determine whether a channel has ever been
+                  shared/disconnected in the past
+                type: integer
+              unread_count:
+                type: integer
+              unread_count_display:
+                type: integer
+              user:
+                $ref: "#/components/schemas/defs_user_id"
+            required:
+              - id
+              - name
+              - created
+              - creator
+              - is_archived
+              - is_channel
+              - is_general
+              - is_mpim
+              - is_group
+              - is_org_shared
+              - is_im
+              - is_shared
+              - is_private
+              - name_normalized
+              - topic
+              - purpose
+            title: Conversation MPIM Object
+            type: object
+          - additionalProperties: true
+            properties:
+              created:
+                type: integer
+              has_pins:
+                type: boolean
+              id:
+                $ref: "#/components/schemas/defs_dm_id"
+              is_ext_shared:
+                type: boolean
+              is_im:
+                type: boolean
+              is_open:
+                type: boolean
+              is_org_shared:
+                type: boolean
+              is_shared:
+                type: boolean
+              is_user_deleted:
+                type: boolean
+              last_read:
+                $ref: "#/components/schemas/defs_ts"
+              latest:
+                items:
+                  anyOf:
+                    - $ref: "#/components/schemas/objs_message"
+                    - nullable: true
+              priority:
+                type: integer
+              unread_count:
+                type: integer
+              unread_count_display:
+                type: integer
+              user:
+                $ref: "#/components/schemas/defs_user_id"
+            required:
+              - id
+              - created
+              - is_im
+              - is_org_shared
+              - user
+              - priority
+            title: Conversation IM Channel Object from conversations.* methods
+            type: object
+    objs_dnd:
+      additionalProperties: true
+      properties:
+        dnd_enabled:
+          type: boolean
+        next_dnd_end_ts:
+          type: integer
+        next_dnd_start_ts:
+          type: integer
+        snooze_enabled:
+          type: boolean
+      required:
+        - dnd_enabled
+        - next_dnd_end_ts
+        - next_dnd_start_ts
+        - snooze_enabled
+      type: object
+    objs_file:
+      additionalProperties: true
+      properties:
+        channels:
+          items:
+            $ref: "#/components/schemas/defs_channel_id"
+          type: array
+          uniqueItems: true
+        comments_count:
+          type: integer
+        created:
+          type: integer
+        display_as_bot:
+          type: boolean
+        editable:
+          type: boolean
+        external_type:
+          type: string
+        filetype:
+          type: string
+        groups:
+          items:
+            $ref: "#/components/schemas/defs_group_id"
+          type: array
+          uniqueItems: true
+        id:
+          $ref: "#/components/schemas/defs_file_id"
+        image_exif_rotation:
+          type: integer
+        ims:
+          items:
+            $ref: "#/components/schemas/defs_dm_id"
+          type: array
+          uniqueItems: true
+        is_external:
+          type: boolean
+        is_public:
+          type: boolean
+        mimetype:
+          type: string
+        mode:
+          type: string
+        name:
+          type: string
+        original_h:
+          type: integer
+        original_w:
+          type: integer
+        permalink:
+          format: uri
+          type: string
+        permalink_public:
+          format: uri
+          type: string
+        pinned_info:
+          $ref: "#/components/schemas/defs_pinned_info"
+        pinned_to:
+          items:
+            $ref: "#/components/schemas/defs_channel"
+          type: array
+        pretty_type:
+          type: string
+        public_url_shared:
+          type: boolean
+        reactions:
+          items:
+            $ref: "#/components/schemas/objs_reaction"
+          type: array
+        size:
+          type: integer
+        thumb_1024:
+          format: uri
+          type: string
+        thumb_1024_h:
+          type: integer
+        thumb_1024_w:
+          type: integer
+        thumb_160:
+          format: uri
+          type: string
+        thumb_360:
+          format: uri
+          type: string
+        thumb_360_h:
+          type: integer
+        thumb_360_w:
+          type: integer
+        thumb_480:
+          format: uri
+          type: string
+        thumb_480_h:
+          type: integer
+        thumb_480_w:
+          type: integer
+        thumb_64:
+          format: uri
+          type: string
+        thumb_720:
+          format: uri
+          type: string
+        thumb_720_h:
+          type: integer
+        thumb_720_w:
+          type: integer
+        thumb_80:
+          format: uri
+          type: string
+        thumb_800:
+          format: uri
+          type: string
+        thumb_800_h:
+          type: integer
+        thumb_800_w:
+          type: integer
+        thumb_960:
+          format: uri
+          type: string
+        thumb_960_h:
+          type: integer
+        thumb_960_w:
+          type: integer
+        timestamp:
+          type: integer
+        title:
+          type: string
+        url_private:
+          format: uri
+          type: string
+        url_private_download:
+          format: uri
+          type: string
+        user:
+          type: string
+        username:
+          type: string
+      title: file object
+      type: object
+    objs_file_object_with_id_only:
+      $ref: "#/components/schemas/defs_file_id"
+    objs_group:
+      additionalProperties: true
+      properties:
+        created:
+          type: integer
+        creator:
+          $ref: "#/components/schemas/defs_user_id"
+        id:
+          $ref: "#/components/schemas/defs_group_id"
+        is_archived:
+          type: boolean
+        is_group:
+          type: boolean
+        is_moved:
+          type: integer
+        is_mpim:
+          type: boolean
+        is_open:
+          type: boolean
+        is_pending_ext_shared:
+          type: boolean
+        last_read:
+          $ref: "#/components/schemas/defs_ts"
+        latest:
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/objs_message"
+              - nullable: true
+        members:
+          items:
+            $ref: "#/components/schemas/defs_user_id"
+          minItems: 1
+          type: array
+          uniqueItems: true
+        name:
+          type: string
+        name_normalized:
+          type: string
+        priority:
+          type: integer
+        purpose:
+          additionalProperties: true
+          properties:
+            creator:
+              $ref: "#/components/schemas/defs_topic_purpose_creator"
+            last_set:
+              type: integer
+            value:
+              type: string
+          required:
+            - value
+            - creator
+            - last_set
+          type: object
+        topic:
+          additionalProperties: true
+          properties:
+            creator:
+              $ref: "#/components/schemas/defs_topic_purpose_creator"
+            last_set:
+              type: integer
+            value:
+              type: string
+          required:
+            - value
+            - creator
+            - last_set
+          type: object
+        unread_count:
+          type: integer
+        unread_count_display:
+          type: integer
+      required:
+        - id
+        - name
+        - is_group
+        - created
+        - creator
+        - name_normalized
+        - members
+        - topic
+        - purpose
+      title: Group object
+      type: object
+    objs_im:
+      additionalProperties: true
+      properties:
+        created:
+          type: integer
+        id:
+          $ref: "#/components/schemas/defs_dm_id"
+        is_im:
+          type: boolean
+        is_org_shared:
+          type: boolean
+        is_user_deleted:
+          type: boolean
+        priority:
+          type: integer
+        user:
+          $ref: "#/components/schemas/defs_user_id"
+      required:
+        - id
+        - is_im
+        - is_org_shared
+        - user
+        - created
+        - is_user_deleted
+      title: IM Object
+      type: object
+    objs_inviting_user:
+      additionalProperties: true
+      properties:
+        id:
+          $ref: "#/components/schemas/defs_user_id"
+        is_app_user:
+          type: boolean
+        is_restricted:
+          type: boolean
+        is_ultra_restricted:
+          type: boolean
+        name:
+          type: string
+        profile:
+          $ref: "#/components/schemas/objs_user_profile_shortest"
+        real_name:
+          type: string
+        team_id:
+          $ref: "#/components/schemas/defs_team"
+        updated:
+          type: number
+      required:
+        - id
+        - team_id
+        - name
+        - profile
+        - is_restricted
+        - is_ultra_restricted
+        - updated
+        - is_app_user
+      type: object
+    objs_message:
+      additionalProperties: true
+      properties:
+        attachments:
+          items:
+            additionalProperties: true
+            properties:
+              fallback:
+                type: string
+              id:
+                type: integer
+              image_bytes:
+                type: integer
+              image_height:
+                type: integer
+              image_url:
+                type: string
+              image_width:
+                type: integer
+            required:
+              - id
+            type: object
+          minItems: 1
+          type: array
+          uniqueItems: true
+        bot_id:
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/defs_bot_id"
+              - title: Nil bot_id set when display_as_bot is false
+                nullable: true
+        comment:
+          $ref: "#/components/schemas/objs_comment"
+        display_as_bot:
+          type: boolean
+        file:
+          $ref: "#/components/schemas/objs_file"
+        icons:
+          additionalProperties: true
+          properties:
+            emoji:
+              type: string
+          type: object
+        inviter:
+          $ref: "#/components/schemas/defs_user_id"
+        is_intro:
+          type: boolean
+        last_read:
+          $ref: "#/components/schemas/defs_ts"
+        name:
+          type: string
+        old_name:
+          type: string
+        permalink:
+          format: uri
+          type: string
+        pinned_to:
+          items:
+            $ref: "#/components/schemas/defs_channel"
+          type: array
+        purpose:
+          type: string
+        reactions:
+          items:
+            $ref: "#/components/schemas/objs_reaction"
+          type: array
+        replies:
+          items:
+            additionalProperties: true
+            properties:
+              ts:
+                $ref: "#/components/schemas/defs_ts"
+              user:
+                $ref: "#/components/schemas/defs_user_id"
+            required:
+              - user
+              - ts
+            type: object
+          type: array
+        reply_count:
+          type: integer
+        source_team:
+          $ref: "#/components/schemas/defs_team"
+        subscribed:
+          type: boolean
+        subtype:
+          type: string
+        team:
+          $ref: "#/components/schemas/defs_team"
+        text:
+          type: string
+        thread_ts:
+          $ref: "#/components/schemas/defs_ts"
+        topic:
+          type: string
+        ts:
+          $ref: "#/components/schemas/defs_ts"
+        type:
+          type: string
+        unread_count:
+          type: integer
+        upload:
+          type: boolean
+        user:
+          $ref: "#/components/schemas/defs_user_id"
+        user_profile:
+          $ref: "#/components/schemas/objs_user_profile_short"
+        user_team:
+          $ref: "#/components/schemas/defs_team"
+        username:
+          type: string
+      required:
+        - text
+        - type
+        - ts
+      title: Message object
+      type: object
+    objs_paging:
+      additionalProperties: true
+      properties:
+        count:
+          type: integer
+        page:
+          type: integer
+        pages:
+          type: integer
+        total:
+          type: integer
+      required:
+        - count
+        - page
+        - total
+      title: paging object for files
+      type: object
+    objs_reaction:
+      additionalProperties: true
+      properties:
+        count:
+          type: integer
+        name:
+          type: string
+        users:
+          items:
+            $ref: "#/components/schemas/defs_user_id"
+          type: array
+      required:
+        - name
+        - users
+        - count
+      title: Reaction object
+      type: object
+    objs_scopes:
+      items:
+        title: Named OAuth scopes
+        type: string
+        x-examples:
+          - chat:write
+          - im:history
+          - im:read
+      type: array
+    objs_team:
+      additionalProperties: true
+      properties:
+        avatar_base_url:
+          format: uri
+          type: string
+        domain:
+          type: string
+        email_domain:
+          type: string
+        enterprise_id:
+          type: string
+        enterprise_name:
+          type: string
+        has_compliance_export:
+          type: boolean
+        icon:
+          properties:
+            image_102:
+              type: string
+            image_132:
+              type: string
+            image_230:
+              type: string
+            image_34:
+              type: string
+            image_44:
+              type: string
+            image_68:
+              type: string
+            image_88:
+              type: string
+            image_default:
+              type: boolean
+          type: object
+        id:
+          $ref: "#/components/schemas/defs_team"
+        messages_count:
+          type: integer
+        msg_edit_window_mins:
+          type: integer
+        name:
+          type: string
+        over_integrations_limit:
+          type: boolean
+        over_storage_limit:
+          type: boolean
+        plan:
+          type: string
+        prefs:
+          $ref: "#/components/schemas/team_prefs_prefs"
+      required:
+        - id
+        - name
+        - domain
+        - email_domain
+        - icon
+      title: Team Object
+      type: object
+    objs_team_profile_field:
+      additionalProperties: true
+      properties:
+        field_name:
+          type: string
+        hint:
+          type: string
+        id:
+          pattern: ^X[a-zA-Z0-9]{9}$
+          type: string
+        is_hidden:
+          type: boolean
+        label:
+          type: string
+        options:
+          items:
+            type: string
+          type: array
+        ordering:
+          type: number
+        possible_values:
+          items:
+            type: string
+          type: array
+        type:
+          enum:
+            - text
+            - date
+            - link
+            - mailto
+            - options_list
+            - user
+          type: string
+      required:
+        - id
+        - ordering
+        - label
+        - hint
+        - type
+        - options
+      type: object
+    objs_user:
+      additionalProperties: true
+      properties:
+        color:
+          pattern: ^[a-fA-F0-9]{6}$
+          type: string
+        deleted:
+          type: boolean
+        has_2fa:
+          type: boolean
+        id:
+          $ref: "#/components/schemas/defs_user_id"
+        is_admin:
+          type: boolean
+        is_app_user:
+          type: boolean
+        is_bot:
+          type: boolean
+        is_owner:
+          type: boolean
+        is_primary_owner:
+          type: boolean
+        is_restricted:
+          type: boolean
+        is_ultra_restricted:
+          type: boolean
+        locale:
+          type: string
+        name:
+          type: string
+        presence:
+          type: string
+        profile:
+          $ref: "#/components/schemas/objs_user_profile"
+        real_name:
+          type: string
+        team_id:
+          $ref: "#/components/schemas/defs_team"
+        tz:
+          type: string
+        tz_label:
+          type: string
+        tz_offset:
+          type: number
+        updated:
+          type: number
+      required:
+        - id
+        - team_id
+        - name
+        - deleted
+        - color
+        - real_name
+        - tz
+        - tz_label
+        - tz_offset
+        - profile
+        - is_admin
+        - is_owner
+        - is_primary_owner
+        - is_restricted
+        - is_ultra_restricted
+        - is_bot
+        - updated
+        - is_app_user
+      type: object
+    objs_user_profile:
+      additionalProperties: true
+      properties:
+        always_active:
+          type: boolean
+        avatar_hash:
+          type: string
+        display_name:
+          type: string
+        display_name_normalized:
+          type: string
+        email:
+          format: email
+          type: string
+        fields:
+          type: object
+        first_name:
+          type: string
+        guest_channels:
+          type: string
+        image_192:
+          format: uri
+          type: string
+        image_24:
+          format: uri
+          type: string
+        image_32:
+          format: uri
+          type: string
+        image_48:
+          format: uri
+          type: string
+        image_512:
+          format: uri
+          type: string
+        image_72:
+          format: uri
+          type: string
+        image_original:
+          format: uri
+          type: string
+        last_name:
+          type: string
+        phone:
+          type: string
+        real_name:
+          type: string
+        real_name_normalized:
+          type: string
+        skype:
+          type: string
+        status_emoji:
+          type: string
+        status_expiration:
+          type: integer
+        status_text:
+          type: string
+        status_text_canonical:
+          type: string
+        team:
+          $ref: "#/components/schemas/defs_team"
+        title:
+          type: string
+      required:
+        - real_name
+        - display_name
+        - avatar_hash
+        - real_name_normalized
+        - display_name_normalized
+        - image_24
+        - image_32
+        - image_48
+        - image_72
+        - image_192
+      title: User profile object
+      type: object
+    objs_user_profile_short:
+      additionalProperties: true
+      properties:
+        avatar_hash:
+          type: string
+        display_name:
+          type: string
+        first_name:
+          type: string
+        image_72:
+          format: uri
+          type: string
+        is_restricted:
+          type: boolean
+        is_ultra_restricted:
+          type: boolean
+        name:
+          type: string
+        real_name:
+          type: string
+        team:
+          $ref: "#/components/schemas/defs_team"
+      required:
+        - avatar_hash
+        - image_72
+        - first_name
+        - real_name
+        - display_name
+        - team
+        - name
+        - is_restricted
+        - is_ultra_restricted
+      type: object
+    objs_user_profile_shortest:
+      additionalProperties: true
+      properties:
+        avatar_hash:
+          type: string
+        display_name:
+          type: string
+        first_name:
+          type: string
+        image_72:
+          format: uri
+          type: string
+        real_name:
+          type: string
+        team:
+          $ref: "#/components/schemas/defs_team"
+      required:
+        - avatar_hash
+        - image_72
+        - first_name
+        - real_name
+        - display_name
+        - team
+      type: object
+    prefs_prefs:
+      additionalProperties: true
+      properties:
+        a11y_animations:
+          type: boolean
+        a11y_font_size:
+          type: string
+        all_channels_loud:
+          type: boolean
+        all_notifications_prefs:
+          type: string
+        all_unreads_sort_order:
+          type: string
+        allow_calls_to_set_current_status:
+          type: boolean
+        allow_cmd_tab_iss:
+          type: boolean
+        analytics_upsell_coachmark_seen:
+          type: boolean
+        arrow_history:
+          type: boolean
+        at_channel_suppressed_channels:
+          type: string
+        box_enabled:
+          type: boolean
+        channel_sort:
+          type: string
+        client_logs_pri:
+          type: string
+        color_names_in_list:
+          type: boolean
+        confirm_clear_all_unreads:
+          type: boolean
+        confirm_sh_call_start:
+          type: boolean
+        confirm_user_marked_away:
+          type: boolean
+        convert_emoticons:
+          type: boolean
+        display_display_names:
+          type: boolean
+        display_real_names_override:
+          type: integer
+        dnd_enabled:
+          type: boolean
+        dnd_end_hour:
+          type: string
+        dnd_start_hour:
+          type: string
+        dropbox_enabled:
+          type: boolean
+        email_alerts:
+          type: string
+        email_alerts_sleep_until:
+          type: integer
+        email_developer:
+          type: boolean
+        email_misc:
+          type: boolean
+        email_offers:
+          type: boolean
+        email_research:
+          type: boolean
+        email_tips:
+          type: boolean
+        email_weekly:
+          type: boolean
+        emoji_autocomplete_big:
+          type: boolean
+        emoji_mode:
+          type: string
+        emoji_use:
+          type: string
+        enable_react_emoji_picker:
+          type: boolean
+        enable_unread_view:
+          type: boolean
+        enhanced_debugging:
+          type: boolean
+        ent_org_wide_channels_sidebar:
+          type: boolean
+        enter_is_special_in_tbt:
+          type: boolean
+        enterprise_excluded_app_teams:
+          nullable: true
+        enterprise_mdm_custom_msg:
+          type: string
+        enterprise_migration_seen:
+          type: boolean
+        expand_inline_imgs:
+          type: boolean
+        expand_internal_inline_imgs:
+          type: boolean
+        expand_non_media_attachments:
+          type: boolean
+        expand_snippets:
+          type: boolean
+        f_key_search:
+          type: boolean
+        flannel_server_pool:
+          type: string
+        folder_data:
+          type: string
+        folders_enabled:
+          type: boolean
+        frecency_ent_jumper:
+          type: string
+        frecency_ent_jumper_backup:
+          type: string
+        frecency_jumper:
+          type: string
+        full_text_extracts:
+          type: boolean
+        fuller_timestamps:
+          type: boolean
+        gdrive_authed:
+          type: boolean
+        gdrive_enabled:
+          type: boolean
+        graphic_emoticons:
+          type: boolean
+        growls_enabled:
+          type: boolean
+        growth_all_banners_prefs:
+          type: string
+        growth_msg_limit_approaching_cta_count:
+          type: integer
+        growth_msg_limit_approaching_cta_ts:
+          type: integer
+        growth_msg_limit_long_reached_cta_count:
+          type: integer
+        growth_msg_limit_long_reached_cta_last_ts:
+          type: integer
+        growth_msg_limit_reached_cta_count:
+          type: integer
+        growth_msg_limit_reached_cta_last_ts:
+          type: integer
+        growth_msg_limit_sixty_day_banner_cta_count:
+          type: integer
+        growth_msg_limit_sixty_day_banner_cta_last_ts:
+          type: integer
+        has_created_channel:
+          type: boolean
+        has_invited:
+          type: boolean
+        has_recently_shared_a_channel:
+          type: boolean
+        has_searched:
+          type: boolean
+        has_uploaded:
+          type: boolean
+        hide_hex_swatch:
+          type: boolean
+        hide_user_group_info_pane:
+          type: boolean
+        highlight_words:
+          type: string
+        in_interactive_mas_migration_flow:
+          type: boolean
+        intro_to_apps_message_seen:
+          type: boolean
+        jumbomoji:
+          type: boolean
+        k_key_omnibox:
+          type: boolean
+        k_key_omnibox_auto_hide_count:
+          type: integer
+        keyboard:
+          nullable: true
+        last_seen_at_channel_warning:
+          type: integer
+        last_snippet_type:
+          type: string
+        last_tos_acknowledged:
+          type: string
+        lessons_enabled:
+          type: boolean
+        load_lato_2:
+          type: boolean
+        locale:
+          type: string
+        locales_enabled:
+          additionalProperties: true
+          properties:
+            de-DE:
+              type: string
+            en-US:
+              type: string
+            es-ES:
+              type: string
+            fr-FR:
+              type: string
+            ja-JP:
+              type: string
+            pseudo:
+              type: string
+          type: object
+        loud_channels:
+          type: string
+        loud_channels_set:
+          type: string
+        ls_disabled:
+          type: boolean
+        mac_ssb_bounce:
+          type: string
+        mac_ssb_bullet:
+          type: boolean
+        mark_msgs_read_immediately:
+          type: boolean
+        measure_css_usage:
+          type: boolean
+        mentions_exclude_at_channels:
+          type: boolean
+        mentions_exclude_at_user_groups:
+          type: boolean
+        messages_theme:
+          type: string
+        msg_input_send_btn:
+          type: boolean
+        msg_input_send_btn_auto_set:
+          type: boolean
+        msg_preview:
+          type: boolean
+        msg_preview_persistent:
+          type: boolean
+        mute_sounds:
+          type: boolean
+        muted_channels:
+          type: string
+        never_channels:
+          type: string
+        new_msg_snd:
+          type: string
+        newxp_seen_last_message:
+          type: integer
+        no_created_overlays:
+          type: boolean
+        no_invites_widget_in_sidebar:
+          type: boolean
+        no_joined_overlays:
+          type: boolean
+        no_macelectron_banner:
+          type: boolean
+        no_macssb1_banner:
+          type: boolean
+        no_macssb2_banner:
+          type: boolean
+        no_omnibox_in_channels:
+          type: boolean
+        no_text_in_notifications:
+          type: boolean
+        no_winssb1_banner:
+          type: boolean
+        obey_inline_img_limit:
+          type: boolean
+        onboarding_cancelled:
+          type: boolean
+        onboarding_slackbot_conversation_step:
+          type: integer
+        overloaded_message_enabled:
+          type: boolean
+        pagekeys_handled:
+          type: boolean
+        posts_formatting_guide:
+          type: boolean
+        preferred_skin_tone:
+          type: string
+        privacy_policy_seen:
+          type: boolean
+        prompted_for_email_disabling:
+          type: boolean
+        purchaser:
+          type: boolean
+        push_at_channel_suppressed_channels:
+          type: string
+        push_dm_alert:
+          type: boolean
+        push_everything:
+          type: boolean
+        push_idle_wait:
+          type: integer
+        push_loud_channels:
+          type: string
+        push_loud_channels_set:
+          type: string
+        push_mention_alert:
+          type: boolean
+        push_mention_channels:
+          type: string
+        push_show_preview:
+          type: boolean
+        push_sound:
+          type: string
+        require_at:
+          type: boolean
+        search_exclude_bots:
+          type: boolean
+        search_exclude_channels:
+          type: string
+        search_only_current_team:
+          type: boolean
+        search_only_my_channels:
+          type: boolean
+        search_sort:
+          type: string
+        seen_administration_menu:
+          type: boolean
+        seen_app_space_coachmark:
+          type: boolean
+        seen_app_space_tutorial:
+          type: boolean
+        seen_calls_interactive_coachmark:
+          type: boolean
+        seen_channel_browser_admin_coachmark:
+          type: boolean
+        seen_custom_status_badge:
+          type: boolean
+        seen_custom_status_callout:
+          type: boolean
+        seen_domain_invite_reminder:
+          type: boolean
+        seen_emoji_update_overlay_coachmark:
+          type: boolean
+        seen_gdrive_coachmark:
+          type: boolean
+        seen_guest_admin_slackbot_announcement:
+          type: boolean
+        seen_highlights_arrows_coachmark:
+          type: boolean
+        seen_highlights_coachmark:
+          type: boolean
+        seen_highlights_warm_welcome:
+          type: boolean
+        seen_intl_channel_names_coachmark:
+          type: boolean
+        seen_japanese_locale_change_message:
+          type: boolean
+        seen_keyboard_shortcuts_coachmark:
+          type: boolean
+        seen_locale_change_message:
+          type: integer
+        seen_member_invite_reminder:
+          type: boolean
+        seen_name_tagging_coachmark:
+          type: boolean
+        seen_onboarding_banner:
+          type: boolean
+        seen_onboarding_channels:
+          type: boolean
+        seen_onboarding_direct_messages:
+          type: boolean
+        seen_onboarding_invites:
+          type: boolean
+        seen_onboarding_private_groups:
+          type: boolean
+        seen_onboarding_recent_mentions:
+          type: boolean
+        seen_onboarding_search:
+          type: boolean
+        seen_onboarding_slackbot_conversation:
+          type: boolean
+        seen_onboarding_starred_items:
+          type: boolean
+        seen_onboarding_start:
+          type: boolean
+        seen_shared_channels_coachmark:
+          type: boolean
+        seen_shared_channels_opt_in_change_message:
+          type: boolean
+        seen_shdep_slackbot_message:
+          type: boolean
+        seen_single_emoji_msg:
+          type: boolean
+        seen_ssb_prompt:
+          type: boolean
+        seen_threads_notification_banner:
+          type: boolean
+        seen_unread_view_coachmark:
+          type: boolean
+        seen_welcome_2:
+          type: boolean
+        separate_private_channels:
+          type: boolean
+        separate_shared_channels:
+          type: boolean
+        shdep_promo_code_submitted:
+          type: boolean
+        show_all_skin_tones:
+          type: boolean
+        show_ent_onboarding:
+          type: boolean
+        show_jumper_scores:
+          type: boolean
+        show_memory_instrument:
+          type: boolean
+        show_sidebar_quickswitcher_button:
+          type: boolean
+        show_typing:
+          type: boolean
+        sidebar_behavior:
+          type: string
+        sidebar_theme:
+          type: string
+        sidebar_theme_custom_values:
+          type: string
+        snippet_editor_wrap_long_lines:
+          type: boolean
+        spaces_new_xp_banner_dismissed:
+          type: boolean
+        ss_emojis:
+          type: boolean
+        ssb_space_window:
+          type: string
+        start_scroll_at_oldest:
+          type: boolean
+        tab_ui_return_selects:
+          type: boolean
+        threads_everything:
+          type: boolean
+        time24:
+          type: boolean
+        two_factor_auth_enabled:
+          type: boolean
+        two_factor_backup_type:
+          nullable: true
+        two_factor_type:
+          nullable: true
+        tz:
+          type: string
+        user_colors:
+          type: string
+        webapp_spellcheck:
+          type: boolean
+        welcome_message_hidden:
+          type: boolean
+        whats_new_read:
+          type: integer
+        winssb_run_from_tray:
+          type: boolean
+        winssb_window_flash_behavior:
+          type: string
+      title: User Prefs object
+      type: object
+    team_prefs_prefs:
+      additionalProperties: true
+      properties:
+        all_users_can_purchase:
+          type: boolean
+        allow_calls:
+          type: boolean
+        allow_calls_interactive_screen_sharing:
+          type: boolean
+        allow_message_deletion:
+          type: boolean
+        allow_retention_override:
+          type: boolean
+        allow_shared_channel_perms_override:
+          type: boolean
+        app_whitelist_enabled:
+          type: boolean
+        auth_mode:
+          type: string
+        calling_app_name:
+          type: string
+        can_receive_shared_channels_invites:
+          type: boolean
+        compliance_export_start:
+          type: integer
+        custom_status_default_emoji:
+          type: string
+        custom_status_presets:
+          items:
+            items:
+              type: string
+            minItems: 1
+            type: array
+            uniqueItems: true
+          minItems: 1
+          type: array
+          uniqueItems: true
+        custom_tos:
+          type: boolean
+        default_channels:
+          items:
+            $ref: "#/components/schemas/defs_channel"
+          type: array
+        default_rxns:
+          items:
+            type: string
+          type: array
+        disable_email_ingestion:
+          type: boolean
+        disable_file_deleting:
+          type: boolean
+        disable_file_editing:
+          type: boolean
+        disable_file_uploads:
+          type: string
+        disallow_public_file_urls:
+          type: boolean
+        discoverable:
+          type: string
+        display_email_addresses:
+          type: boolean
+        display_real_names:
+          type: boolean
+        dm_retention_duration:
+          type: integer
+        dm_retention_type:
+          type: integer
+        dnd_enabled:
+          type: boolean
+        dnd_end_hour:
+          type: string
+        dnd_start_hour:
+          type: string
+        enable_shared_channels:
+          type: integer
+        enterprise_default_channels:
+          items: {}
+          type: array
+        enterprise_mandatory_channels:
+          items: {}
+          type: array
+        enterprise_mdm_date_enabled:
+          type: integer
+        enterprise_mdm_level:
+          type: integer
+        enterprise_team_creation_request:
+          additionalProperties: true
+          properties:
+            is_enabled:
+              type: boolean
+          required:
+            - is_enabled
+          type: object
+        file_limit_whitelisted:
+          type: boolean
+        file_retention_duration:
+          type: integer
+        file_retention_type:
+          type: integer
+        gdrive_enabled_team:
+          type: boolean
+        group_retention_duration:
+          type: integer
+        group_retention_type:
+          type: integer
+        hide_referers:
+          type: boolean
+        invites_limit:
+          type: boolean
+        invites_only_admins:
+          type: boolean
+        locale:
+          type: string
+        loud_channel_mentions_limit:
+          type: integer
+        msg_edit_window_mins:
+          type: integer
+        require_at_for_mention:
+          type: boolean
+        retention_duration:
+          type: integer
+        retention_type:
+          type: integer
+        show_join_leave:
+          type: boolean
+        uses_customized_custom_status_presets:
+          type: boolean
+        warn_before_at_channel:
+          type: string
+        who_can_archive_channels:
+          type: string
+        who_can_at_channel:
+          type: string
+        who_can_at_everyone:
+          type: string
+        who_can_change_team_profile:
+          type: string
+        who_can_create_channels:
+          type: string
+        who_can_create_delete_user_groups:
+          type: string
+        who_can_create_groups:
+          type: string
+        who_can_create_shared_channels:
+          type: string
+        who_can_edit_user_groups:
+          type: string
+        who_can_kick_channels:
+          type: string
+        who_can_kick_groups:
+          type: string
+        who_can_manage_guests:
+          additionalProperties: true
+          properties:
+            type:
+              items:
+                type: string
+              type: array
+          required:
+            - type
+          type: object
+        who_can_manage_integrations:
+          additionalProperties: true
+          properties:
+            type:
+              items:
+                type: string
+              type: array
+          required:
+            - type
+          type: object
+        who_can_manage_shared_channels:
+          additionalProperties: true
+          properties:
+            type:
+              items:
+                type: string
+              type: array
+          required:
+            - type
+          type: object
+        who_can_post_general:
+          type: string
+        who_can_post_in_shared_channels:
+          additionalProperties: true
+          properties:
+            type:
+              items:
+                type: string
+              type: array
+          required:
+            - type
+          type: object
+        who_has_team_visibility:
+          type: string
+      required:
+        - default_channels
+      title: Team Prefs Object
+      type: object

--- a/packages/unmock-node/src/__tests__/resources/slack/swagger.yaml
+++ b/packages/unmock-node/src/__tests__/resources/slack/swagger.yaml
@@ -1,0 +1,15430 @@
+swagger: '2.0'
+schemes:
+  - https
+host: slack.com
+basePath: /api
+info:
+  description: 'One way to interact with the Slack platform is its HTTP RPC-based Web API, a collection of methods requiring OAuth 2.0-based user, bot, or workspace tokens blessed with related OAuth scopes.'
+  title: Slack
+  version: 1.0.6
+  x-apisguru-categories:
+    - collaboration
+    - messaging
+  x-logo:
+    url: 'https://api.apis.guru/v2/cache/logo/http_static.tumblr.com_wvuzcz9_LlKncfhmp_slack_logo_240.png'
+  x-origin:
+    - format: swagger
+      url: 'https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json'
+      version: '2.0'
+  x-preferred: true
+  x-providerName: slack.com
+externalDocs:
+  description: Learn more about the Slack Web API
+  url: 'https://api.slack.com/web'
+produces:
+  - application/json
+securityDefinitions:
+  slackAuth:
+    authorizationUrl: 'https://slack.com/oauth/authorize'
+    flow: accessCode
+    scopes:
+      admin: admin
+      bot: Bot user scope
+      'channels:history': 'channels:history'
+      'channels:read': 'channels:read'
+      'channels:write': 'channels:write'
+      'chat:write': 'chat:write'
+      'chat:write:bot': Author messages as a bot
+      'chat:write:user': 'chat:write:user'
+      'conversations:history': 'conversations:history'
+      'conversations:read': 'conversations:read'
+      'conversations:write': 'conversations:write'
+      'dnd:read': 'dnd:read'
+      'dnd:write': 'dnd:write'
+      'emoji:read': 'emoji:read'
+      'files:read': 'files:read'
+      'files:write:user': 'files:write:user'
+      'groups:history': 'groups:history'
+      'groups:read': 'groups:read'
+      'groups:write': 'groups:write'
+      identity.basic: identity.basic
+      'im:history': 'im:history'
+      'im:read': 'im:read'
+      'im:write': 'im:write'
+      'links:write': 'links:write'
+      'mpim:history': 'mpim:history'
+      'mpim:read': 'mpim:read'
+      'mpim:write': 'mpim:write'
+      none: No scope required
+      'pins:read': 'pins:read'
+      'pins:write': 'pins:write'
+      'reactions:read': 'reactions:read'
+      'reactions:write': 'reactions:write'
+      'reminders:read': 'reminders:read'
+      'reminders:write': 'reminders:write'
+      'rtm:stream': 'rtm:stream'
+      'search:read': 'search:read'
+      'stars:read': 'stars:read'
+      'stars:write': 'stars:write'
+      'team:read': 'team:read'
+      tokens.basic: tokens.basic
+      'usergroups:read': 'usergroups:read'
+      'usergroups:write': 'usergroups:write'
+      'users.profile:read': 'users.profile:read'
+      'users.profile:write': 'users.profile:write'
+      'users:read': 'users:read'
+      'users:read.email': 'users:read.email'
+      'users:write': 'users:write'
+    tokenUrl: 'https://slack.com/api/oauth.access'
+    type: oauth2
+paths:
+  /api.test:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Checks API calling code.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/api.test'
+      operationId: api_test
+      parameters:
+        - description: example property to return
+          in: query
+          name: foo
+          type: string
+        - description: Error response to return
+          in: query
+          name: error
+          type: string
+      responses:
+        '200':
+          description: Standard success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties:
+              type: object
+            description: Schema for successful response api.test method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: api.test success schema
+            type: object
+        default:
+          description: Artificial error response
+          examples:
+            application/json:
+              args:
+                error: my_error
+              error: my_error
+              ok: false
+          schema:
+            additionalProperties:
+              type: object
+            description: Schema for error response api.test method
+            properties:
+              error:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: api.test error schema
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - api
+  /apps.permissions.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Returns list of permissions this app has on a team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/apps.permissions.info'
+      operationId: apps_permissions_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `none`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Standard success response when used with a user token
+          examples:
+            application/json:
+              info:
+                app_home:
+                  resources:
+                    ids:
+                      - D0C0NU1Q8
+                      - D0BH95DLH
+                  scopes:
+                    - 'chat:write'
+                    - 'im:history'
+                    - 'im:read'
+                channel:
+                  resources:
+                    excluded_ids: []
+                    ids:
+                      - C061FA5PB
+                    wildcard: false
+                  scopes:
+                    - 'channels:read'
+                group:
+                  resources:
+                    ids: []
+                  scopes: []
+                im:
+                  resources:
+                    ids: []
+                  scopes: []
+                mpim:
+                  resources:
+                    ids: []
+                  scopes: []
+                team:
+                  resources:
+                    ids: []
+                  scopes: []
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Standard failure response when used with an invalid token
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions
+        - apps
+  /apps.permissions.request:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Allows an app to request additional scopes
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/apps.permissions.request'
+      operationId: apps_permissions_request
+      parameters:
+        - description: A comma separated list of scopes to request for
+          in: query
+          name: scopes
+          type: string
+        - description: 'Authentication token. Requires scope: `none`'
+          in: query
+          name: token
+          type: string
+        - description: Token used to trigger the permissions API
+          in: query
+          name: trigger_id
+          type: string
+      responses:
+        '200':
+          description: Standard success response when used with a user token
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from apps.permissions.request method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: apps.permissions.request schema
+            type: object
+        default:
+          description: Standard failure response when trigger_id is invalid
+          examples:
+            application/json:
+              error: invalid_trigger_id
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from apps.permissions.request method
+            properties:
+              error:
+                enum:
+                  - invalid_trigger
+                  - trigger_exchanged
+                  - invalid_scope
+                  - invalid_user
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: apps.permissions.request error schema
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions
+        - apps
+  /apps.permissions.resources.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Returns list of resource grants this app has on a team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/apps.permissions.resources.list'
+      operationId: apps_permissions_resources_list
+      parameters:
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `none`'
+          in: query
+          name: token
+          type: string
+        - description: The maximum number of items to return.
+          in: query
+          name: limit
+          type: integer
+      responses:
+        '200':
+          description: Typical successful paginated response
+          examples:
+            application/json:
+              ok: true
+              resources:
+                - id: T0DES3UAN
+                  type: team
+                - id: D024BFF1M
+                  type: app_home
+                - id: C024BE91L
+                  type: channel
+              response_metadata:
+                next_cursor: dGVhbTpDMUg5UkVTR0w=
+          schema:
+            additionalProperties: true
+            description: Schema for successful response apps.permissions.resources.list method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              resources:
+                items:
+                  properties:
+                    id:
+                      title: An ID for a resource
+                      type: string
+                      x-examples:
+                        - T0DES3UAN
+                        - C0ABC1ABC
+                    type:
+                      title: The type of resource the `id` corresponds to
+                      type: string
+                      x-examples:
+                        - team
+                        - channel
+                        - mpim
+                  type: object
+                type: array
+              response_metadata:
+                additionalProperties: true
+                properties:
+                  next_cursor:
+                    type: string
+                    x-examples:
+                      - dGVhbTpDMUg5UkVTR0w=
+                required:
+                  - next_cursor
+                type: object
+            required:
+              - ok
+              - resources
+            title: apps.permissions.resources.list success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_cursor
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from apps.permissions.resources.list method
+            properties:
+              error:
+                enum:
+                  - invalid_cursor
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: apps.permissions.resources.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions.resources
+        - apps
+  /apps.permissions.scopes.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Returns list of scopes this app has on a team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/apps.permissions.scopes.list'
+      operationId: apps_permissions_scopes_list
+      parameters:
+        - description: 'Authentication token. Requires scope: `none`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical successful paginated response
+          examples:
+            application/json:
+              ok: true
+              scopes:
+                app_home:
+                  - 'chat:write'
+                  - 'im:history'
+                  - 'im:read'
+                channel:
+                  - 'channels:history'
+                  - 'chat:write'
+                group:
+                  - 'chat:write'
+                im:
+                  - 'chat:write'
+                mpim:
+                  - 'chat:write'
+                team:
+                  - 'users:read'
+                user: []
+          schema:
+            additionalProperties: true
+            description: Schema for successful response api.permissions.scopes.list method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              scopes:
+                additionalProperties: true
+                properties:
+                  app_home:
+                    $ref: '#/definitions/objs_scopes'
+                  channel:
+                    $ref: '#/definitions/objs_scopes'
+                  group:
+                    $ref: '#/definitions/objs_scopes'
+                  im:
+                    $ref: '#/definitions/objs_scopes'
+                  mpim:
+                    $ref: '#/definitions/objs_scopes'
+                  team:
+                    $ref: '#/definitions/objs_scopes'
+                  user:
+                    $ref: '#/definitions/objs_scopes'
+                type: object
+            required:
+              - ok
+              - scopes
+            title: api.permissions.scopes.list success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from apps.permissions.scopes.list method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: apps.permissions.scopes.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - apps.permissions.scopes
+        - apps
+  /auth.revoke:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Revokes a token.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/auth.revoke'
+      operationId: auth_revoke
+      parameters:
+        - description: Setting this parameter to `1` triggers a _testing mode_ where the specified token will not actually be revoked.
+          in: query
+          name: test
+          type: boolean
+        - description: 'Authentication token. Requires scope: `none`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              revoked: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from auth.revoke method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              revoked:
+                type: boolean
+            required:
+              - ok
+              - revoked
+            title: auth.revoke schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from auth.revoke method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: auth.revoke error schema
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - auth
+  /auth.test:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Checks authentication & identity.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/auth.test'
+      operationId: auth_test
+      parameters:
+        - description: 'Authentication token. Requires scope: `none`'
+          in: header
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Standard success response when used with a user token
+          examples:
+            application/json:
+              ok: true
+              team: Subarachnoid Workspace
+              team_id: T12345678
+              url: 'https://subarachnoid.slack.com/'
+              user: grace
+              user_id: W12345678
+          schema:
+            additionalProperties: true
+            description: Schema for successful response auth.test method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              team:
+                type: string
+              team_id:
+                $ref: '#/definitions/defs_team'
+              url:
+                type: string
+              user:
+                type: string
+              user_id:
+                $ref: '#/definitions/defs_user_id'
+            required:
+              - ok
+              - url
+              - team
+              - user
+              - team_id
+              - user_id
+            title: auth.test success schema
+            type: object
+        default:
+          description: Standard failure response when used with an invalid token
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response auth.test method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - token_revoked
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: auth.test error schema
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - auth
+  /bots.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets information about a bot user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/bots.info'
+      operationId: bots_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `users:read`'
+          in: query
+          name: token
+          type: string
+        - description: Bot user to get info on
+          in: query
+          name: bot
+          type: string
+      responses:
+        '200':
+          description: 'When successful, returns bot info by bot ID.'
+          examples:
+            application/json:
+              bot:
+                app_id: A061BLERW
+                deleted: false
+                icons:
+                  image_36: 'https://...'
+                  image_48: 'https://...'
+                  image_72: 'https://...'
+                id: B061F7JQ1
+                name: commandeer
+                updated: 1449272004
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from bots.info method
+            properties:
+              bot:
+                additionalProperties: true
+                properties:
+                  app_id:
+                    $ref: '#/definitions/defs_app_id'
+                  deleted:
+                    type: boolean
+                  icons:
+                    additionalProperties: true
+                    properties:
+                      image_36:
+                        format: uri
+                        type: string
+                      image_48:
+                        format: uri
+                        type: string
+                      image_72:
+                        format: uri
+                        type: string
+                    required:
+                      - image_36
+                      - image_48
+                      - image_72
+                    type: object
+                  id:
+                    $ref: '#/definitions/defs_bot_id'
+                  name:
+                    type: string
+                  updated:
+                    type: integer
+                  user_id:
+                    $ref: '#/definitions/defs_user_id'
+                required:
+                  - id
+                  - deleted
+                  - name
+                  - updated
+                  - app_id
+                  - icons
+                type: object
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - bot
+            title: bots.info schema
+            type: object
+        default:
+          description: 'When no bot can be found, it returns an error.'
+          examples:
+            application/json:
+              error: bot_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from bots.info method
+            properties:
+              error:
+                enum:
+                  - bot_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: bots.info error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users:read'
+      tags:
+        - bots
+  /channels.archive:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Archives a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.archive'
+      operationId: channels_archive
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: Channel to archive
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from channels.archive method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: channels.archive success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response channels.archive method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - already_archived
+                  - cant_archive_general
+                  - restricted_action
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.archive error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.create:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Creates a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.create'
+      operationId: channels_create
+      parameters:
+        - description: Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+          in: formData
+          name: validate
+          type: boolean
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: Name of channel to create
+          in: formData
+          name: name
+          type: string
+      responses:
+        '200':
+          description: Typical success response resulting in a new channel
+          examples:
+            application/json:
+              channel:
+                created: 1502833204
+                creator: U061F7AUR
+                id: C0DEL09A5
+                is_archived: false
+                is_channel: true
+                is_general: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_private: false
+                is_shared: false
+                last_read: 0000000000.000000
+                members:
+                  - U061F7AUR
+                name: endeavor
+                name_normalized: endeavor
+                previous_names: []
+                purpose:
+                  creator: ''
+                  last_set: 0
+                  value: ''
+                topic:
+                  creator: ''
+                  last_set: 0
+                  value: ''
+                unread_count: 0
+                unread_count_display: 0
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response channels.create method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: channels.create error schema
+            type: object
+        default:
+          description: Example error response when an invalid name is provided
+          examples:
+            application/json:
+              detail: Value passed for `name` contained unallowed special characters.
+              error: invalid_name_specials
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response channels.create method
+            properties:
+              error:
+                enum:
+                  - name_taken
+                  - restricted_action
+                  - no_channel
+                  - invalid_name_required
+                  - invalid_name_punctuation
+                  - invalid_name_maxlength
+                  - invalid_name_specials
+                  - invalid_name
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.create error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.history:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Fetches history of messages and events from a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.history'
+      operationId: channels_history
+      parameters:
+        - description: 'Number of messages to return, between 1 and 1000.'
+          in: query
+          name: count
+          type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          type: boolean
+        - description: 'Authentication token. Requires scope: `channels:history`'
+          in: query
+          name: token
+          type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          type: number
+        - description: Channel to fetch history for.
+          in: query
+          name: channel
+          type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          type: number
+      responses:
+        '200':
+          description: Typical success response containing the channel's history
+          examples:
+            application/json:
+              has_more: false
+              latest: '1358547726.000003'
+              messages:
+                - text: Hello
+                  ts: '1358546515.000008'
+                  type: message
+                  user: U2147483896
+                - is_starred: true
+                  reactions:
+                    - count: 3
+                      name: space_invader
+                      users:
+                        - U1
+                        - U2
+                        - U3
+                    - count: 5
+                      name: sweet_potato
+                      users:
+                        - U1
+                        - U2
+                        - U3
+                        - U4
+                        - U5
+                  text: World
+                  ts: '1358546515.000007'
+                  type: message
+                  user: U2147483896
+                - ts: '1358546515.000007'
+                  type: something_else
+                - attachments:
+                    - fallback: This is an attachment fallback
+                      id: 1
+                      text: Don't get too attached
+                  bot_id: B19LU7CSY
+                  subtype: bot_message
+                  text: Containment unit is 98% full
+                  ts: '1503435956.000247'
+                  type: message
+                  username: ecto1138
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response channels.history method
+            properties:
+              has_more:
+                type: boolean
+              messages:
+                items:
+                  $ref: '#/definitions/objs_message'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - messages
+              - has_more
+            title: channels.history success schema
+            type: object
+        default:
+          description: Error response when the specified channel cannot be found
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response channels.history method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_ts_latest
+                  - invalid_ts_oldest
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.history error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:history'
+      tags:
+        - channels
+  /channels.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets information about a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.info'
+      operationId: channels_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:read`'
+          in: query
+          name: token
+          type: string
+        - description: Set this to `true` to receive the locale for this channel. Defaults to `false`
+          in: query
+          name: include_locale
+          type: boolean
+        - description: Channel to get info on
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                created: 1466025154
+                creator: U0G9QF9C6
+                id: C1H9RESGL
+                is_archived: false
+                is_channel: true
+                is_general: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_private: false
+                is_shared: false
+                last_read: '1503435939.000101'
+                latest:
+                  attachments:
+                    - fallback: This is an attachment fallback
+                      id: 1
+                      text: Don't get too attached
+                  bot_id: B19LU7CSY
+                  subtype: bot_message
+                  text: Containment unit is 98% full
+                  ts: '1503435956.000247'
+                  type: message
+                  username: ecto1138
+                members:
+                  - U0G9QF9C6
+                  - U1QNSQB9U
+                name: busting
+                name_normalized: busting
+                previous_names:
+                  - dusting
+                purpose:
+                  creator: U0G9QF9C6
+                  last_set: 1503435128
+                  value: Discuss busting ghosts
+                topic:
+                  creator: U0G9QF9C6
+                  last_set: 1503435128
+                  value: Spiritual containment strategies
+                unread_count: 1
+                unread_count_display: 1
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response channels.info method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: channels.info success schema
+            type: object
+        default:
+          description: Error response when the specified channel cannot be found
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response channels.info method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.info error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:read'
+      tags:
+        - channels
+  /channels.invite:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Invites a user to a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.invite'
+      operationId: channels_invite
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: User to invite to channel.
+          in: formData
+          name: user
+          type: string
+        - description: Channel to invite user to.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                created: 1466025154
+                creator: U0G9QF9C6
+                id: C1H9RESGL
+                is_archived: false
+                is_channel: true
+                is_general: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_private: false
+                is_shared: false
+                last_read: '1503435963.000307'
+                latest:
+                  subtype: channel_leave
+                  text: <@U1QNSQB9U|protobot> has left the channel
+                  ts: '1503435963.000307'
+                  type: message
+                  user: U1QNSQB9U
+                members:
+                  - U0G9QF9C6
+                  - U1QNSQB9U
+                name: busting
+                name_normalized: busting
+                previous_names: []
+                purpose:
+                  creator: U0G9QF9C6
+                  last_set: 1503435128
+                  value: My Purpose
+                topic:
+                  creator: U0G9QF9C6
+                  last_set: 1503435128
+                  value: My Topic
+                unread_count: 0
+                unread_count_display: 0
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response channels.invite method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: channels.invite error schema
+            type: object
+        default:
+          description: A somewhat typical error response
+          examples:
+            application/json:
+              error: cant_invite
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response channels.invite method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - user_not_found
+                  - cant_invite_self
+                  - not_in_channel
+                  - already_in_channel
+                  - is_archived
+                  - cant_invite
+                  - too_many_users
+                  - ura_max_channels
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.invite error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.join:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: 'Joins a channel, creating it if needed.'
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.join'
+      operationId: channels_join
+      parameters:
+        - description: Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+          in: formData
+          name: validate
+          type: boolean
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: Name of channel to join
+          in: formData
+          name: name
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              already_in_channel: true
+              channel:
+                created: 1466025154
+                creator: U0G9QF9C6
+                id: C1H9RESGL
+                is_archived: false
+                is_channel: true
+                is_general: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_private: false
+                is_shared: false
+                members:
+                  - U0G9QF9C6
+                  - U1QNSQB9U
+                name: busting
+                name_normalized: busting
+                previous_names: []
+                purpose:
+                  creator: U0G9QF9C6
+                  last_set: 1503435128
+                  value: My Purpose
+                topic:
+                  creator: U0G9QF9C6
+                  last_set: 1503435128
+                  value: My Topic
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from channels.join method
+            properties:
+              already_in_channel:
+                type: boolean
+              channel:
+                $ref: '#/definitions/objs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: channels.join schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from channels.join method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - name_taken
+                  - restricted_action
+                  - no_channel
+                  - is_archived
+                  - invalid_name_required
+                  - invalid_name_punctuation
+                  - invalid_name_maxlength
+                  - invalid_name_specials
+                  - invalid_name
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - user_is_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.join error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.kick:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Removes a user from a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.kick'
+      operationId: channels_kick
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: User to remove from channel.
+          in: formData
+          name: user
+          type: string
+        - description: Channel to remove user from.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from channels.kick method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: channels.kick schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: not_in_channel
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from channels.kick method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - user_not_found
+                  - cant_kick_self
+                  - not_in_channel
+                  - cant_kick_from_general
+                  - restricted_action
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - user_is_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.kick error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.leave:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Leaves a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.leave'
+      operationId: channels_leave
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: Channel to leave
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists all channels in a Slack team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.list'
+      operationId: channels_list
+      parameters:
+        - description: Exclude the `members` collection from each `channel`
+          in: query
+          name: exclude_members
+          type: boolean
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `channels:read`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn''t been reached.'
+          in: query
+          name: limit
+          type: integer
+        - description: Exclude archived channels from the list
+          in: query
+          name: exclude_archived
+          type: boolean
+      responses:
+        '200':
+          description: Typical cursored success response
+          examples:
+            application/json:
+              channels:
+                - created: 1449709280
+                  creator: U0G9QF9C6
+                  id: C0G9QF9GW
+                  is_archived: false
+                  is_channel: true
+                  is_general: false
+                  is_member: true
+                  is_mpim: false
+                  is_org_shared: false
+                  is_private: false
+                  is_shared: false
+                  members:
+                    - U0G9QF9C6
+                    - U0G9WFXNZ
+                  name: random
+                  name_normalized: random
+                  num_members: 2
+                  previous_names: []
+                  purpose:
+                    creator: ''
+                    last_set: 0
+                    value: 'A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you''d prefer to keep out of more focused work-related channels.'
+                  topic:
+                    creator: U0G9QF9C6
+                    last_set: 1449709352
+                    value: Other stuff
+                - created: 1449709280
+                  creator: U0G9QF9C6
+                  id: C0G9QKBBL
+                  is_archived: false
+                  is_channel: true
+                  is_general: true
+                  is_member: true
+                  is_mpim: false
+                  is_org_shared: false
+                  is_private: false
+                  is_shared: false
+                  members:
+                    - U0G9QF9C6
+                    - U0G9WFXNZ
+                  name: general
+                  name_normalized: general
+                  num_members: 2
+                  previous_names: []
+                  purpose:
+                    creator: U0G9QF9C6
+                    last_set: 1449709334
+                    value: To talk about anything!
+                  topic:
+                    creator: U0G9QF9C6
+                    last_set: 1449709364
+                    value: Talk about anything!
+              ok: true
+              response_metadata:
+                next_cursor: dGVhbTpDMUg5UkVTR0w=
+          schema:
+            additionalProperties: true
+            description: Schema for successful response channels.list method
+            properties:
+              channels:
+                items:
+                  $ref: '#/definitions/objs_channel'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channels
+            title: channels.list success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response channels.list method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:read'
+      tags:
+        - channels
+  /channels.mark:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the read cursor in a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.mark'
+      operationId: channels_mark
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: Timestamp of the most recently seen message.
+          in: formData
+          name: ts
+          type: number
+        - description: Channel to set reading cursor in.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response channels.mark method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: channels.mark success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response channels.mark method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_timestamp
+                  - not_in_channel
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.mark error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.rename:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Renames a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.rename'
+      operationId: channels_rename
+      parameters:
+        - description: Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+          in: formData
+          name: validate
+          type: boolean
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: New name for channel.
+          in: formData
+          name: name
+          type: string
+        - description: Channel to rename
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                created: 1477445146
+                creator: U2U85N1RZ
+                id: C2U875RJN
+                is_archived: false
+                is_channel: true
+                is_general: false
+                is_member: false
+                is_mpim: false
+                is_org_shared: false
+                is_private: false
+                is_shared: false
+                members: []
+                name: humans-and-bots
+                name_normalized: humans-and-bots
+                previous_names:
+                  - humans
+                purpose:
+                  creator: U2U85N1RZ
+                  last_set: 1509475801
+                  value: the purpose of this channel is to bring people and robots together in harmony
+                topic:
+                  creator: U2U85N1RZ
+                  last_set: 1509475775
+                  value: here be robots
+                unlinked: 0
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from channels.rename method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: channels.rename schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from channels.rename method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - not_in_channel
+                  - not_authorized
+                  - invalid_name
+                  - name_taken
+                  - invalid_name_required
+                  - invalid_name_punctuation
+                  - invalid_name_maxlength
+                  - invalid_name_specials
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - user_is_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.rename error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.replies:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve a thread of messages posted to a channel
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.replies'
+      operationId: channels_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message
+          in: query
+          name: thread_ts
+          type: number
+        - description: 'Authentication token. Requires scope: `channels:history`'
+          in: query
+          name: token
+          type: string
+        - description: Channel to fetch thread from
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              has_more: false
+              messages:
+                - last_read: '1509484885.000082'
+                  replies:
+                    - ts: '1509484424.000601'
+                      user: U2U85N1RZ
+                    - ts: '1509484885.000082'
+                      user: U2U85N1RZ
+                  reply_count: 2
+                  subscribed: true
+                  text: This is a channel message
+                  thread_ts: '1485913694.000025'
+                  ts: '1485913694.000025'
+                  type: message
+                  unread_count: 0
+                  user: U2X9P5FEL
+                - parent_user_id: U2X9P5FEL
+                  text: This is a thread reply
+                  thread_ts: '1485913694.000025'
+                  ts: '1509484424.000601'
+                  type: message
+                  user: U2U85N1RZ
+                - parent_user_id: U2X9P5FEL
+                  text: This is another thread reply
+                  thread_ts: '1485913694.000025'
+                  ts: '1509484885.000082'
+                  type: message
+                  user: U2U85N1RZ
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: thread_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:history'
+      tags:
+        - channels
+  /channels.setPurpose:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the purpose for a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.setPurpose'
+      operationId: channels_setPurpose
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: The new purpose
+          in: formData
+          name: purpose
+          type: string
+        - description: Channel to set the purpose of
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              purpose: My special purpose
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from channels.setPurpose method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              purpose:
+                type: string
+            required:
+              - ok
+              - purpose
+            title: channels.setPurpose schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from channels.setPurpose method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - not_in_channel
+                  - is_archived
+                  - too_long
+                  - user_is_restricted
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: channels.setPurpose error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.setTopic:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the topic for a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.setTopic'
+      operationId: channels_setTopic
+      parameters:
+        - description: The new topic
+          in: formData
+          name: topic
+          type: string
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: Channel to set the topic of
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              topic: To picture topicality
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /channels.unarchive:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Unarchives a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/channels.unarchive'
+      operationId: channels_unarchive
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: Channel to unarchive
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - channels
+  /chat.delete:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Deletes a message.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/chat.delete'
+      operationId: chat_delete
+      parameters:
+        - description: 'Pass true to delete the message as the authed user with `chat:write:user` scope. [Bot users](/bot-users) in this context are considered authed users. If unused or false, the message will be deleted with `chat:write:bot` scope.'
+          in: formData
+          name: as_user
+          type: boolean
+        - description: 'Authentication token. Requires scope: `chat:write`'
+          in: header
+          name: token
+          type: string
+        - description: Timestamp of the message to be deleted.
+          in: formData
+          name: ts
+          type: number
+        - description: Channel containing the message to be deleted.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel: C024BE91L
+              ok: true
+              ts: '1401383885.000061'
+          schema:
+            additionalProperties: true
+            description: Schema for successful response of chat.delete method
+            properties:
+              channel:
+                $ref: '#/definitions/defs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              ts:
+                $ref: '#/definitions/defs_ts'
+            required:
+              - ok
+              - channel
+              - ts
+            title: chat.delete success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: message_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from chat.delete method
+            properties:
+              error:
+                enum:
+                  - message_not_found
+                  - channel_not_found
+                  - cant_delete_message
+                  - compliance_exports_prevent_deletion
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: chat.delete error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'chat:write:user'
+            - 'chat:write:bot'
+      tags:
+        - chat
+  /chat.getPermalink:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve a permalink URL for a specific extant message
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/chat.getPermalink'
+      operationId: chat_getPermalink
+      parameters:
+        - description: 'Authentication token. Requires scope: `none`'
+          in: query
+          name: token
+          type: string
+        - description: 'A message''s `ts` value, uniquely identifying it within a channel'
+          in: query
+          name: message_ts
+          type: number
+        - description: The ID of the conversation or channel containing the message
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Standard success response
+          examples:
+            application/json:
+              channel: C1H9RESGA
+              ok: true
+              permalink: 'https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008'
+          schema:
+            additionalProperties: true
+            description: Schema for successful response chat.getPermalink
+            properties:
+              channel:
+                $ref: '#/definitions/defs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              permalink:
+                format: uri
+                type: string
+            required:
+              - ok
+              - channel
+              - permalink
+            title: chat.getPermalink success schema
+            type: object
+        default:
+          description: Error response when channel cannot be found
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from chat.getPermalink method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - message_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: chat.getPermalink error schema
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - chat
+  /chat.meMessage:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Share a me message into a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/chat.meMessage'
+      operationId: chat_meMessage
+      parameters:
+        - description: Text of the message to send.
+          in: formData
+          name: text
+          type: string
+        - description: 'Authentication token. Requires scope: `chat:write:user`'
+          in: header
+          name: token
+          type: string
+        - description: 'Channel to send message to. Can be a public channel, private group or IM channel. Can be an encoded ID, or a name.'
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel: C024BE7LR
+              ok: true
+              ts: '1417671948.000006'
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'chat:write:user'
+      tags:
+        - chat
+  /chat.postEphemeral:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sends an ephemeral message to a user in a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/chat.postEphemeral'
+      operationId: chat_postEphemeral
+      parameters:
+        - description: 'A JSON-based array of structured attachments, presented as a URL-encoded string.'
+          in: formData
+          name: attachments
+          type: string
+        - description: 'Text of the message to send. See below for an explanation of [formatting](#formatting). This field is usually required, unless you''re providing only `attachments` instead.'
+          in: formData
+          name: text
+          type: string
+        - description: Find and link channel names and usernames.
+          in: formData
+          name: link_names
+          type: boolean
+        - description: 'Change how messages are treated. Defaults to `none`. See [below](#formatting).'
+          in: formData
+          name: parse
+          type: string
+        - description: 'Authentication token. Requires scope: `chat:write`'
+          in: header
+          name: token
+          type: string
+        - description: '`id` of the user who will receive the ephemeral message. The user should be in the channel specified by the `channel` argument.'
+          in: formData
+          name: user
+          type: string
+        - description: Pass true to post the message as the authed bot. Defaults to false.
+          in: formData
+          name: as_user
+          type: boolean
+        - description: 'Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name.'
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              message_ts: '1502210682.580145'
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from chat.postEphemeral method
+            properties:
+              message_ts:
+                $ref: '#/definitions/defs_ts'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - message_ts
+            title: chat.postEphemeral success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: user_not_in_channel
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from chat.postEphemeral method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - is_archived
+                  - msg_too_long
+                  - no_text
+                  - restricted_action
+                  - too_many_attachments
+                  - user_not_in_channel
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: chat.postEphemeral error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'chat:write:user'
+            - 'chat:write:bot'
+      tags:
+        - chat
+  /chat.postMessage:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sends a message to a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/chat.postMessage'
+      operationId: chat_postMessage
+      parameters:
+        - description: 'Set your bot''s user name. Must be used in conjunction with `as_user` set to false, otherwise ignored. See [authorship](#authorship) below.'
+          in: formData
+          name: username
+          type: string
+        - description: Provide another message's `ts` value to make this message a reply. Avoid using a reply's `ts` value; use its parent instead.
+          in: formData
+          name: thread_ts
+          type: number
+        - description: 'A JSON-based array of structured attachments, presented as a URL-encoded string.'
+          in: formData
+          name: attachments
+          type: string
+        - description: Pass true to enable unfurling of primarily text-based content.
+          in: formData
+          name: unfurl_links
+          type: boolean
+        - description: 'Text of the message to send. See below for an explanation of [formatting](#formatting). This field is usually required, unless you''re providing only `attachments` instead. Provide no more than 40,000 characters or [risk truncation](/changelog/2018-04-truncating-really-long-messages).'
+          in: formData
+          name: text
+          type: string
+        - description: Pass false to disable unfurling of media content.
+          in: formData
+          name: unfurl_media
+          type: boolean
+        - description: 'Change how messages are treated. Defaults to `none`. See [below](#formatting).'
+          in: formData
+          name: parse
+          type: string
+        - description: 'Pass true to post the message as the authed user, instead of as a bot. Defaults to false. See [authorship](#authorship) below.'
+          in: formData
+          name: as_user
+          type: boolean
+        - description: 'Authentication token. Requires scope: `chat:write`'
+          in: header
+          name: token
+          type: string
+        - description: Disable Slack markup parsing by setting to `false`. Enabled by default.
+          in: formData
+          name: mrkdwn
+          type: boolean
+        - description: 'Emoji to use as the icon for this message. Overrides `icon_url`. Must be used in conjunction with `as_user` set to `false`, otherwise ignored. See [authorship](#authorship) below.'
+          in: formData
+          name: icon_emoji
+          type: string
+        - description: Find and link channel names and usernames.
+          in: formData
+          name: link_names
+          type: boolean
+        - description: 'URL to an image to use as the icon for this message. Must be used in conjunction with `as_user` set to false, otherwise ignored. See [authorship](#authorship) below.'
+          in: formData
+          name: icon_url
+          type: string
+        - description: 'Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name. See [below](#channels) for more details.'
+          in: formData
+          name: channel
+          type: string
+        - description: Used in conjunction with `thread_ts` and indicates whether reply should be made visible to everyone in the channel or conversation. Defaults to `false`.
+          in: formData
+          name: reply_broadcast
+          type: boolean
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel: C1H9RESGL
+              message:
+                attachments:
+                  - fallback: This is an attachment's fallback
+                    id: 1
+                    text: This is an attachment
+                bot_id: B19LU7CSY
+                subtype: bot_message
+                text: Here's a message for you
+                ts: '1503435956.000247'
+                type: message
+                username: ecto1
+              ok: true
+              ts: '1503435956.000247'
+          schema:
+            additionalProperties: true
+            description: Schema for successful response of chat.postMessage method
+            properties:
+              channel:
+                $ref: '#/definitions/defs_channel'
+              message:
+                $ref: '#/definitions/objs_message'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              ts:
+                $ref: '#/definitions/defs_ts'
+            required:
+              - ok
+              - channel
+              - ts
+              - message
+            title: chat.postMessage success schema
+            type: object
+        default:
+          description: Typical error response if too many attachments are included
+          examples:
+            application/json:
+              error: too_many_attachments
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response chat.postMessage method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - not_in_channel
+                  - is_archived
+                  - msg_too_long
+                  - no_text
+                  - too_many_attachments
+                  - rate_limited
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: chat.postMessage error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'chat:write:user'
+            - 'chat:write:bot'
+      tags:
+        - chat
+  /chat.unfurl:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Provide custom unfurl behavior for user-posted URLs
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/chat.unfurl'
+      operationId: chat_unfurl
+      parameters:
+        - description: Provide a simply-formatted string to send as an ephemeral message to the user as invitation to authenticate further and enable full unfurling behavior
+          in: formData
+          name: user_auth_message
+          type: string
+        - description: Set to `true` or `1` to indicate the user must install your Slack app to trigger unfurls for this domain
+          in: formData
+          name: user_auth_required
+          type: boolean
+        - description: 'URL-encoded JSON map with keys set to URLs featured in the the message, pointing to their unfurl message attachments.'
+          in: formData
+          name: unfurls
+          type: string
+        - description: Timestamp of the message to add unfurl behavior to.
+          in: formData
+          name: ts
+          type: string
+        - description: Send users to this custom URL where they will complete authentication in your app to fully trigger unfurling. Value should be properly URL-encoded.
+          in: formData
+          name: user_auth_url
+          type: string
+        - description: 'Authentication token. Requires scope: `links:write`'
+          in: header
+          name: token
+          type: string
+        - description: Channel ID of the message
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: 'Typical, minimal success response'
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from chat.unfurl method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: chat.unfurl success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: cannot_unfurl_url
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from chat.unfurl method
+            properties:
+              error:
+                enum:
+                  - cannot_unfurl_url
+                  - cannot_find_service
+                  - missing_unfurls
+                  - cannot_prompt
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: chat.unfurl error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'links:write'
+      tags:
+        - chat
+  /chat.update:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Updates a message.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/chat.update'
+      operationId: chat_update
+      parameters:
+        - description: 'A JSON-based array of structured attachments, presented as a URL-encoded string. This field is required when not presenting `text`.'
+          in: formData
+          name: attachments
+          type: string
+        - description: 'New text for the message, using the [default formatting rules](/docs/formatting). It''s not required when presenting `attachments`.'
+          in: formData
+          name: text
+          type: string
+        - description: Timestamp of the message to be updated.
+          in: formData
+          name: ts
+          type: number
+        - description: 'Change how messages are treated. Defaults to `client`, unlike `chat.postMessage`. See [below](#formatting).'
+          in: formData
+          name: parse
+          type: string
+        - description: 'Pass true to update the message as the authed user. [Bot users](/bot-users) in this context are considered authed users.'
+          in: formData
+          name: as_user
+          type: boolean
+        - description: 'Authentication token. Requires scope: `chat:write`'
+          in: header
+          name: token
+          type: string
+        - description: 'Find and link channel names and usernames. Defaults to `none`. See [below](#formatting).'
+          in: formData
+          name: link_names
+          type: boolean
+        - description: Channel containing the message to be updated.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel: C024BE91L
+              ok: true
+              text: Updated text you carefully authored
+              ts: '1401383885.000061'
+          schema:
+            additionalProperties: true
+            description: Schema for successful response of chat.update method
+            properties:
+              channel:
+                $ref: '#/definitions/defs_channel'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              text:
+                title: Updated message text
+                type: string
+              ts:
+                $ref: '#/definitions/defs_ts'
+            required:
+              - ok
+              - channel
+              - ts
+              - text
+            title: chat.update success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: cant_update_message
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response chat.update method
+            properties:
+              error:
+                enum:
+                  - message_not_found
+                  - cant_update_message
+                  - channel_not_found
+                  - edit_window_closed
+                  - msg_too_long
+                  - too_many_attachments
+                  - rate_limited
+                  - no_text
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - request_timeout
+                  - invalid_json
+                  - json_not_object
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: chat.update error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'chat:write:user'
+            - 'chat:write:bot'
+      tags:
+        - chat
+  /conversations.archive:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Archives a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.archive'
+      operationId: conversations_archive
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: ID of conversation to archive
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response conversations.archive method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: conversations.archive success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.archive method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - not_supported
+                  - channel_not_found
+                  - already_archived
+                  - cant_archive_general
+                  - restricted_action
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.archive error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.close:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Closes a direct message or multi-person direct message.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.close'
+      operationId: conversations_close
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: Conversation to close.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response conversations.close method
+            properties:
+              already_closed:
+                type: boolean
+              no_op:
+                type: boolean
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: conversations.close success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.close method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - channel_not_found
+                  - user_does_not_own_channel
+                  - missing_scope
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.close error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.create:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Initiates a public or private channel-based conversation
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.create'
+      operationId: conversations_create
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: Name of the public or private channel to create
+          in: formData
+          name: name
+          type: string
+        - description: Create a private channel instead of a public one
+          in: formData
+          name: is_private
+          type: boolean
+      responses:
+        '200':
+          description: 'If successful, the command returns a rather stark [conversation object](/types/conversation)'
+          examples:
+            application/json:
+              channel:
+                created: 1504554479
+                creator: U0123456
+                id: C0EAQDV4Z
+                is_archived: false
+                is_channel: true
+                is_ext_shared: false
+                is_general: false
+                is_group: false
+                is_im: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_pending_ext_shared: false
+                is_private: false
+                is_shared: false
+                last_read: 0000000000.000000
+                name: endeavor
+                name_normalized: endeavor
+                pending_shared: []
+                previous_names: []
+                priority: 0
+                purpose:
+                  creator: ''
+                  last_set: 0
+                  value: ''
+                topic:
+                  creator: ''
+                  last_set: 0
+                  value: ''
+                unlinked: 0
+                unread_count: 0
+                unread_count_display: 0
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response conversations.create method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: conversations.create success schema
+            type: object
+        default:
+          description: Typical error response when name already in use
+          examples:
+            application/json:
+              error: name_taken
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.create method
+            properties:
+              detail:
+                type: string
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - name_taken
+                  - restricted_action
+                  - no_channel
+                  - invalid_name_required
+                  - invalid_name_punctuation
+                  - invalid_name_maxlength
+                  - invalid_name_specials
+                  - invalid_name
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.create error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.history:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Fetches a conversation's history of messages and events.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.history'
+      operationId: conversations_history
+      parameters:
+        - description: Include messages with latest or oldest timestamp in results only when either timestamp is specified.
+          in: query
+          name: inclusive
+          type: boolean
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `conversations:history`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn''t been reached.'
+          in: query
+          name: limit
+          type: integer
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          type: number
+        - description: Conversation ID to fetch history for.
+          in: query
+          name: channel
+          type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          type: number
+      responses:
+        '200':
+          description: Typical success response containing a channel's messages
+          examples:
+            application/json:
+              has_more: true
+              messages:
+                - text: I find you punny and would like to smell your nose letter
+                  ts: '1512085950.000216'
+                  type: message
+                  user: U012AB3CDE
+                - text: 'What, you want to smell my shoes better?'
+                  ts: '1512104434.000490'
+                  type: message
+                  user: U061F7AUR
+              ok: true
+              pin_count: 0
+              response_metadata:
+                next_cursor: bmV4dF90czoxNTEyMDg1ODYxMDAwNTQz
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.history method
+            properties:
+              has_more:
+                type: boolean
+              messages:
+                items:
+                  $ref: '#/definitions/objs_message'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              pin_count:
+                type: integer
+            required:
+              - ok
+              - messages
+              - has_more
+              - pin_count
+            title: conversations.history success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.history method
+            properties:
+              error:
+                enum:
+                  - missing_scope
+                  - channel_not_found
+                  - invalid_ts_latest
+                  - invalid_ts_oldest
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.history error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:history'
+            - 'groups:history'
+            - 'im:history'
+            - 'mpim:history'
+      tags:
+        - conversations
+  /conversations.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve information about a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.info'
+      operationId: conversations_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:read`'
+          in: query
+          name: token
+          type: string
+        - description: Conversation ID to learn more about
+          in: query
+          name: channel
+          type: string
+        - description: Set this to `true` to receive the locale for this conversation. Defaults to `false`
+          in: query
+          name: include_locale
+          type: boolean
+      responses:
+        '200':
+          description: 'Typical success response for a public channel. (Also, a response from a private channel and a multi-party IM is very similar to this example.)'
+          examples:
+            application/json:
+              channel:
+                created: 1449252889
+                creator: W012A3BCD
+                id: C012AB3CD
+                is_archived: false
+                is_channel: true
+                is_ext_shared: false
+                is_general: true
+                is_group: false
+                is_im: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_pending_ext_shared: false
+                is_private: false
+                is_read_only: false
+                is_shared: false
+                last_read: '1502126650.228446'
+                locale: en-US
+                name: general
+                name_normalized: general
+                num_members: 23
+                pending_shared: []
+                previous_names:
+                  - specifics
+                  - abstractions
+                  - etc
+                purpose:
+                  creator: W012A3BCD
+                  last_set: 1449709364
+                  value: This part of the workspace is for fun. Make fun here.
+                topic:
+                  creator: W012A3BCD
+                  last_set: 1449709364
+                  value: For public discussion of generalities
+                unlinked: 0
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response conversations.info
+            properties:
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: conversations.info success schema
+            type: object
+        default:
+          description: Typical error response when a channel cannot be found
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.info method
+            properties:
+              error:
+                enum:
+                  - missing_scope
+                  - channel_not_found
+                  - team_added_to_org
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.info error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:read'
+            - 'groups:read'
+            - 'im:read'
+            - 'mpim:read'
+      tags:
+        - conversations
+  /conversations.invite:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Invites users to a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.invite'
+      operationId: conversations_invite
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: A comma separated list of user IDs. Up to 30 users may be listed.
+          in: formData
+          name: users
+          type: string
+        - description: The ID of the public or private channel to invite user(s) to.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response when an invitation is extended
+          examples:
+            application/json:
+              channel:
+                created: 1449252889
+                creator: W012A3BCD
+                id: C012AB3CD
+                is_archived: false
+                is_channel: true
+                is_ext_shared: false
+                is_general: true
+                is_group: false
+                is_im: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_pending_ext_shared: false
+                is_private: false
+                is_read_only: false
+                is_shared: false
+                last_read: '1502126650.228446'
+                locale: en-US
+                name: general
+                name_normalized: general
+                num_members: 23
+                pending_shared: []
+                previous_names:
+                  - specifics
+                  - abstractions
+                  - etc
+                purpose:
+                  creator: W012A3BCD
+                  last_set: 1449709364
+                  value: This part of the workspace is for fun. Make fun here.
+                topic:
+                  creator: W012A3BCD
+                  last_set: 1449709364
+                  value: For public discussion of generalities
+                unlinked: 0
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.invite method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: conversations.invite error schema
+            type: object
+        default:
+          description: Typical error response when an invite is attempted on a conversation type that does not support it
+          examples:
+            application/json:
+              error: method_not_supported_for_channel_type
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.invite method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - channel_not_found
+                  - user_not_found
+                  - cant_invite_self
+                  - not_in_channel
+                  - already_in_channel
+                  - is_archived
+                  - cant_invite
+                  - too_many_users
+                  - ura_max_channels
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              errors:
+                items:
+                  additionalProperties: true
+                  properties:
+                    error:
+                      enum:
+                        - method_not_supported_for_channel_type
+                        - missing_scope
+                        - channel_not_found
+                        - user_not_found
+                        - cant_invite_self
+                        - not_in_channel
+                        - already_in_channel
+                        - is_archived
+                        - cant_invite
+                        - too_many_users
+                        - ura_max_channels
+                        - not_authed
+                        - invalid_auth
+                        - account_inactive
+                        - user_is_bot
+                        - user_is_restricted
+                        - user_is_ultra_restricted
+                        - invalid_arg_name
+                        - invalid_array_arg
+                        - invalid_charset
+                        - invalid_form_data
+                        - invalid_post_type
+                        - missing_post_type
+                        - invalid_json
+                        - json_not_object
+                        - request_timeout
+                        - upgrade_required
+                        - team_added_to_org
+                        - missing_charset
+                        - superfluous_charset
+                      type: string
+                    ok:
+                      $ref: '#/definitions/defs_ok_false'
+                    user:
+                      $ref: '#/definitions/defs_user_id'
+                  required:
+                    - ok
+                    - error
+                  type: object
+                minItems: 1
+                title: errors is returned when an error associates an user
+                type: array
+                uniqueItems: true
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+            title: conversations.invite error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.join:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Joins an existing conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.join'
+      operationId: conversations_join
+      parameters:
+        - description: 'Authentication token. Requires scope: `channels:write`'
+          in: header
+          name: token
+          type: string
+        - description: ID of conversation to join
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                created: 1449252889
+                creator: U061F7AUR
+                id: C061EG9SL
+                is_archived: false
+                is_channel: true
+                is_ext_shared: false
+                is_general: true
+                is_group: false
+                is_im: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_pending_ext_shared: false
+                is_private: false
+                is_shared: false
+                name: general
+                name_normalized: general
+                pending_shared: []
+                previous_names: []
+                purpose:
+                  creator: ''
+                  last_set: 0
+                  value: For widget discussion
+                topic:
+                  creator: ''
+                  last_set: 0
+                  value: Which widget do you worry about?
+                unlinked: 0
+              ok: true
+              response_metadata:
+                warnings:
+                  - already_in_channel
+              warning: already_in_channel
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.join method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              response_metadata:
+                properties:
+                  warnings:
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                title: Response metadata
+                type: object
+              warning:
+                type: string
+            required:
+              - ok
+              - channel
+            title: conversations.join success schema
+            type: object
+        default:
+          description: Typical error response if the conversation is archived and cannot be joined
+          examples:
+            application/json:
+              error: is_archived
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.join method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - channel_not_found
+                  - is_archived
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.join error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+      tags:
+        - conversations
+  /conversations.kick:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Removes a user from a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.kick'
+      operationId: conversations_kick
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: User ID to be removed.
+          in: formData
+          name: user
+          type: string
+        - description: ID of conversation to remove user from.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response conversations.kick method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: conversations.kick success schema
+            type: object
+        default:
+          description: Typical error response when you attempt to kick yourself from a channel
+          examples:
+            application/json:
+              error: cant_kick_self
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response conversations.kick method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - channel_not_found
+                  - user_not_found
+                  - cant_kick_self
+                  - not_in_channel
+                  - cant_kick_from_general
+                  - restricted_action
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.kick error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.leave:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Leaves a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.leave'
+      operationId: conversations_leave
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: Conversation to leave
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.leave method
+            properties:
+              not_in_channel:
+                enum:
+                  - true
+                type: boolean
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: conversations.leave success schema
+            type: object
+        default:
+          description: Typical error response when attempting to leave a workspace's "general" channel
+          examples:
+            application/json:
+              error: cant_leave_general
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.leave method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - last_member
+                  - missing_scope
+                  - channel_not_found
+                  - is_archived
+                  - cant_leave_general
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.leave error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists all channels in a Slack team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.list'
+      operationId: conversations_list
+      parameters:
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `conversations:read`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn''t been reached. Must be an integer no larger than 1000.'
+          in: query
+          name: limit
+          type: integer
+        - description: Set to `true` to exclude archived channels from the list
+          in: query
+          name: exclude_archived
+          type: boolean
+        - description: 'Mix and match channel types by providing a comma-separated list of any combination of `public_channel`, `private_channel`, `mpim`, `im`'
+          in: query
+          name: types
+          type: string
+      responses:
+        '200':
+          description: Typical success response with only public channels
+          examples:
+            application/json:
+              channels:
+                - created: 1449252889
+                  creator: U012A3CDE
+                  id: C012AB3CD
+                  is_archived: false
+                  is_channel: true
+                  is_ext_shared: false
+                  is_general: true
+                  is_group: false
+                  is_im: false
+                  is_member: true
+                  is_mpim: false
+                  is_org_shared: false
+                  is_pending_ext_shared: false
+                  is_private: false
+                  is_shared: false
+                  name: general
+                  name_normalized: general
+                  num_members: 4
+                  pending_shared: []
+                  previous_names: []
+                  purpose:
+                    creator: ''
+                    last_set: 0
+                    value: This channel is for team-wide communication and announcements. All team members are in this channel.
+                  topic:
+                    creator: ''
+                    last_set: 0
+                    value: Company-wide announcements and work-based matters
+                  unlinked: 0
+                - created: 1449252889
+                  creator: U061F7AUR
+                  id: C061EG9T2
+                  is_archived: false
+                  is_channel: true
+                  is_ext_shared: false
+                  is_general: false
+                  is_group: false
+                  is_im: false
+                  is_member: true
+                  is_mpim: false
+                  is_org_shared: false
+                  is_pending_ext_shared: false
+                  is_private: false
+                  is_shared: false
+                  name: random
+                  name_normalized: random
+                  num_members: 4
+                  pending_shared: []
+                  previous_names: []
+                  purpose:
+                    creator: ''
+                    last_set: 0
+                    value: 'A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you''d prefer to keep out of more focused work-related channels.'
+                  topic:
+                    creator: ''
+                    last_set: 0
+                    value: Non-work banter and water cooler conversation
+                  unlinked: 0
+              ok: true
+              response_metadata:
+                next_cursor: dGVhbTpDMDYxRkE1UEI=
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.list method
+            properties:
+              channels:
+                items:
+                  $ref: '#/definitions/objs_conversation'
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              response_metadata:
+                additionalProperties: true
+                properties:
+                  next_cursor:
+                    type: string
+                required:
+                  - next_cursor
+                type: object
+            required:
+              - ok
+              - channels
+            title: conversations.list success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.list method
+            properties:
+              error:
+                enum:
+                  - missing_scope
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:read'
+            - 'groups:read'
+            - 'im:read'
+            - 'mpim:read'
+      tags:
+        - conversations
+  /conversations.members:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve members of a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.members'
+      operationId: conversations_members
+      parameters:
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `conversations:read`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn''t been reached.'
+          in: query
+          name: limit
+          type: integer
+        - description: ID of the conversation to retrieve members for
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical paginated success response
+          examples:
+            application/json:
+              members:
+                - U023BECGF
+                - U061F7AUR
+                - W012A3CDE
+              ok: true
+              response_metadata:
+                next_cursor: e3VzZXJfaWQ6IFcxMjM0NTY3fQ==
+          schema:
+            additionalProperties: true
+            description: Schema for successful response conversations.members method
+            properties:
+              members:
+                items:
+                  $ref: '#/definitions/defs_user_id'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              response_metadata:
+                additionalProperties: true
+                properties:
+                  next_cursor:
+                    type: string
+                required:
+                  - next_cursor
+                type: object
+            required:
+              - ok
+              - members
+              - response_metadata
+            title: conversations.members success schema
+            type: object
+        default:
+          description: Typical error response when an invalid cursor is provided
+          examples:
+            application/json:
+              error: invalid_cursor
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response conversations.members method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_limit
+                  - invalid_cursor
+                  - fetch_members_failed
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: conversations.members error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:read'
+            - 'groups:read'
+            - 'im:read'
+            - 'mpim:read'
+      tags:
+        - conversations
+  /conversations.open:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Opens or resumes a direct message or multi-person direct message.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.open'
+      operationId: conversations_open
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: 'Boolean, indicates you want the full IM channel definition in the response.'
+          in: formData
+          name: return_im
+          type: boolean
+        - description: 'Comma separated lists of users. If only one user is included, this creates a 1:1 DM.  The ordering of the users is preserved whenever a multi-person direct message is returned. Supply a `channel` when not supplying `users`.'
+          in: formData
+          name: users
+          type: string
+        - description: Resume a conversation by supplying an `im` or `mpim`'s ID. Or provide the `users` field instead.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                id: D069C7QFK
+              ok: true
+          schema:
+            additionalProperties: true
+            description: 'Schema for successful response from conversations.open method when opening channels, ims, mpims'
+            properties:
+              already_open:
+                type: boolean
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              no_op:
+                type: boolean
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: conversations.open success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.open method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - user_not_found
+                  - user_not_visible
+                  - user_disabled
+                  - users_list_not_supplied
+                  - not_enough_users
+                  - too_many_users
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - channel_not_found
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: conversations.open error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.rename:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Renames a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.rename'
+      operationId: conversations_rename
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: New name for conversation.
+          in: formData
+          name: name
+          type: string
+        - description: ID of conversation to rename
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                created: 1449252889
+                creator: W012A3BCD
+                id: C012AB3CD
+                is_archived: false
+                is_channel: true
+                is_ext_shared: false
+                is_general: true
+                is_group: false
+                is_im: false
+                is_member: true
+                is_mpim: false
+                is_org_shared: false
+                is_pending_ext_shared: false
+                is_private: false
+                is_read_only: false
+                is_shared: false
+                last_read: '1502126650.228446'
+                locale: en-US
+                name: general
+                name_normalized: general
+                num_members: 23
+                pending_shared: []
+                previous_names:
+                  - specifics
+                  - abstractions
+                  - etc
+                purpose:
+                  creator: W012A3BCD
+                  last_set: 1449709364
+                  value: This part of the workspace is for fun. Make fun here.
+                topic:
+                  creator: W012A3BCD
+                  last_set: 1449709364
+                  value: For public discussion of generalities
+                unlinked: 0
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.rename method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: conversations.rename success schema
+            type: object
+        default:
+          description: Typical error response when the calling user is not a member of the conversation
+          examples:
+            application/json:
+              error: not_in_channel
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.rename method
+            properties:
+              error:
+                enum:
+                  - user_is_restricted
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - channel_not_found
+                  - not_in_channel
+                  - not_authorized
+                  - invalid_name
+                  - name_taken
+                  - invalid_name_required
+                  - invalid_name_punctuation
+                  - invalid_name_maxlength
+                  - invalid_name_specials
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.rename error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.replies:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve a thread of messages posted to a conversation
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.replies'
+      operationId: conversations_replies
+      parameters:
+        - description: Include messages with latest or oldest timestamp in results only when either timestamp is specified.
+          in: query
+          name: inclusive
+          type: boolean
+        - description: Unique identifier of a thread's parent message.
+          in: query
+          name: ts
+          type: number
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `conversations:history`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn''t been reached.'
+          in: query
+          name: limit
+          type: integer
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          type: number
+        - description: Conversation ID to fetch thread from.
+          in: query
+          name: channel
+          type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          type: number
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              has_more: true
+              messages:
+                - last_read: '1484678597.521003'
+                  replies:
+                    - ts: '1483037603.017503'
+                      user: U061F7AUR
+                    - ts: '1483051909.018632'
+                      user: U061F7AUR
+                    - ts: '1483125339.020269'
+                      user: U061F7AUR
+                  reply_count: 3
+                  subscribed: true
+                  text: island
+                  thread_ts: '1482960137.003543'
+                  ts: '1482960137.003543'
+                  type: message
+                  unread_count: 0
+                  user: U061F7AUR
+                - parent_user_id: U061F7AUR
+                  text: one island
+                  thread_ts: '1482960137.003543'
+                  ts: '1483037603.017503'
+                  type: message
+                  user: U061F7AUR
+                - parent_user_id: U061F7AUR
+                  text: two island
+                  thread_ts: '1482960137.003543'
+                  ts: '1483051909.018632'
+                  type: message
+                  user: U061F7AUR
+                - parent_user_id: U061F7AUR
+                  text: three for the land
+                  thread_ts: '1482960137.003543'
+                  ts: '1483125339.020269'
+                  type: message
+                  user: U061F7AUR
+              ok: true
+              response_metadata:
+                next_cursor: bmV4dF90czoxNDg0Njc4MjkwNTE3MDkx
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.replies method
+            properties:
+              has_more:
+                type: boolean
+              messages:
+                items:
+                  items:
+                    - additionalProperties: true
+                      properties:
+                        last_read:
+                          $ref: '#/definitions/defs_ts'
+                        replies:
+                          items:
+                            additionalProperties: true
+                            properties:
+                              ts:
+                                $ref: '#/definitions/defs_ts'
+                              user:
+                                $ref: '#/definitions/defs_user_id'
+                            required:
+                              - user
+                              - ts
+                            type: object
+                          type: array
+                        reply_count:
+                          type: integer
+                        source_team:
+                          $ref: '#/definitions/defs_team'
+                        subscribed:
+                          type: boolean
+                        team:
+                          $ref: '#/definitions/defs_team'
+                        text:
+                          type: string
+                        thread_ts:
+                          $ref: '#/definitions/defs_ts'
+                        ts:
+                          $ref: '#/definitions/defs_ts'
+                        type:
+                          type: string
+                        unread_count:
+                          type: integer
+                        user:
+                          $ref: '#/definitions/defs_user_id'
+                        user_profile:
+                          $ref: '#/definitions/objs_user_profile_short'
+                        user_team:
+                          $ref: '#/definitions/defs_team'
+                      required:
+                        - type
+                        - user
+                        - text
+                        - thread_ts
+                        - reply_count
+                        - replies
+                        - subscribed
+                        - ts
+                      type: object
+                    - additionalProperties: true
+                      properties:
+                        is_starred:
+                          type: boolean
+                        parent_user_id:
+                          $ref: '#/definitions/defs_user_id'
+                        source_team:
+                          $ref: '#/definitions/defs_team'
+                        team:
+                          $ref: '#/definitions/defs_team'
+                        text:
+                          type: string
+                        thread_ts:
+                          $ref: '#/definitions/defs_ts'
+                        ts:
+                          $ref: '#/definitions/defs_ts'
+                        type:
+                          type: string
+                        user:
+                          $ref: '#/definitions/defs_user_id'
+                        user_profile:
+                          $ref: '#/definitions/objs_user_profile_short'
+                        user_team:
+                          $ref: '#/definitions/defs_team'
+                      required:
+                        - type
+                        - user
+                        - text
+                        - thread_ts
+                        - parent_user_id
+                        - ts
+                      type: object
+                type: array
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - messages
+            title: conversations.replies success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: thread_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.replies method
+            properties:
+              error:
+                enum:
+                  - missing_scope
+                  - channel_not_found
+                  - thread_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.replies error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:history'
+            - 'groups:history'
+            - 'im:history'
+            - 'mpim:history'
+      tags:
+        - conversations
+  /conversations.setPurpose:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the purpose for a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.setPurpose'
+      operationId: conversations_setPurpose
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: 'A new, specialer purpose'
+          in: formData
+          name: purpose
+          type: string
+        - description: Conversation to set the purpose of
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.setPurpose method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: conversations.setPurpose success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.setPurpose method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - channel_not_found
+                  - not_in_channel
+                  - is_archived
+                  - too_long
+                  - user_is_restricted
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.setPurpose error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.setTopic:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the topic for a conversation.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.setTopic'
+      operationId: conversations_setTopic
+      parameters:
+        - description: The new topic string. Does not support formatting or linkification.
+          in: formData
+          name: topic
+          type: string
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: Conversation to set the topic of
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.setTopic method
+            properties:
+              channel:
+                $ref: '#/definitions/objs_conversation'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: conversations.setTopic success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.setTopic method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - channel_not_found
+                  - not_in_channel
+                  - is_archived
+                  - too_long
+                  - user_is_restricted
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.setTopic error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /conversations.unarchive:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Reverses conversation archival.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/conversations.unarchive'
+      operationId: conversations_unarchive
+      parameters:
+        - description: 'Authentication token. Requires scope: `conversations:write`'
+          in: header
+          name: token
+          type: string
+        - description: ID of conversation to unarchive
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from conversations.unarchive method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: conversations.unarchive success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from conversations.unarchive method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - channel_not_found
+                  - not_archived
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_restricted
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - team_added_to_org
+                  - missing_charset
+                  - superfluous_charset
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: conversations.unarchive error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:write'
+            - 'groups:write'
+            - 'im:write'
+            - 'mpim:write'
+      tags:
+        - conversations
+  /dialog.open:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Open a dialog with a user
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/dialog.open'
+      operationId: dialog_open
+      parameters:
+        - description: 'Authentication token. Requires scope: `none`'
+          in: header
+          name: token
+          type: string
+        - description: The dialog definition. This must be a JSON-encoded string.
+          in: query
+          name: dialog
+          type: string
+        - description: Exchange a trigger to post to the user.
+          in: query
+          name: trigger_id
+          type: string
+      responses:
+        '200':
+          description: Typical success response is quite minimal.
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: 'Typical error response, before getting to any possible validation errors.'
+          examples:
+            application/json:
+              error: missing_trigger
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - dialog
+  /dnd.endDnd:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Ends the current user's Do Not Disturb session immediately.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/dnd.endDnd'
+      operationId: dnd_endDnd
+      parameters:
+        - description: 'Authentication token. Requires scope: `dnd:write`'
+          in: header
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'dnd:write'
+      tags:
+        - dnd
+  /dnd.endSnooze:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Ends the current user's snooze mode immediately.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/dnd.endSnooze'
+      operationId: dnd_endSnooze
+      parameters:
+        - description: 'Authentication token. Requires scope: `dnd:write`'
+          in: header
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'dnd:write'
+      tags:
+        - dnd
+  /dnd.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieves a user's current Do Not Disturb status.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/dnd.info'
+      operationId: dnd_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `dnd:read`'
+          in: query
+          name: token
+          type: string
+        - description: User to fetch status for (defaults to current user)
+          in: query
+          name: user
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'dnd:read'
+      tags:
+        - dnd
+  /dnd.setSnooze:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: 'Turns on Do Not Disturb mode for the current user, or changes its duration.'
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/dnd.setSnooze'
+      operationId: dnd_setSnooze
+      parameters:
+        - description: 'Number of minutes, from now, to snooze until.'
+          in: formData
+          name: num_minutes
+          type: integer
+        - description: 'Authentication token. Requires scope: `dnd:write`'
+          in: formData
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'dnd:write'
+      tags:
+        - dnd
+  /dnd.teamInfo:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieves the Do Not Disturb status for users on a team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/dnd.teamInfo'
+      operationId: dnd_teamInfo
+      parameters:
+        - description: 'Authentication token. Requires scope: `dnd:read`'
+          in: query
+          name: token
+          type: string
+        - description: Comma-separated list of users to fetch Do Not Disturb status for
+          in: query
+          name: users
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              users:
+                U023BECGF:
+                  dnd_enabled: true
+                  next_dnd_end_ts: 1450423800
+                  next_dnd_start_ts: 1450387800
+                W058CJVAA:
+                  dnd_enabled: false
+                  next_dnd_end_ts: 1
+                  next_dnd_start_ts: 1
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from dnd.teamInfo method
+            properties:
+              cached:
+                type: boolean
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              users:
+                additionalProperties: true
+                type: object
+            required:
+              - ok
+              - users
+            title: dnd.teamInfo success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from dnd.teamInfo method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: dnd.teamInfo error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'dnd:read'
+      tags:
+        - dnd
+  /emoji.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists custom emoji for a team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/emoji.list'
+      operationId: emoji_list
+      parameters:
+        - description: 'Authentication token. Requires scope: `emoji:read`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'emoji:read'
+      tags:
+        - emoji
+  /files.comments.add:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Add a comment to an existing file.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.comments.add'
+      operationId: files_comments_add
+      parameters:
+        - description: Text of the comment to add.
+          in: formData
+          name: comment
+          type: string
+        - description: 'Authentication token. Requires scope: `files:write:user`'
+          in: header
+          name: token
+          type: string
+        - description: File to add a comment to.
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Standard success response
+          examples:
+            application/json:
+              comment:
+                channel: C1234467890
+                comment: Everyone should take a moment to read this file.
+                created: 1356032811
+                id: Fc1234567890
+                timestamp: 1356032811
+                user: U1234567890
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response files.comments.add method
+            properties:
+              comment:
+                $ref: '#/definitions/objs_comment'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - comment
+            title: files.comments.add schema
+            type: object
+        default:
+          description: Artificial error response
+          examples:
+            application/json:
+              error: file_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from files.comments.add method
+            properties:
+              error:
+                enum:
+                  - file_not_found
+                  - file_deleted
+                  - no_comment
+                  - cant_add
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: files.comments.add error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'files:write:user'
+      tags:
+        - files.comments
+        - files
+  /files.comments.delete:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Deletes an existing comment on a file.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.comments.delete'
+      operationId: files_comments_delete
+      parameters:
+        - description: 'Authentication token. Requires scope: `files:write:user`'
+          in: header
+          name: token
+          type: string
+        - description: The comment to delete.
+          in: formData
+          name: id
+          type: string
+        - description: File to delete a comment from.
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Standard success response is very simple
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response files.comments.delete method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: files.comments.delete schema
+            type: object
+        default:
+          description: Standard failure response when used with an invalid token
+          examples:
+            application/json:
+              error: file_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response files.comments.delete method
+            properties:
+              error:
+                enum:
+                  - cant_delete
+                  - comment_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: files.comments.delete error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'files:write:user'
+      tags:
+        - files.comments
+        - files
+  /files.comments.edit:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Edit an existing file comment.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.comments.edit'
+      operationId: files_comments_edit
+      parameters:
+        - description: Text of the comment to edit.
+          in: formData
+          name: comment
+          type: string
+        - description: 'Authentication token. Requires scope: `files:write:user`'
+          in: header
+          name: token
+          type: string
+        - description: The comment to edit.
+          in: formData
+          name: id
+          type: string
+        - description: File containing the comment to edit.
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Standard success response when used with a user token
+          examples:
+            application/json:
+              ok: true
+              team: Subarachnoid Workspace
+              team_id: T12345678
+              url: 'https://subarachnoid.slack.com/'
+              user: grace
+              user_id: W12345678
+          schema:
+            additionalProperties: true
+            description: Schema for successful response files.comments.edit method
+            properties:
+              comment:
+                $ref: '#/definitions/objs_comment'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - comment
+            title: files.comments.edit schema
+            type: object
+        default:
+          description: Standard failure response when used with an invalid token
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response files.comments.edit method
+            properties:
+              error:
+                enum:
+                  - cant_edit
+                  - comment_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: files.comments.edit error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'files:write:user'
+      tags:
+        - files.comments
+        - files
+  /files.delete:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Deletes a file.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.delete'
+      operationId: files_delete
+      parameters:
+        - description: 'Authentication token. Requires scope: `files:write:user`'
+          in: header
+          name: token
+          type: string
+        - description: ID of file to delete.
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response files.delete method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: files.delete schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response files.delete method
+            properties:
+              error:
+                enum:
+                  - file_not_found
+                  - file_deleted
+                  - cant_delete_file
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: files.delete error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'files:write:user'
+      tags:
+        - files
+  /files.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets information about a team file.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.info'
+      operationId: files_info
+      parameters:
+        - in: query
+          name: count
+          type: string
+        - description: 'Authentication token. Requires scope: `files:read`'
+          in: query
+          name: token
+          type: string
+        - description: Specify a file by providing its ID.
+          in: query
+          name: file
+          type: string
+        - in: query
+          name: page
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from files.info method
+            properties:
+              comments:
+                $ref: '#/definitions/objs_comments'
+              file:
+                $ref: '#/definitions/objs_file'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              paging:
+                $ref: '#/definitions/objs_paging'
+            required:
+              - ok
+              - file
+              - comments
+              - paging
+            title: files.info schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from files.info method
+            properties:
+              error:
+                enum:
+                  - file_not_found
+                  - file_deleted
+                  - timezone_count_failed
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: files.info error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'files:read'
+      tags:
+        - files
+  /files.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists & filters team files.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.list'
+      operationId: files_list
+      parameters:
+        - in: query
+          name: count
+          type: string
+        - description: 'Filter files appearing in a specific channel, indicated by its ID.'
+          in: query
+          name: channel
+          type: string
+        - description: Filter files created before this timestamp (inclusive).
+          in: query
+          name: ts_to
+          type: number
+        - description: Filter files created after this timestamp (inclusive).
+          in: query
+          name: ts_from
+          type: number
+        - description: 'Authentication token. Requires scope: `files:read`'
+          in: query
+          name: token
+          type: string
+        - description: Filter files created by a single user.
+          in: query
+          name: user
+          type: string
+        - in: query
+          name: page
+          type: string
+        - description: |-
+            Filter files by type:
+
+            * `all` - All files
+            * `spaces` - Posts
+            * `snippets` - Snippets
+            * `images` - Image files
+            * `gdocs` - Google docs
+            * `zips` - Zip files
+            * `pdfs` - PDF files
+
+            You can pass multiple values in the types argument, like `types=spaces,snippets`.The default value is `all`, which does not filter the list.
+          in: query
+          name: types
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from files.list method
+            properties:
+              files:
+                items:
+                  $ref: '#/definitions/objs_file'
+                minItems: 0
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              paging:
+                $ref: '#/definitions/objs_paging'
+            required:
+              - ok
+              - files
+              - paging
+            title: files.list schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from files.list method
+            properties:
+              error:
+                enum:
+                  - user_not_found
+                  - unknown_type
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: files.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'files:read'
+      tags:
+        - files
+  /files.revokePublicURL:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Revokes public/external sharing access for a file
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.revokePublicURL'
+      operationId: files_revokePublicURL
+      parameters:
+        - description: 'Authentication token. Requires scope: `files:write:user`'
+          in: header
+          name: token
+          type: string
+        - description: File to revoke
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'files:write:user'
+      tags:
+        - files
+  /files.sharedPublicURL:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Enables a file for public/external sharing.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.sharedPublicURL'
+      operationId: files_sharedPublicURL
+      parameters:
+        - description: 'Authentication token. Requires scope: `files:write:user`'
+          in: header
+          name: token
+          type: string
+        - description: File to share
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'files:write:user'
+      tags:
+        - files
+  /files.upload:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Uploads or creates a file.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/files.upload'
+      operationId: files_upload
+      parameters:
+        - description: Comma-separated list of channel names or IDs where the file will be shared.
+          in: formData
+          name: channels
+          type: string
+        - description: Title of file.
+          in: formData
+          name: title
+          type: string
+        - description: Initial comment to add to file.
+          in: formData
+          name: initial_comment
+          type: string
+        - description: 'A [file type](/types/file#file_types) identifier.'
+          in: formData
+          name: filetype
+          type: string
+        - description: Filename of file.
+          in: formData
+          name: filename
+          type: string
+        - description: 'File contents via a POST variable. If omitting this parameter, you must provide a `file`.'
+          in: formData
+          name: content
+          type: string
+        - description: 'Authentication token. Requires scope: `files:write:user`'
+          in: formData
+          name: token
+          type: string
+        - description: 'File contents via `multipart/form-data`. If omitting this parameter, you must submit `content`.'
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response files.upload method
+            properties:
+              file:
+                $ref: '#/definitions/objs_file'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - file
+            title: files.upload schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response files.upload method
+            properties:
+              error:
+                enum:
+                  - posting_to_general_channel_denied
+                  - invalid_channel
+                  - file_uploads_disabled
+                  - file_uploads_except_images_disabled
+                  - storage_limit_reached
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: files.upload error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'files:write:user'
+      tags:
+        - files
+  /groups.archive:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Archives a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.archive'
+      operationId: groups_archive
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Private channel to archive
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from groups.archive method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: groups.archive schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from groups.archive method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - already_archived
+                  - group_contains_others
+                  - restricted_action
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.archive error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.create:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Creates a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.create'
+      operationId: groups_create
+      parameters:
+        - description: Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+          in: formData
+          name: validate
+          type: boolean
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Name of private channel to create
+          in: formData
+          name: name
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response groups.create method
+            properties:
+              group:
+                $ref: '#/definitions/objs_group'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - group
+            title: groups.create success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response groups.create method
+            properties:
+              error:
+                enum:
+                  - no_channel
+                  - restricted_action
+                  - name_taken
+                  - invalid_name_required
+                  - invalid_name_punctuation
+                  - invalid_name_maxlength
+                  - invalid_name_specials
+                  - invalid_name
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.create error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.createChild:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Clones and archives a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.createChild'
+      operationId: groups_createChild
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: formData
+          name: token
+          type: string
+        - description: Private channel to clone and archive.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.history:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Fetches history of messages and events from a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.history'
+      operationId: groups_history
+      parameters:
+        - description: 'Number of messages to return, between 1 and 1000.'
+          in: query
+          name: count
+          type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          type: boolean
+        - description: 'Authentication token. Requires scope: `groups:history`'
+          in: query
+          name: token
+          type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          type: number
+        - description: Private channel to fetch history for.
+          in: query
+          name: channel
+          type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          type: number
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              has_more: false
+              latest: '1358547726.000003'
+              messages:
+                - text: Hello
+                  ts: '1358546515.000008'
+                  type: message
+                  user: U2147483896
+                - is_starred: true
+                  text: World
+                  ts: '1358546515.000007'
+                  type: message
+                  user: U2147483896
+                - ts: '1358546515.000007'
+                  type: something_else
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response groups.history method
+            properties:
+              has_more:
+                type: boolean
+              messages:
+                items:
+                  $ref: '#/definitions/objs_message'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - messages
+              - has_more
+            title: groups.history success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response groups.history method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_ts_latest
+                  - invalid_ts_oldest
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.history error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:history'
+      tags:
+        - groups
+  /groups.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets information about a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.info'
+      operationId: groups_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:read`'
+          in: query
+          name: token
+          type: string
+        - description: Set this to `true` to receive the locale for this group. Defaults to `false`
+          in: query
+          name: include_locale
+          type: boolean
+        - description: Private channel to get info on
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response groups.info method
+            properties:
+              group:
+                $ref: '#/definitions/objs_group'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - group
+            title: groups.info success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response groups.info method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.info error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:read'
+      tags:
+        - groups
+  /groups.invite:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Invites a user to a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.invite'
+      operationId: groups_invite
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: User to invite.
+          in: formData
+          name: user
+          type: string
+        - description: Private channel to invite user to.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response groups.invite method
+            properties:
+              group:
+                $ref: '#/definitions/objs_group'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - group
+            title: groups.invite success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response groups.invite method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - user_not_found
+                  - cant_invite_self
+                  - is_archived
+                  - cant_invite
+                  - ura_max_channels
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - user_is_bot
+                  - user_is_ultra_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.invite error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.kick:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Removes a user from a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.kick'
+      operationId: groups_kick
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: User to remove from private channel.
+          in: formData
+          name: user
+          type: string
+        - description: Private channel to remove user from.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from groups.kick method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: groups.kick schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from groups.kick method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - user_not_found
+                  - cant_kick_self
+                  - not_in_group
+                  - restricted_action
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - user_is_restricted
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.kick error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.leave:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Leaves a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.leave'
+      operationId: groups_leave
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Private channel to leave
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists private channels that the calling user has access to.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.list'
+      operationId: groups_list
+      parameters:
+        - description: Exclude the `members` from each `group`
+          in: query
+          name: exclude_members
+          type: boolean
+        - description: 'Authentication token. Requires scope: `groups:read`'
+          in: query
+          name: token
+          type: string
+        - description: Don't return archived private channels.
+          in: query
+          name: exclude_archived
+          type: boolean
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response groups.list method
+            properties:
+              groups:
+                items:
+                  $ref: '#/definitions/objs_group'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - groups
+            title: groups.list success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response groups.list method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:read'
+      tags:
+        - groups
+  /groups.mark:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the read cursor in a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.mark'
+      operationId: groups_mark
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Timestamp of the most recently seen message.
+          in: formData
+          name: ts
+          type: number
+        - description: Private channel to set reading cursor in.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from groups.mark method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: groups.mark success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from groups.mark method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_timestamp
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.mark error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.open:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Opens a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.open'
+      operationId: groups_open
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Private channel to open.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.rename:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Renames a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.rename'
+      operationId: groups_rename
+      parameters:
+        - description: Whether to return errors on invalid channel name instead of modifying it to meet the specified criteria.
+          in: formData
+          name: validate
+          type: boolean
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: New name for private channel.
+          in: formData
+          name: name
+          type: string
+        - description: Private channel to rename
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.replies:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve a thread of messages posted to a private channel
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.replies'
+      operationId: groups_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message
+          in: query
+          name: thread_ts
+          type: number
+        - description: 'Authentication token. Requires scope: `groups:history`'
+          in: query
+          name: token
+          type: string
+        - description: Private channel to fetch thread from
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              messages:
+                - text: Hello
+                  ts: '1358546515.000008'
+                  type: message
+                  user: U2147483896
+                - is_starred: true
+                  text: World
+                  ts: '1358546515.000007'
+                  type: message
+                  user: U2147483896
+                - ts: '1358546515.000007'
+                  type: something_else
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:history'
+      tags:
+        - groups
+  /groups.setPurpose:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the purpose for a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.setPurpose'
+      operationId: groups_setPurpose
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: The new purpose
+          in: formData
+          name: purpose
+          type: string
+        - description: Private channel to set the purpose of
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from groups.setPurpose method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              purpose:
+                type: string
+            required:
+              - ok
+              - purpose
+            title: groups.setPurpose schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from groups.setPurpose method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - is_archived
+                  - too_long
+                  - user_is_restricted
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.setPurpose error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.setTopic:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the topic for a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.setTopic'
+      operationId: groups_setTopic
+      parameters:
+        - description: The new topic
+          in: formData
+          name: topic
+          type: string
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Private channel to set the topic of
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from groups.setTopic method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              topic:
+                type: string
+            required:
+              - ok
+              - topic
+            title: groups.setTopic schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from groups.setTopic method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - is_archived
+                  - too_long
+                  - user_is_restricted
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: groups.setTopic error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /groups.unarchive:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Unarchives a private channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/groups.unarchive'
+      operationId: groups_unarchive
+      parameters:
+        - description: 'Authentication token. Requires scope: `groups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Private channel to unarchive
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'groups:write'
+      tags:
+        - groups
+  /im.close:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Close a direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/im.close'
+      operationId: im_close
+      parameters:
+        - description: 'Authentication token. Requires scope: `im:write`'
+          in: header
+          name: token
+          type: string
+        - description: Direct message channel to close.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'im:write'
+      tags:
+        - im
+  /im.history:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Fetches history of messages and events from direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/im.history'
+      operationId: im_history
+      parameters:
+        - description: 'Number of messages to return, between 1 and 1000.'
+          in: query
+          name: count
+          type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          type: boolean
+        - description: 'Authentication token. Requires scope: `im:history`'
+          in: query
+          name: token
+          type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          type: number
+        - description: Direct message channel to fetch history for.
+          in: query
+          name: channel
+          type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          type: number
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              has_more: false
+              latest: '1358547726.000003'
+              messages:
+                - text: Hello
+                  ts: '1358546515.000008'
+                  type: message
+                  user: U2147483896
+                - is_starred: true
+                  text: World
+                  ts: '1358546515.000007'
+                  type: message
+                  user: U2147483896
+                - ts: '1358546515.000007'
+                  type: something_else
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from im.history method
+            properties:
+              has_more:
+                type: boolean
+              messages:
+                items:
+                  $ref: '#/definitions/objs_message'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - messages
+              - has_more
+            title: im.history success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from im.history method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_ts_latest
+                  - invalid_ts_oldest
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              needed:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+              provided:
+                type: string
+            required:
+              - ok
+              - error
+            title: im.history error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'im:history'
+      tags:
+        - im
+  /im.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists direct message channels for the calling user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/im.list'
+      operationId: im_list
+      parameters:
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `im:read`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn''t been reached.'
+          in: query
+          name: limit
+          type: integer
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ims:
+                - created: 1449709280
+                  id: D0G9QPY56
+                  is_im: true
+                  is_org_shared: false
+                  is_user_deleted: false
+                  user: USLACKBOT
+                - created: 1466692204
+                  id: D1KL59A72
+                  is_im: true
+                  is_org_shared: false
+                  is_user_deleted: false
+                  user: U0G9QF9C6
+                - created: 1449722883
+                  id: D0G9XPFH9
+                  is_im: true
+                  is_org_shared: false
+                  is_user_deleted: false
+                  user: U0G9WFXNZ
+                - created: 1452098023
+                  id: D0HRHJSF7
+                  is_im: true
+                  is_org_shared: false
+                  is_user_deleted: false
+                  user: W0HRJL7CK
+                - created: 1465834222
+                  id: D1GD7CHC0
+                  is_im: true
+                  is_org_shared: false
+                  is_user_deleted: true
+                  user: U1GDBDGR3
+                - created: 1468274703
+                  id: D1QMF76M9
+                  is_im: true
+                  is_org_shared: false
+                  is_user_deleted: false
+                  user: U1QNSQB9U
+                - created: 1502210225
+                  id: D6K48KKRN
+                  is_im: true
+                  is_org_shared: false
+                  is_user_deleted: false
+                  user: U6KR7BVFW
+              ok: true
+              response_metadata:
+                next_cursor: aW1faWQ6RDBCSDk1RExI=
+          schema:
+            additionalProperties: true
+            description: Schema for successful response im.list method
+            properties:
+              ims:
+                items:
+                  $ref: '#/definitions/objs_im'
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - ims
+            title: im.list success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from im.list method
+            properties:
+              error:
+                enum:
+                  - invalid_cursor
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: im.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'im:read'
+      tags:
+        - im
+  /im.mark:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the read cursor in a direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/im.mark'
+      operationId: im_mark
+      parameters:
+        - description: 'Authentication token. Requires scope: `im:write`'
+          in: header
+          name: token
+          type: string
+        - description: Timestamp of the most recently seen message.
+          in: formData
+          name: ts
+          type: number
+        - description: Direct message channel to set reading cursor in.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response im.mark method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: im.mark success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response im.mark method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_timestamp
+                  - not_in_channel
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: im.mark error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'im:write'
+      tags:
+        - im
+  /im.open:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Opens a direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/im.open'
+      operationId: im_open
+      parameters:
+        - description: 'Authentication token. Requires scope: `im:write`'
+          in: header
+          name: token
+          type: string
+        - description: 'Boolean, indicates you want the full IM channel definition in the response.'
+          in: formData
+          name: return_im
+          type: boolean
+        - description: User to open a direct message channel with.
+          in: formData
+          name: user
+          type: string
+        - description: Set this to `true` to receive the locale for this im. Defaults to `false`
+          in: formData
+          name: include_locale
+          type: boolean
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                id: D947RLWRX
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from im.open method
+            properties:
+              already_open:
+                type: boolean
+              channel:
+                additionalProperties: true
+                properties:
+                  created:
+                    type: string
+                  id:
+                    $ref: '#/definitions/defs_dm_id'
+                  is_im:
+                    type: boolean
+                  is_open:
+                    type: boolean
+                  last_read:
+                    $ref: '#/definitions/defs_ts'
+                  latest:
+                    $ref: '#/definitions/objs_message'
+                  unread_count:
+                    type: number
+                  unread_count_display:
+                    type: number
+                  user:
+                    $ref: '#/definitions/defs_user_id'
+                required:
+                  - id
+                type: object
+              no_op:
+                type: boolean
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - channel
+            title: im.open success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from im.open method
+            properties:
+              error:
+                enum:
+                  - user_not_found
+                  - user_not_visible
+                  - user_disabled
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: im.open error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'im:write'
+      tags:
+        - im
+  /im.replies:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve a thread of messages posted to a direct message conversation
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/im.replies'
+      operationId: im_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message
+          in: query
+          name: thread_ts
+          type: number
+        - description: 'Authentication token. Requires scope: `im:history`'
+          in: query
+          name: token
+          type: string
+        - description: Direct message channel to fetch thread from
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              messages:
+                - text: Hello
+                  ts: '1358546515.000008'
+                  type: message
+                  user: U2147483896
+                - is_starred: true
+                  text: World
+                  ts: '1358546515.000007'
+                  type: message
+                  user: U2147483896
+                - ts: '1358546515.000007'
+                  type: something_else
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'im:history'
+      tags:
+        - im
+  /migration.exchange:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: 'For Enterprise Grid workspaces, map local user IDs to global user IDs'
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/migration.exchange'
+      operationId: migration_exchange
+      parameters:
+        - description: 'Authentication token. Requires scope: `tokens.basic`'
+          in: query
+          name: token
+          type: string
+        - description: Specify `true` to convert `W` global user IDs to workspace-specific `U` IDs. Defaults to `false`.
+          in: query
+          name: to_old
+          type: boolean
+        - description: 'A comma-separated list of user ids, up to 400 per request'
+          in: query
+          name: users
+          type: string
+      responses:
+        '200':
+          description: Typical success response when mappings exist for the specified user IDs
+          examples:
+            application/json:
+              enterprise_id: E1KQTNXE1
+              invalid_user_ids:
+                - U21ABZZXX
+              ok: true
+              team_id: T1KR7PE1W
+              user_id_map:
+                U06UBSUN5: W06M56XJM
+                U06UBSVB3: W06PUUDLY
+                U06UBSVDX: W06PUUDMW
+                U06UEB62U: W06PTT6GH
+                W06UAZ65Q: W06UAZ65Q
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from migration.exchange method
+            properties:
+              enterprise_id:
+                title: The enterprise grid organization ID containing the workspace/team.
+                type: string
+              invalid_user_ids:
+                items:
+                  type: string
+                title: A list of User IDs that cannot be mapped or found
+                type: array
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              team_id:
+                $ref: '#/definitions/defs_team'
+              user_id_map:
+                additionalProperties: true
+                title: A mapping of provided user IDs with mapped user IDs
+                type: object
+            required:
+              - ok
+              - team_id
+              - enterprise_id
+            title: migration.exchange success schema
+            type: object
+        default:
+          description: Typical error response when there are no mappings to provide
+          examples:
+            application/json:
+              error: not_enterprise_team
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from migration.exchange method
+            properties:
+              error:
+                enum:
+                  - not_enterprise_team
+                  - too_many_users
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: migration.exchange error schema
+            type: object
+      security:
+        - slackAuth:
+            - tokens.basic
+      tags:
+        - migration
+  /mpim.close:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Closes a multiparty direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/mpim.close'
+      operationId: mpim_close
+      parameters:
+        - description: 'Authentication token. Requires scope: `mpim:write`'
+          in: header
+          name: token
+          type: string
+        - description: MPIM to close.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'mpim:write'
+      tags:
+        - mpim
+  /mpim.history:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Fetches history of messages and events from a multiparty direct message.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/mpim.history'
+      operationId: mpim_history
+      parameters:
+        - description: 'Number of messages to return, between 1 and 1000.'
+          in: query
+          name: count
+          type: integer
+        - description: Include `unread_count_display` in the output?
+          in: query
+          name: unreads
+          type: boolean
+        - description: Include messages with latest or oldest timestamp in results.
+          in: query
+          name: inclusive
+          type: boolean
+        - description: 'Authentication token. Requires scope: `mpim:history`'
+          in: query
+          name: token
+          type: string
+        - description: Start of time range of messages to include in results.
+          in: query
+          name: oldest
+          type: number
+        - description: Multiparty direct message to fetch history for.
+          in: query
+          name: channel
+          type: string
+        - description: End of time range of messages to include in results.
+          in: query
+          name: latest
+          type: number
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              has_more: false
+              latest: '1358547726.000003'
+              messages:
+                - text: Hello
+                  ts: '1358546515.000008'
+                  type: message
+                  user: U2147483896
+                - is_starred: true
+                  text: World
+                  ts: '1358546515.000007'
+                  type: message
+                  user: U2147483896
+                - ts: '1358546515.000007'
+                  type: something_else
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'mpim:history'
+      tags:
+        - mpim
+  /mpim.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists multiparty direct message channels for the calling user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/mpim.list'
+      operationId: mpim_list
+      parameters:
+        - description: 'Authentication token. Requires scope: `mpim:read`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'mpim:read'
+      tags:
+        - mpim
+  /mpim.mark:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Sets the read cursor in a multiparty direct message channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/mpim.mark'
+      operationId: mpim_mark
+      parameters:
+        - description: 'Authentication token. Requires scope: `mpim:write`'
+          in: header
+          name: token
+          type: string
+        - description: Timestamp of the most recently seen message.
+          in: formData
+          name: ts
+          type: number
+        - description: multiparty direct message channel to set reading cursor in.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from mpim.mark method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: mpim.mark schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from mpim.mark method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - invalid_timestamp
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: mpim.mark error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'mpim:write'
+      tags:
+        - mpim
+  /mpim.open:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: This method opens a multiparty direct message.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/mpim.open'
+      operationId: mpim_open
+      parameters:
+        - description: 'Authentication token. Requires scope: `mpim:write`'
+          in: header
+          name: token
+          type: string
+        - description: Comma separated lists of users.  The ordering of the users is preserved whenever a MPIM group is returned.
+          in: formData
+          name: users
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              channel:
+                id: D024BFF1M
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from mpim.open method
+            properties:
+              group:
+                $ref: '#/definitions/objs_group'
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - group
+            title: mpim.open success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from mpim.open method
+            properties:
+              error:
+                enum:
+                  - users_list_not_supplied
+                  - not_enough_users
+                  - too_many_users
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: mpim.open error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'mpim:write'
+      tags:
+        - mpim
+  /mpim.replies:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve a thread of messages posted to a direct message conversation from a multiparty direct message.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/mpim.replies'
+      operationId: mpim_replies
+      parameters:
+        - description: Unique identifier of a thread's parent message.
+          in: query
+          name: thread_ts
+          type: number
+        - description: 'Authentication token. Requires scope: `mpim:history`'
+          in: query
+          name: token
+          type: string
+        - description: Multiparty direct message channel to fetch thread from.
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              messages:
+                - text: Hello
+                  ts: '1358546515.000008'
+                  type: message
+                  user: U2147483896
+                - is_starred: true
+                  text: World
+                  ts: '1358546515.000007'
+                  type: message
+                  user: U2147483896
+                - ts: '1358546515.000007'
+                  type: something_else
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'mpim:history'
+      tags:
+        - mpim
+  /oauth.access:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Exchanges a temporary OAuth verifier code for an access token.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/oauth.access'
+      operationId: oauth_access
+      parameters:
+        - description: Issued when you created your application.
+          in: query
+          name: client_secret
+          type: string
+        - description: The `code` param returned via the OAuth callback.
+          in: query
+          name: code
+          type: string
+        - description: Request the user to add your app only to a single channel.
+          in: query
+          name: single_channel
+          type: boolean
+        - description: Issued when you created your application.
+          in: query
+          name: client_id
+          type: string
+        - description: This must match the originally submitted URI (if one was sent).
+          in: query
+          name: redirect_uri
+          type: string
+      responses:
+        '200':
+          description: Successful user token negotiation for a single scope
+          examples:
+            application/json:
+              access_token: xoxp-XXXXXXXX-XXXXXXXX-XXXXX
+              scope: 'groups:write'
+              team_id: TXXXXXXXXX
+              team_name: Wyld Stallyns LLC
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_client_id
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - oauth
+  /oauth.token:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Exchanges a temporary OAuth verifier code for a workspace token.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/oauth.token'
+      operationId: oauth_token
+      parameters:
+        - description: Issued when you created your application.
+          in: query
+          name: client_secret
+          type: string
+        - description: The `code` param returned via the OAuth callback.
+          in: query
+          name: code
+          type: string
+        - description: Request the user to add your app only to a single channel.
+          in: query
+          name: single_channel
+          type: boolean
+        - description: Issued when you created your application.
+          in: query
+          name: client_id
+          type: string
+        - description: This must match the originally submitted URI (if one was sent).
+          in: query
+          name: redirect_uri
+          type: string
+      responses:
+        '200':
+          description: Success example using a workspace app produces a very different kind of response
+          examples:
+            application/json:
+              access_token: xoxa-access-token-string
+              app_id: A012345678
+              app_user_id: U0AB12ABC
+              authorizing_user_id: U0HTT3Q0G
+              installer_user_id: U061F7AUR
+              ok: true
+              permissions:
+                - resource_id: 0
+                  resource_type: channel
+                  scopes:
+                    - 'channels:read'
+                    - 'chat:write:user'
+              single_channel_id: C061EG9T2
+              team_id: T061EG9Z9
+              team_name: Subarachnoid Workspace
+              token_type: app
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_client_id
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - none
+      tags:
+        - oauth
+  /pins.add:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Pins an item to a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/pins.add'
+      operationId: pins_add
+      parameters:
+        - description: File comment to pin.
+          in: formData
+          name: file_comment
+          type: string
+        - description: Timestamp of the message to pin.
+          in: formData
+          name: timestamp
+          type: number
+        - description: 'Authentication token. Requires scope: `pins:write`'
+          in: header
+          name: token
+          type: string
+        - description: File to pin.
+          in: formData
+          name: file
+          type: string
+        - description: Channel to pin the item in.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from pins.add method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: pins.add schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: channel_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from pins.add method
+            properties:
+              error:
+                enum:
+                  - bad_timestamp
+                  - file_not_found
+                  - file_comment_not_found
+                  - message_not_found
+                  - channel_not_found
+                  - no_item_specified
+                  - already_pinned
+                  - permission_denied
+                  - file_not_shared
+                  - not_pinnable
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: pins.add error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'pins:write'
+      tags:
+        - pins
+  /pins.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists items pinned to a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/pins.list'
+      operationId: pins_list
+      parameters:
+        - description: 'Authentication token. Requires scope: `pins:read`'
+          in: query
+          name: token
+          type: string
+        - description: Channel to get pinned items for.
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              items:
+                - channel: C2U86NC6H
+                  created: 1508881078
+                  created_by: U2U85N1RZ
+                  message:
+                    permalink: 'https://hitchhikers.slack.com/archives/C2U86NC6H/p1508197641000151'
+                    pinned_to:
+                      - C2U86NC6H
+                    text: What is the meaning of life?
+                    ts: '1508197641.000151'
+                    type: message
+                    user: U2U85N1RZ
+                  type: message
+                - channel: C2U86NC6H
+                  created: 1508880991
+                  created_by: U2U85N1RZ
+                  message:
+                    permalink: 'https://hitchhikers.slack.com/archives/C2U86NC6H/p1508284197000015'
+                    pinned_to:
+                      - C2U86NC6H
+                    text: 'The meaning of life, the universe, and everything is 42.'
+                    ts: '1503289197.000015'
+                    type: message
+                    user: U2U85N1RZ
+                  type: message
+              ok: true
+          schema:
+            description: Schema for successful response from pins.list method
+            items:
+              - additionalProperties: true
+                properties:
+                  items:
+                    items:
+                      - additionalProperties: true
+                        properties:
+                          comment:
+                            $ref: '#/definitions/objs_comment'
+                          created:
+                            type: integer
+                          created_by:
+                            $ref: '#/definitions/defs_user_id'
+                          file:
+                            $ref: '#/definitions/objs_file'
+                          type:
+                            enum:
+                              - file_comment
+                            type: string
+                        title: File Comment Pin
+                        type: object
+                      - additionalProperties: true
+                        properties:
+                          created:
+                            type: integer
+                          created_by:
+                            $ref: '#/definitions/defs_user_id'
+                          file:
+                            $ref: '#/definitions/objs_file'
+                          type:
+                            enum:
+                              - file
+                            type: string
+                        title: File Pin
+                        type: object
+                      - additionalProperties: true
+                        properties:
+                          channel:
+                            $ref: '#/definitions/defs_channel'
+                          created:
+                            type: integer
+                          created_by:
+                            $ref: '#/definitions/defs_user_id'
+                          message:
+                            $ref: '#/definitions/objs_message'
+                          type:
+                            enum:
+                              - message
+                            type: string
+                        title: Message Pin
+                        type: object
+                    type: array
+                    uniqueItems: true
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                required:
+                  - ok
+                  - items
+                type: object
+              - additionalProperties: true
+                properties:
+                  count:
+                    type: integer
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                required:
+                  - ok
+                  - count
+                type: object
+            title: pins.list success schema
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from pins.list method
+            properties:
+              error:
+                enum:
+                  - channel_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: pins.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'pins:read'
+      tags:
+        - pins
+  /pins.remove:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Un-pins an item from a channel.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/pins.remove'
+      operationId: pins_remove
+      parameters:
+        - description: File comment to un-pin.
+          in: formData
+          name: file_comment
+          type: string
+        - description: Timestamp of the message to un-pin.
+          in: formData
+          name: timestamp
+          type: number
+        - description: 'Authentication token. Requires scope: `pins:write`'
+          in: header
+          name: token
+          type: string
+        - description: File to un-pin.
+          in: formData
+          name: file
+          type: string
+        - description: Channel where the item is pinned to.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from pins.remove method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: pins.remove schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: no_pin
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from pins.remove method
+            properties:
+              error:
+                enum:
+                  - bad_timestamp
+                  - file_not_found
+                  - file_comment_not_found
+                  - message_not_found
+                  - no_item_specified
+                  - not_pinned
+                  - permission_denied
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_typ
+                  - missing_post_typ
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeou
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: pins.remove error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'pins:write'
+      tags:
+        - pins
+  /reactions.add:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Adds a reaction to an item.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reactions.add'
+      operationId: reactions_add
+      parameters:
+        - description: Reaction (emoji) name.
+          in: formData
+          name: name
+          type: string
+        - description: File comment to add reaction to.
+          in: formData
+          name: file_comment
+          type: string
+        - description: Timestamp of the message to add reaction to.
+          in: formData
+          name: timestamp
+          type: number
+        - description: 'Authentication token. Requires scope: `reactions:write`'
+          in: header
+          name: token
+          type: string
+        - description: File to add reaction to.
+          in: formData
+          name: file
+          type: string
+        - description: Channel where the message to add reaction to was posted.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from reactions.add method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: reactions.add schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: already_reacted
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from reactions.add method
+            properties:
+              error:
+                enum:
+                  - bad_timestamp
+                  - file_not_found
+                  - file_comment_not_found
+                  - message_not_found
+                  - no_item_specified
+                  - invalid_name
+                  - already_reacted
+                  - too_many_emoji
+                  - too_many_reactions
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: reactions.add error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'reactions:write'
+      tags:
+        - reactions
+  /reactions.get:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets reactions for an item.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reactions.get'
+      operationId: reactions_get
+      parameters:
+        - description: If true always return the complete reaction list.
+          in: query
+          name: full
+          type: boolean
+        - description: File comment to get reactions for.
+          in: query
+          name: file_comment
+          type: string
+        - description: Timestamp of the message to get reactions for.
+          in: query
+          name: timestamp
+          type: number
+        - description: 'Authentication token. Requires scope: `reactions:read`'
+          in: query
+          name: token
+          type: string
+        - description: File to get reactions for.
+          in: query
+          name: file
+          type: string
+        - description: Channel where the message to get reactions for was posted.
+          in: query
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              file:
+                channels:
+                  - C2U7V2YA2
+                comments_count: 1
+                created: 1507850315
+                groups: []
+                id: F7H0D7ZA4
+                ims: []
+                name: computer.gif
+                reactions:
+                  - count: 1
+                    name: stuck_out_tongue_winking_eye
+                    users:
+                      - U2U85N1RV
+                timestamp: 1507850315
+                title: computer.gif
+                user: U2U85N1RV
+              ok: true
+              type: file
+          schema:
+            description: Schema for successful response from reactions.get method
+            items:
+              - additionalProperties: true
+                properties:
+                  channel:
+                    $ref: '#/definitions/defs_channel'
+                  message:
+                    $ref: '#/definitions/objs_message'
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                  type:
+                    enum:
+                      - message
+                    type: string
+                required:
+                  - ok
+                  - type
+                  - channel
+                  - message
+              - additionalProperties: true
+                properties:
+                  file:
+                    $ref: '#/definitions/objs_file'
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                  type:
+                    enum:
+                      - file
+                    type: string
+                required:
+                  - ok
+                  - type
+                  - file
+              - additionalProperties: true
+                properties:
+                  comment:
+                    $ref: '#/definitions/objs_comment'
+                  file:
+                    $ref: '#/definitions/objs_file'
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                  type:
+                    enum:
+                      - file_comment
+                    type: string
+                required:
+                  - ok
+                  - type
+                  - file
+                  - comment
+            title: reactions.get success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from reactions.get method
+            properties:
+              error:
+                enum:
+                  - bad_timestamp
+                  - file_not_found
+                  - file_comment_not_found
+                  - message_not_found
+                  - no_item_specified
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: reactions.get error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'reactions:read'
+      tags:
+        - reactions
+  /reactions.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists reactions made by a user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reactions.list'
+      operationId: reactions_list
+      parameters:
+        - in: query
+          name: count
+          type: string
+        - description: 'Authentication token. Requires scope: `reactions:read`'
+          in: query
+          name: token
+          type: string
+        - description: If true always return the complete reaction list.
+          in: query
+          name: full
+          type: boolean
+        - description: Show reactions made by this user. Defaults to the authed user.
+          in: query
+          name: user
+          type: string
+        - in: query
+          name: page
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              items:
+                - channel: C3UKJTQAC
+                  message:
+                    bot_id: B4VLRLMKJ
+                    reactions:
+                      - count: 1
+                        name: robot_face
+                        users:
+                          - U2U85N1RV
+                    subtype: bot_message
+                    text: 'Hello from Python! :tada:'
+                    ts: '1507849573.000090'
+                    username: Shipit Notifications
+                  type: message
+                - comment:
+                    comment: This is a file comment
+                    created: 1508286096
+                    id: Fc7LP08P1U
+                    reactions:
+                      - count: 1
+                        name: white_check_mark
+                        users:
+                          - U2U85N1RV
+                    timestamp: 1508286096
+                    type: file_comment
+                    user: U2U85N1RV
+                  file:
+                    channels:
+                      - C2U7V2YA2
+                    comments_count: 1
+                    created: 1507850315
+                    reactions:
+                      - count: 1
+                        name: stuck_out_tongue_winking_eye
+                        users:
+                          - U2U85N1RV
+                    title: computer.gif
+                    user: U2U85N1RV
+                    username: ''
+                - file:
+                    channels:
+                      - C2U7V2YA2
+                    comments_count: 1
+                    created: 1507850315
+                    id: F7H0D7ZA4
+                    name: computer.gif
+                    reactions:
+                      - count: 1
+                        name: stuck_out_tongue_winking_eye
+                        users:
+                          - U2U85N1RV
+                    size: 1639034
+                    title: computer.gif
+                    user: U2U85N1RV
+                    username: ''
+                  type: file
+              ok: true
+              paging:
+                count: 100
+                page: 1
+                pages: 1
+                total: 3
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from reactions.list method
+            properties:
+              items:
+                items:
+                  items:
+                    - additionalProperties: true
+                      properties:
+                        channel:
+                          $ref: '#/definitions/defs_channel'
+                        message:
+                          $ref: '#/definitions/objs_message'
+                        type:
+                          enum:
+                            - message
+                          type: string
+                      required:
+                        - type
+                        - channel
+                        - message
+                      type: object
+                    - additionalProperties: true
+                      properties:
+                        file:
+                          $ref: '#/definitions/objs_file'
+                        type:
+                          enum:
+                            - file
+                          type: string
+                      required:
+                        - type
+                        - file
+                      type: object
+                    - additionalProperties: true
+                      properties:
+                        comment:
+                          $ref: '#/definitions/objs_comment'
+                        file:
+                          $ref: '#/definitions/objs_file'
+                        type:
+                          enum:
+                            - file_comment
+                          type: string
+                      required:
+                        - type
+                        - file
+                        - comment
+                      type: object
+                type: array
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              paging:
+                $ref: '#/definitions/objs_paging'
+            required:
+              - ok
+              - items
+            title: reactions.list schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from reactions.list method
+            properties:
+              error:
+                enum:
+                  - user_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactiv
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: reactions.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'reactions:read'
+      tags:
+        - reactions
+  /reactions.remove:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Removes a reaction from an item.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reactions.remove'
+      operationId: reactions_remove
+      parameters:
+        - description: Reaction (emoji) name.
+          in: formData
+          name: name
+          type: string
+        - description: File comment to remove reaction from.
+          in: formData
+          name: file_comment
+          type: string
+        - description: Timestamp of the message to remove reaction from.
+          in: formData
+          name: timestamp
+          type: number
+        - description: 'Authentication token. Requires scope: `reactions:write`'
+          in: header
+          name: token
+          type: string
+        - description: File to remove reaction from.
+          in: formData
+          name: file
+          type: string
+        - description: Channel where the message to remove reaction from was posted.
+          in: formData
+          name: channel
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from reactions.remove method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: reactions.remove schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: no_reaction
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from reactions.remove method
+            properties:
+              error:
+                enum:
+                  - bad_timestamp
+                  - file_not_found
+                  - file_comment_not_found
+                  - message_not_found
+                  - no_item_specified
+                  - invalid_name
+                  - no_reaction
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: reactions.remove error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'reactions:write'
+      tags:
+        - reactions
+  /reminders.add:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Creates a reminder.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reminders.add'
+      operationId: reminders_add
+      parameters:
+        - description: The content of the reminder
+          in: formData
+          name: text
+          type: string
+        - description: 'Authentication token. Requires scope: `reminders:write`'
+          in: header
+          name: token
+          type: string
+        - description: 'The user who will receive the reminder. If no user is specified, the reminder will go to user who created it.'
+          in: formData
+          name: user
+          type: string
+        - description: 'When this reminder should happen: the Unix timestamp (up to five years from now), the number of seconds until the reminder (if within 24 hours), or a natural language description (Ex. "in 15 minutes," or "every Thursday")'
+          in: formData
+          name: time
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'reminders:write'
+      tags:
+        - reminders
+  /reminders.complete:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Marks a reminder as complete.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reminders.complete'
+      operationId: reminders_complete
+      parameters:
+        - description: 'Authentication token. Requires scope: `reminders:write`'
+          in: header
+          name: token
+          type: string
+        - description: The ID of the reminder to be marked as complete
+          in: formData
+          name: reminder
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'reminders:write'
+      tags:
+        - reminders
+  /reminders.delete:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Deletes a reminder.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reminders.delete'
+      operationId: reminders_delete
+      parameters:
+        - description: 'Authentication token. Requires scope: `reminders:write`'
+          in: header
+          name: token
+          type: string
+        - description: The ID of the reminder
+          in: formData
+          name: reminder
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'reminders:write'
+      tags:
+        - reminders
+  /reminders.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets information about a reminder.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reminders.info'
+      operationId: reminders_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `reminders:read`'
+          in: query
+          name: token
+          type: string
+        - description: The ID of the reminder
+          in: query
+          name: reminder
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'reminders:read'
+      tags:
+        - reminders
+  /reminders.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists all reminders created by or for a given user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/reminders.list'
+      operationId: reminders_list
+      parameters:
+        - description: 'Authentication token. Requires scope: `reminders:read`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'reminders:read'
+      tags:
+        - reminders
+  /rtm.connect:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Starts a Real Time Messaging session.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/rtm.connect'
+      operationId: rtm_connect
+      parameters:
+        - description: 'Only deliver presence events when requested by subscription. See [presence subscriptions](/docs/presence-and-status#subscriptions).'
+          in: query
+          name: presence_sub
+          type: boolean
+        - description: 'Authentication token. Requires scope: `rtm:stream`'
+          in: query
+          name: token
+          type: string
+        - description: 'Batch presence deliveries via subscription. Enabling changes the shape of `presence_change` events. See [batch presence](/docs/presence-and-status#batching).'
+          in: query
+          name: batch_presence_aware
+          type: boolean
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              self:
+                id: U4X318ZMZ
+                name: robotoverlord
+              team:
+                domain: slackdemo
+                id: T2U81E2FP
+                name: SlackDemo
+              url: 'wss://...'
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from rtm.connect method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              self:
+                additionalProperties: true
+                properties:
+                  id:
+                    $ref: '#/definitions/defs_user_id'
+                  name:
+                    type: string
+                required:
+                  - id
+                  - name
+                type: object
+              team:
+                additionalProperties: true
+                properties:
+                  domain:
+                    type: string
+                  id:
+                    $ref: '#/definitions/defs_team'
+                  name:
+                    type: string
+                required:
+                  - id
+                  - name
+                  - domain
+                type: object
+              url:
+                format: uri
+                type: string
+            required:
+              - ok
+              - url
+              - team
+              - self
+            title: rtm.connect schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from rtm.connect method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: rtm.connect error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'rtm:stream'
+      tags:
+        - rtm
+  /rtm.start:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Starts a Real Time Messaging session.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/rtm.start'
+      operationId: rtm_start
+      parameters:
+        - description: 'Exclude latest timestamps for channels, groups, mpims, and ims. Automatically sets `no_unreads` to `1`'
+          in: query
+          name: no_latest
+          type: boolean
+        - description: Return timestamp only for latest message object of each channel (improves performance).
+          in: query
+          name: simple_latest
+          type: boolean
+        - description: Set this to `true` to receive the locale for users and channels. Defaults to `false`
+          in: query
+          name: include_locale
+          type: boolean
+        - description: 'Only deliver presence events when requested by subscription. See [presence subscriptions](/docs/presence-and-status#subscriptions).'
+          in: query
+          name: presence_sub
+          type: boolean
+        - description: Skip unread counts for each channel (improves performance).
+          in: query
+          name: no_unreads
+          type: boolean
+        - description: 'Batch presence deliveries via subscription. Enabling changes the shape of `presence_change` events. See [batch presence](/docs/presence-and-status#batching).'
+          in: query
+          name: batch_presence_aware
+          type: boolean
+        - description: Returns MPIMs to the client in the API response.
+          in: query
+          name: mpim_aware
+          type: boolean
+        - description: 'Authentication token. Requires scope: `rtm:stream`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from rtm.start method
+            properties:
+              bots:
+                items: {}
+                type: array
+              cache_ts:
+                type: integer
+              cache_ts_version:
+                type: string
+              cache_version:
+                type: string
+              can_manage_shared_channels:
+                type: boolean
+              channels:
+                items:
+                  $ref: '#/definitions/objs_conversation'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              dead_pig:
+                type: boolean
+              dnd:
+                $ref: '#/definitions/objs_dnd'
+              groups:
+                description: Group objects present for rtm.start. Can be null when there are no groups
+                items:
+                  items:
+                    - type: 'null'
+                    - $ref: '#/definitions/objs_conversation'
+                type: array
+                uniqueItems: true
+              ims:
+                items:
+                  $ref: '#/definitions/objs_conversation'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              latest_event_ts:
+                type: string
+              mpims:
+                description: Mpim objects present for rtm.start. Can be null when there are no mpims
+                items:
+                  items:
+                    - type: 'null'
+                    - $ref: '#/definitions/objs_conversation'
+                type: array
+                uniqueItems: true
+              non_threadable_channels:
+                items: {}
+                type: array
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              read_only_channels:
+                items: {}
+                type: array
+              self:
+                additionalProperties: true
+                properties:
+                  created:
+                    type: integer
+                  id:
+                    type: string
+                  manual_presence:
+                    type: string
+                  name:
+                    type: string
+                  prefs:
+                    $ref: '#/definitions/prefs_prefs'
+                required:
+                  - created
+                  - id
+                  - manual_presence
+                  - prefs
+                type: object
+              subteams:
+                additionalProperties: true
+                properties:
+                  all:
+                    items: {}
+                    type: array
+                  self:
+                    items: {}
+                    type: array
+                required:
+                  - all
+                  - self
+                type: object
+              team:
+                $ref: '#/definitions/objs_team'
+              thread_only_channels:
+                items: {}
+                type: array
+              url:
+                format: uri
+                type: string
+              users:
+                items:
+                  $ref: '#/definitions/objs_user'
+                minItems: 1
+                type: array
+                uniqueItems: true
+            required:
+              - ok
+              - bots
+              - cache_ts
+              - cache_ts_version
+              - can_manage_shared_channels
+              - channels
+              - groups
+              - dnd
+              - ims
+              - latest_event_ts
+              - non_threadable_channels
+              - read_only_channels
+              - self
+              - subteams
+              - thread_only_channels
+              - team
+              - url
+              - users
+            title: rtm.start success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from rtm.start method
+            properties:
+              error:
+                enum:
+                  - migration_in_progress
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: rtm.start error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'rtm:stream'
+      tags:
+        - rtm
+  /search.all:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Searches for messages and files matching a query.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/search.all'
+      operationId: search_all
+      parameters:
+        - description: Change sort direction to ascending (`asc`) or descending (`desc`).
+          in: query
+          name: sort_dir
+          type: string
+        - description: 'Search query. May contains booleans, etc.'
+          in: query
+          name: query
+          type: string
+        - description: Return matches sorted by either `score` or `timestamp`.
+          in: query
+          name: sort
+          type: string
+        - in: query
+          name: count
+          type: string
+        - description: 'Authentication token. Requires scope: `search:read`'
+          in: query
+          name: token
+          type: string
+        - description: Pass a value of `true` to enable query highlight markers (see below).
+          in: query
+          name: highlight
+          type: boolean
+        - in: query
+          name: page
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              files:
+                matches:
+                  - channels: []
+                    comments_count: 1
+                    created: 1508804330
+                    display_as_bot: false
+                    editable: false
+                    external_type: ''
+                    filetype: png
+                    groups: []
+                    id: F7PKF1NR7
+                    image_exif_rotation: 1
+                    ims: []
+                    initial_comment:
+                      comment: Sure! Here's the workflow diagram!
+                      created: 1508804330
+                      id: Fc7NLL52E7
+                      is_intro: true
+                      timestamp: 1508804330
+                      user: U2U85N1RZ
+                    is_external: false
+                    is_public: true
+                    mimetype: image/png
+                    mode: hosted
+                    name: slack workflow diagram.png
+                    original_h: 117
+                    original_w: 128
+                    permalink: 'https://example.slack.com/files/U2U85N1RZ/F7PKF1NR7/slack_workflow_diagram.png'
+                    permalink_public: 'https://slack-files.com/T2U81E2FZ-F7PKF1NR7-bea9143f18'
+                    pretty_type: PNG
+                    public_url_shared: false
+                    score: '0.99982661240974'
+                    size: 35705
+                    thumb_160: 'https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_160.png'
+                    thumb_360: 'https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_360.png'
+                    thumb_360_h: 117
+                    thumb_360_w: 128
+                    thumb_64: 'https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_64.png'
+                    thumb_80: 'https://files.slack.com/files-tmb/T2U81E2FZ-F7PKF1NR7-19f33fc256/slack_workflow_diagram_80.png'
+                    timestamp: 1508804330
+                    title: slack workflow diagram
+                    top_file: false
+                    url_private: 'https://files.slack.com/files-pri/T2U81E2FZ-F7PKF1NR7/slack_workflow_diagram.png'
+                    url_private_download: 'https://files.slack.com/files-pri/T2U81E2FZ-F7PKF1NR7/download/slack_workflow_diagram.png'
+                    user: U2U85N1RZ
+                    username: amy
+                pagination:
+                  first: 1
+                  last: 1
+                  page: 1
+                  page_count: 1
+                  per_page: 20
+                  total_count: 1
+                paging:
+                  count: 20
+                  page: 1
+                  pages: 1
+                  total: 1
+                total: 1
+              messages:
+                matches:
+                  - channel:
+                      id: C2U86NC6M
+                      is_ext_shared: false
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_shared: false
+                      name: general
+                      pending_shared: []
+                    iid: 35692677-e60e-43d9-ac45-1987cea88975
+                    next:
+                      iid: 6f510ea1-e1d3-4f3f-bdb9-f9c6f6e9d609
+                      text: Thanks!
+                      ts: '1508804378.000219'
+                      type: message
+                      user: U2U85HJ7R
+                      username: john
+                    permalink: 'https://example.slack.com/archives/C2U86NC6M/p1508804330000296'
+                    previous:
+                      iid: aba8603c-0543-4fb2-9118-a5ac85f3d138
+                      text: Can you send me the Slack workflow diagram?
+                      ts: '1508804301.000026'
+                      type: message
+                      user: U2U85HJ7R
+                      username: john
+                    team: T2U81E2FZ
+                    text: 'uploaded a file: <https://example.slack.com/files/U2U85N1RZ/F7PKF1NR7/slack_workflow_diagram.png|slack workflow diagram> and commented: Sure! Here''s the workflow diagram!'
+                    ts: '1508804330.000296'
+                    type: message
+                    user: U2U85N1RZ
+                    username: amy
+                pagination:
+                  first: 1
+                  last: 1
+                  page: 1
+                  page_count: 1
+                  per_page: 20
+                  total_count: 1
+                paging:
+                  count: 20
+                  page: 1
+                  pages: 1
+                  total: 1
+                total: 1
+              ok: true
+              posts:
+                matches: []
+                total: 0
+              query: diagram
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: missing_scope
+              needed: 'search:read'
+              ok: false
+              provided: 'identify,bot:basic'
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'search:read'
+      tags:
+        - search
+  /search.files:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Searches for files matching a query.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/search.files'
+      operationId: search_files
+      parameters:
+        - description: Change sort direction to ascending (`asc`) or descending (`desc`).
+          in: query
+          name: sort_dir
+          type: string
+        - description: Search query.
+          in: query
+          name: query
+          type: string
+        - description: Return matches sorted by either `score` or `timestamp`.
+          in: query
+          name: sort
+          type: string
+        - description: Pass a value of `true` to enable query highlight markers (see below).
+          in: query
+          name: highlight
+          type: boolean
+        - in: query
+          name: count
+          type: string
+        - description: 'Authentication token. Requires scope: `search:read`'
+          in: query
+          name: token
+          type: string
+        - in: query
+          name: page
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              files:
+                matches:
+                  - channels: []
+                    comments_count: 1
+                    created: 1507850315
+                    deanimate_gif: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_deanimate_gif.png'
+                    display_as_bot: false
+                    editable: false
+                    external_type: ''
+                    filetype: gif
+                    groups: []
+                    id: F7H0D7ZBB
+                    image_exif_rotation: 1
+                    ims: []
+                    is_external: false
+                    is_public: true
+                    mimetype: image/gif
+                    mode: hosted
+                    name: computer.gif
+                    original_h: 313
+                    original_w: 500
+                    permalink: 'https://eventsdemo.slack.com/files/U2U85N1RZ/F7H0D7ZBB/computer.gif'
+                    permalink_public: 'https://slack-files.com/T2U81E2BB-F7H0D7ZBB-85b7f5557e'
+                    pretty_type: GIF
+                    public_url_shared: false
+                    reactions:
+                      - count: 1
+                        name: stuck_out_tongue_winking_eye
+                        users:
+                          - U2U85N1RZ
+                    score: '0.38899223746309'
+                    size: 1639034
+                    thumb_160: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_160.png'
+                    thumb_360: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_360.png'
+                    thumb_360_gif: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_360.gif'
+                    thumb_360_h: 225
+                    thumb_360_w: 360
+                    thumb_480: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_480.png'
+                    thumb_480_gif: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_480.gif'
+                    thumb_480_h: 300
+                    thumb_480_w: 480
+                    thumb_64: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_64.png'
+                    thumb_80: 'https://files.slack.com/files-tmb/T2U81E2BB-F7H0D7ZBB-21624821e6/computer_80.png'
+                    timestamp: 1507850315
+                    title: computer.gif
+                    top_file: false
+                    url_private: 'https://files.slack.com/files-pri/T2U81E2BB-F7H0D7ZBB/computer.gif'
+                    url_private_download: 'https://files.slack.com/files-pri/T2U81E2BB-F7H0D7ZBB/download/computer.gif'
+                    user: U2U85N1RZ
+                    username: ''
+                pagination:
+                  first: 1
+                  last: 3
+                  page: 1
+                  page_count: 1
+                  per_page: 20
+                  total_count: 3
+                paging:
+                  count: 20
+                  page: 1
+                  pages: 1
+                  total: 3
+                total: 3
+              ok: true
+              query: computer.gif
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: No query passed
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'search:read'
+      tags:
+        - search
+  /search.messages:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Searches for messages matching a query.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/search.messages'
+      operationId: search_messages
+      parameters:
+        - description: Change sort direction to ascending (`asc`) or descending (`desc`).
+          in: query
+          name: sort_dir
+          type: string
+        - description: Search query.
+          in: query
+          name: query
+          type: string
+        - description: Return matches sorted by either `score` or `timestamp`.
+          in: query
+          name: sort
+          type: string
+        - description: Pass the number of results you want per "page". Maximum of `100`.
+          in: query
+          name: count
+          type: string
+        - description: 'Authentication token. Requires scope: `search:read`'
+          in: query
+          name: token
+          type: string
+        - description: Pass a value of `true` to enable query highlight markers (see below).
+          in: query
+          name: highlight
+          type: boolean
+        - in: query
+          name: page
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              messages:
+                matches:
+                  - channel:
+                      id: C12345678
+                      is_ext_shared: false
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_shared: false
+                      name: general
+                      pending_shared: []
+                    iid: cb64bdaa-c1e8-4631-8a91-0f78080113e9
+                    permalink: 'https://hitchhikers.slack.com/archives/C12345678/p1508284197000015'
+                    team: T12345678
+                    text: The meaning of life the universe and everything is 42.
+                    ts: '1508284197.000015'
+                    type: message
+                    user: U2U85N1RV
+                    username: roach
+                  - channel:
+                      id: C12345678
+                      is_ext_shared: false
+                      is_mpim: false
+                      is_org_shared: false
+                      is_pending_ext_shared: false
+                      is_private: false
+                      is_shared: false
+                      name: random
+                      pending_shared: []
+                    iid: 9a00d3c9-bd2d-45b0-988b-6cff99ae2a90
+                    permalink: 'https://hitchhikers.slack.com/archives/C12345678/p1508795665000236'
+                    team: T12345678
+                    text: The meaning of life the universe and everything is 101010
+                    ts: '1508795665.000236'
+                    type: message
+                    user: ''
+                    username: robot overlord
+                pagination:
+                  first: 1
+                  last: 2
+                  page: 1
+                  page_count: 1
+                  per_page: 20
+                  total_count: 2
+                paging:
+                  count: 20
+                  page: 1
+                  pages: 1
+                  total: 2
+                total: 2
+              ok: true
+              query: The meaning of life the universe and everything
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: No query passed
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'search:read'
+      tags:
+        - search
+  /stars.add:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Adds a star to an item.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/stars.add'
+      operationId: stars_add
+      parameters:
+        - description: File comment to add star to.
+          in: formData
+          name: file_comment
+          type: string
+        - description: Timestamp of the message to add star to.
+          in: formData
+          name: timestamp
+          type: number
+        - description: 'Authentication token. Requires scope: `stars:write`'
+          in: header
+          name: token
+          type: string
+        - description: 'Channel to add star to, or channel where the message to add star to was posted (used with `timestamp`).'
+          in: formData
+          name: channel
+          type: string
+        - description: File to add star to.
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'stars:write'
+      tags:
+        - stars
+  /stars.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists stars for a user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/stars.list'
+      operationId: stars_list
+      parameters:
+        - in: query
+          name: count
+          type: string
+        - description: 'Authentication token. Requires scope: `stars:read`'
+          in: query
+          name: token
+          type: string
+        - in: query
+          name: page
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'stars:read'
+      tags:
+        - stars
+  /stars.remove:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Removes a star from an item.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/stars.remove'
+      operationId: stars_remove
+      parameters:
+        - description: File comment to remove star from.
+          in: formData
+          name: file_comment
+          type: string
+        - description: Timestamp of the message to remove star from.
+          in: formData
+          name: timestamp
+          type: number
+        - description: 'Authentication token. Requires scope: `stars:write`'
+          in: header
+          name: token
+          type: string
+        - description: 'Channel to remove star from, or channel where the message to remove star from was posted (used with `timestamp`).'
+          in: formData
+          name: channel
+          type: string
+        - description: File to remove star from.
+          in: formData
+          name: file
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'stars:write'
+      tags:
+        - stars
+  /team.accessLogs:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets the access logs for the current team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/team.accessLogs'
+      operationId: team_accessLogs
+      parameters:
+        - in: query
+          name: count
+          type: string
+        - description: 'Authentication token. Requires scope: `admin`'
+          in: query
+          name: token
+          type: string
+        - in: query
+          name: page
+          type: string
+        - description: End of time range of logs to include in results (inclusive).
+          in: query
+          name: before
+          type: integer
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - admin
+      tags:
+        - team
+  /team.billableInfo:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets billable users information for the current team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/team.billableInfo'
+      operationId: team_billableInfo
+      parameters:
+        - description: 'Authentication token. Requires scope: `admin`'
+          in: query
+          name: token
+          type: string
+        - description: A user to retrieve the billable information for. Defaults to all users.
+          in: query
+          name: user
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - admin
+      tags:
+        - team
+  /team.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets information about the current team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/team.info'
+      operationId: team_info
+      parameters:
+        - description: 'Authentication token. Requires scope: `team:read`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              team:
+                domain: example
+                email_domain: example.com
+                enterprise_id: E1234A12AB
+                enterprise_name: Umbrella Corporation
+                icon:
+                  image_102: 'https://...'
+                  image_132: 'https://...'
+                  image_34: 'https://...'
+                  image_44: 'https://...'
+                  image_68: 'https://...'
+                  image_88: 'https://...'
+                  image_default: true
+                id: T12345
+                name: My Team
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from team.info method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              team:
+                $ref: '#/definitions/objs_team'
+            required:
+              - ok
+              - team
+            title: team.info schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from team.info method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revokedno_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: team.info error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'team:read'
+      tags:
+        - team
+  /team.integrationLogs:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets the integration logs for the current team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/team.integrationLogs'
+      operationId: team_integrationLogs
+      parameters:
+        - in: query
+          name: count
+          type: string
+        - description: Filter logs with this change type. Defaults to all logs.
+          in: query
+          name: change_type
+          type: string
+        - description: Filter logs to this Slack app. Defaults to all logs.
+          in: query
+          name: app_id
+          type: integer
+        - description: 'Authentication token. Requires scope: `admin`'
+          in: query
+          name: token
+          type: string
+        - description: Filter logs generated by this user’s actions. Defaults to all logs.
+          in: query
+          name: user
+          type: string
+        - description: Filter logs to this service. Defaults to all logs.
+          in: query
+          name: service_id
+          type: integer
+        - in: query
+          name: page
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - admin
+      tags:
+        - team
+  /team.profile.get:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieve a team's profile.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/team.profile.get'
+      operationId: team_profile_get
+      parameters:
+        - description: 'Authentication token. Requires scope: `users.profile:read`'
+          in: query
+          name: token
+          type: string
+        - description: Filter by visibility.
+          in: query
+          name: visibility
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              profile:
+                fields:
+                  - hint: Enter the extension to reach your desk
+                    id: Xf06054AAA
+                    is_hidden: 1
+                    label: Phone extension
+                    ordering: 0
+                    type: text
+                  - hint: When you were born
+                    id: Xf06054BBB
+                    label: Date of birth
+                    ordering: 1
+                    type: date
+                  - hint: Enter a link to your Facebook profile
+                    id: Xf06054CCC
+                    label: Facebook
+                    ordering: 2
+                    type: link
+                  - hint: 'Hogwarts, obviously'
+                    id: Xf06054DDD
+                    label: House
+                    ordering: 3
+                    possible_values:
+                      - Gryffindor
+                      - Hufflepuff
+                      - Ravenclaw
+                      - Slytherin
+                    type: options_list
+                  - hint: Office location (LDAP)
+                    id: Xf06054EEE
+                    label: Location
+                    options:
+                      is_protected: 1
+                    ordering: 4
+                    type: text
+                  - hint: The boss
+                    id: Xf06054FFF
+                    label: Manager
+                    ordering: 5
+                    type: user
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from team.profile.get method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              profile:
+                additionalProperties: true
+                properties:
+                  fields:
+                    items:
+                      $ref: '#/definitions/objs_team_profile_field'
+                    minItems: 1
+                    type: array
+                    uniqueItems: true
+                required:
+                  - fields
+                type: object
+            required:
+              - ok
+              - profile
+            title: team.profile.get success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from team.profile.get method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_typ
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeou
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: team.profile.get error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users.profile:read'
+      tags:
+        - team.profile
+        - team
+  /usergroups.create:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Create a User Group
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/usergroups.create'
+      operationId: usergroups_create
+      parameters:
+        - description: 'A mention handle. Must be unique among channels, users and User Groups.'
+          in: formData
+          name: handle
+          type: string
+        - description: A name for the User Group. Must be unique among User Groups.
+          in: formData
+          name: name
+          type: string
+        - description: A comma separated string of encoded channel IDs for which the User Group uses as a default.
+          in: formData
+          name: channels
+          type: string
+        - description: 'Authentication token. Requires scope: `usergroups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Include the number of users in each User Group.
+          in: formData
+          name: include_count
+          type: boolean
+        - description: A short description of the User Group.
+          in: formData
+          name: description
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'usergroups:write'
+      tags:
+        - usergroups
+  /usergroups.disable:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Disable an existing User Group
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/usergroups.disable'
+      operationId: usergroups_disable
+      parameters:
+        - description: 'Authentication token. Requires scope: `usergroups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Include the number of users in the User Group.
+          in: formData
+          name: include_count
+          type: boolean
+        - description: The encoded ID of the User Group to disable.
+          in: formData
+          name: usergroup
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'usergroups:write'
+      tags:
+        - usergroups
+  /usergroups.enable:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Enable a User Group
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/usergroups.enable'
+      operationId: usergroups_enable
+      parameters:
+        - description: 'Authentication token. Requires scope: `usergroups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Include the number of users in the User Group.
+          in: formData
+          name: include_count
+          type: boolean
+        - description: The encoded ID of the User Group to enable.
+          in: formData
+          name: usergroup
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'usergroups:write'
+      tags:
+        - usergroups
+  /usergroups.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: List all User Groups for a team
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/usergroups.list'
+      operationId: usergroups_list
+      parameters:
+        - description: Include the list of users for each User Group.
+          in: query
+          name: include_users
+          type: boolean
+        - description: 'Authentication token. Requires scope: `usergroups:read`'
+          in: query
+          name: token
+          type: string
+        - description: Include the number of users in each User Group.
+          in: query
+          name: include_count
+          type: boolean
+        - description: Include disabled User Groups.
+          in: query
+          name: include_disabled
+          type: boolean
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              usergroups:
+                - auto_type: admin
+                  created_by: USLACKBOT
+                  date_create: 1446598059
+                  date_delete: 0
+                  date_update: 1446670362
+                  description: A group of all Administrators on your team.
+                  handle: admins
+                  id: S0614TZR7
+                  is_external: false
+                  is_usergroup: true
+                  name: Team Admins
+                  prefs:
+                    channels: []
+                    groups: []
+                  team_id: T060RNRCH
+                  updated_by: U060RNRCZ
+                  user_count: '2'
+                - auto_type: owner
+                  created_by: USLACKBOT
+                  date_create: 1446678371
+                  date_delete: 0
+                  date_update: 1446678371
+                  description: A group of all Owners on your team.
+                  handle: owners
+                  id: S06158AV7
+                  is_external: false
+                  is_usergroup: true
+                  name: Team Owners
+                  prefs:
+                    channels: []
+                    groups: []
+                  team_id: T060RNRCH
+                  updated_by: USLACKBOT
+                  user_count: '1'
+                - created_by: U060RNRCZ
+                  date_create: 1446746793
+                  date_delete: 1446748865
+                  date_update: 1446747767
+                  description: 'Marketing gurus, PR experts and product advocates.'
+                  handle: marketing-team
+                  id: S0615G0KT
+                  is_external: false
+                  is_usergroup: true
+                  name: Marketing Team
+                  prefs:
+                    channels: []
+                    groups: []
+                  team_id: T060RNRCH
+                  updated_by: U060RNRCZ
+                  user_count: '0'
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'usergroups:read'
+      tags:
+        - usergroups
+  /usergroups.update:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Update an existing User Group
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/usergroups.update'
+      operationId: usergroups_update
+      parameters:
+        - description: 'A mention handle. Must be unique among channels, users and User Groups.'
+          in: formData
+          name: handle
+          type: string
+        - description: A short description of the User Group.
+          in: formData
+          name: description
+          type: string
+        - description: A comma separated string of encoded channel IDs for which the User Group uses as a default.
+          in: formData
+          name: channels
+          type: string
+        - description: 'Authentication token. Requires scope: `usergroups:write`'
+          in: header
+          name: token
+          type: string
+        - description: Include the number of users in the User Group.
+          in: formData
+          name: include_count
+          type: boolean
+        - description: The encoded ID of the User Group to update.
+          in: formData
+          name: usergroup
+          type: string
+        - description: A name for the User Group. Must be unique among User Groups.
+          in: formData
+          name: name
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              usergroup:
+                created_by: U060R4BJ4
+                date_create: 1447096577
+                date_delete: 0
+                date_update: 1447102109
+                description: 'Marketing gurus, PR experts and product advocates.'
+                handle: marketing-team
+                id: S0616NG6M
+                is_external: false
+                is_usergroup: true
+                name: Marketing Team
+                prefs:
+                  channels: []
+                  groups: []
+                team_id: T060R4BHN
+                updated_by: U060R4BJ4
+                user_count: 1
+                users:
+                  - U060R4BJ4
+                  - U060RNRCZ
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'usergroups:write'
+      tags:
+        - usergroups
+  /usergroups.users.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: List all users in a User Group
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/usergroups.users.list'
+      operationId: usergroups_users_list
+      parameters:
+        - description: 'Authentication token. Requires scope: `usergroups:read`'
+          in: query
+          name: token
+          type: string
+        - description: Allow results that involve disabled User Groups.
+          in: query
+          name: include_disabled
+          type: boolean
+        - description: The encoded ID of the User Group to update.
+          in: query
+          name: usergroup
+          type: string
+      responses:
+        '200':
+          description: Standard success response when used with a user token
+          examples:
+            application/json:
+              ok: true
+              users:
+                - U060R4BJ4
+                - W123A4BC5
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Standard failure response when used with an invalid token
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'usergroups:read'
+      tags:
+        - usergroups.users
+        - usergroups
+  /usergroups.users.update:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Update the list of users for a User Group
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/usergroups.users.update'
+      operationId: usergroups_users_update
+      parameters:
+        - description: Include the number of users in the User Group.
+          in: formData
+          name: include_count
+          type: boolean
+        - description: 'Authentication token. Requires scope: `usergroups:write`'
+          in: header
+          name: token
+          type: string
+        - description: A comma separated string of encoded user IDs that represent the entire list of users for the User Group.
+          in: formData
+          name: users
+          type: string
+        - description: The encoded ID of the User Group to update.
+          in: formData
+          name: usergroup
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              usergroup:
+                created_by: U060R4BJ4
+                date_create: 1447096577
+                date_delete: 0
+                date_update: 1447102109
+                description: 'Marketing gurus, PR experts and product advocates.'
+                handle: marketing-team
+                id: S0616NG6M
+                is_external: false
+                is_usergroup: true
+                name: Marketing Team
+                prefs:
+                  channels: []
+                  groups: []
+                team_id: T060R4BHN
+                updated_by: U060R4BJ4
+                user_count: 1
+                users:
+                  - U060R4BJ4
+                  - U060RNRCZ
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'usergroups:write'
+      tags:
+        - usergroups.users
+        - usergroups
+  /users.conversations:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: List conversations the calling user may access.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.conversations'
+      operationId: users_conversations
+      parameters:
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `conversations:read`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the list hasn''t been reached. Must be an integer no larger than 1000.'
+          in: query
+          name: limit
+          type: integer
+        - description: Browse conversations by a specific user ID's membership. Non-public channels are restricted to those where the calling user shares membership.
+          in: query
+          name: user
+          type: string
+        - description: Set to `true` to exclude archived channels from the list
+          in: query
+          name: exclude_archived
+          type: boolean
+        - description: 'Mix and match channel types by providing a comma-separated list of any combination of `public_channel`, `private_channel`, `mpim`, `im`'
+          in: query
+          name: types
+          type: string
+      responses:
+        '200':
+          description: Typical success response with only public channels. Note how `num_members` and `is_member` are not returned like typical `conversations` objects.
+          examples:
+            application/json:
+              channels:
+                - created: 1449252889
+                  creator: U012A3CDE
+                  id: C012AB3CD
+                  is_archived: false
+                  is_channel: true
+                  is_ext_shared: false
+                  is_general: true
+                  is_group: false
+                  is_im: false
+                  is_mpim: false
+                  is_org_shared: false
+                  is_pending_ext_shared: false
+                  is_private: false
+                  is_shared: false
+                  name: general
+                  name_normalized: general
+                  pending_shared: []
+                  previous_names: []
+                  purpose:
+                    creator: ''
+                    last_set: 0
+                    value: This channel is for team-wide communication and announcements. All team members are in this channel.
+                  topic:
+                    creator: ''
+                    last_set: 0
+                    value: Company-wide announcements and work-based matters
+                  unlinked: 0
+                - created: 1449252889
+                  creator: U061F7AUR
+                  id: C061EG9T2
+                  is_archived: false
+                  is_channel: true
+                  is_ext_shared: false
+                  is_general: false
+                  is_group: false
+                  is_im: false
+                  is_mpim: false
+                  is_org_shared: false
+                  is_pending_ext_shared: false
+                  is_private: false
+                  is_shared: false
+                  name: random
+                  name_normalized: random
+                  pending_shared: []
+                  previous_names: []
+                  purpose:
+                    creator: ''
+                    last_set: 0
+                    value: 'A place for non-work-related flimflam, faffing, hodge-podge or jibber-jabber you''d prefer to keep out of more focused work-related channels.'
+                  topic:
+                    creator: ''
+                    last_set: 0
+                    value: Non-work banter and water cooler conversation
+                  unlinked: 0
+              ok: true
+              response_metadata:
+                next_cursor: dGVhbTpDMDYxRkE1UEI=
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from users.conversations method. Returned conversation objects do not include `num_members` or `is_member`
+            properties:
+              channels:
+                items:
+                  $ref: '#/definitions/objs_conversation'
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              response_metadata:
+                additionalProperties: true
+                properties:
+                  next_cursor:
+                    type: string
+                required:
+                  - next_cursor
+                type: object
+            required:
+              - ok
+              - channels
+            title: users.conversations success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from users.conversations method
+            properties:
+              error:
+                enum:
+                  - method_not_supported_for_channel_type
+                  - missing_scope
+                  - invalid_types
+                  - invalid_cursor
+                  - invalid_limit
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.conversations error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'channels:read'
+            - 'groups:read'
+            - 'im:read'
+            - 'mpim:read'
+      tags:
+        - users
+  /users.deletePhoto:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Delete the user profile photo
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.deletePhoto'
+      operationId: users_deletePhoto
+      parameters:
+        - description: 'Authentication token. Requires scope: `users.profile:write`'
+          in: formData
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'users.profile:write'
+      tags:
+        - users
+  /users.getPresence:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets user presence information.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.getPresence'
+      operationId: users_getPresence
+      parameters:
+        - description: 'Authentication token. Requires scope: `users:read`'
+          in: query
+          name: token
+          type: string
+        - description: User to get presence info on. Defaults to the authed user.
+          in: query
+          name: user
+          type: string
+      responses:
+        '200':
+          description: 'When requesting information for a different user, this method just returns the current presence (either `active` or `away`).'
+          examples:
+            application/json:
+              ok: true
+              presence: active
+          schema:
+            additionalProperties: true
+            description: Generated from users.getPresence with shasum e7251aec575d8863f9e0eb38663ae9dc26655f65
+            properties:
+              auto_away:
+                type: boolean
+              connection_count:
+                type: integer
+              last_activity:
+                type: integer
+              manual_away:
+                type: boolean
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              online:
+                type: boolean
+              presence:
+                type: string
+            required:
+              - ok
+              - presence
+            title: 'API method: users.getPresence'
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties:
+              type: object
+            description: Schema for error response users.getPresence method
+            properties:
+              error:
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.counts error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users:read'
+      tags:
+        - users
+  /users.identity:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Get a user's identity.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.identity'
+      operationId: users_identity
+      parameters:
+        - description: 'Authentication token. Requires scope: `identity.basic`'
+          in: query
+          name: token
+          type: string
+      responses:
+        '200':
+          description: 'You will receive at a minimum the following information:'
+          examples:
+            application/json:
+              ok: true
+              team:
+                id: T0G9PQBBK
+              user:
+                id: U0G9QF9C6
+                name: Sonny Whether
+          schema:
+            description: Schema for successful response from users.identity method
+            items:
+              - additionalProperties: true
+                description: Schema for 'identity.basic' scope
+                properties:
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                  team:
+                    additionalProperties: true
+                    properties:
+                      id:
+                        $ref: '#/definitions/defs_team'
+                    required:
+                      - id
+                    type: object
+                  user:
+                    additionalProperties: true
+                    properties:
+                      id:
+                        $ref: '#/definitions/defs_user_id'
+                      name:
+                        type: string
+                    required:
+                      - name
+                      - id
+                    type: object
+                required:
+                  - ok
+                  - user
+                  - team
+                type: object
+              - additionalProperties: true
+                description: 'Schema for ''identity.basic,identity.email'' scopes'
+                properties:
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                  team:
+                    additionalProperties: true
+                    properties:
+                      id:
+                        $ref: '#/definitions/defs_team'
+                    required:
+                      - id
+                    type: object
+                  user:
+                    additionalProperties: true
+                    properties:
+                      email:
+                        format: email
+                        type: string
+                      id:
+                        $ref: '#/definitions/defs_user_id'
+                      name:
+                        type: string
+                    required:
+                      - name
+                      - id
+                      - email
+                    type: object
+                required:
+                  - ok
+                  - user
+                  - team
+                type: object
+              - additionalProperties: true
+                description: 'Schema for ''identity.basic,identity.avatar'' scopes'
+                properties:
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                  team:
+                    additionalProperties: true
+                    properties:
+                      id:
+                        $ref: '#/definitions/defs_team'
+                    required:
+                      - id
+                    type: object
+                  user:
+                    additionalProperties: true
+                    properties:
+                      id:
+                        $ref: '#/definitions/defs_user_id'
+                      image_192:
+                        format: url
+                        type: string
+                      image_24:
+                        format: url
+                        type: string
+                      image_32:
+                        format: url
+                        type: string
+                      image_48:
+                        format: url
+                        type: string
+                      image_512:
+                        format: url
+                        type: string
+                      image_72:
+                        format: url
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - name
+                      - id
+                      - image_24
+                      - image_32
+                      - image_48
+                      - image_72
+                      - image_192
+                      - image_512
+                    type: object
+                required:
+                  - ok
+                  - user
+                  - team
+                type: object
+              - additionalProperties: true
+                description: 'Schema for ''identity.basic,identity.team'' scopes'
+                properties:
+                  ok:
+                    $ref: '#/definitions/defs_ok_true'
+                  team:
+                    additionalProperties: true
+                    properties:
+                      domain:
+                        type: string
+                      id:
+                        $ref: '#/definitions/defs_team'
+                      image_102:
+                        format: url
+                        type: string
+                      image_132:
+                        format: url
+                        type: string
+                      image_230:
+                        format: url
+                        type: string
+                      image_34:
+                        format: url
+                        type: string
+                      image_44:
+                        format: url
+                        type: string
+                      image_68:
+                        format: url
+                        type: string
+                      image_88:
+                        format: url
+                        type: string
+                      image_default:
+                        type: boolean
+                      name:
+                        type: string
+                    required:
+                      - id
+                      - name
+                      - domain
+                      - image_34
+                      - image_44
+                      - image_68
+                      - image_88
+                      - image_102
+                      - image_132
+                      - image_230
+                      - image_default
+                    type: object
+                  user:
+                    additionalProperties: true
+                    properties:
+                      id:
+                        $ref: '#/definitions/defs_user_id'
+                      name:
+                        type: string
+                    required:
+                      - name
+                      - id
+                    type: object
+                required:
+                  - ok
+                  - user
+                  - team
+                type: object
+            title: users.identity schema
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: account_inactive
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from users.identity method
+            properties:
+              error:
+                enum:
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.identity error schema
+            type: object
+      security:
+        - slackAuth:
+            - identity.basic
+      tags:
+        - users
+  /users.info:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Gets information about a user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.info'
+      operationId: users_info
+      parameters:
+        - description: Set this to `true` to receive the locale for this user. Defaults to `false`
+          in: query
+          name: include_locale
+          type: boolean
+        - description: 'Authentication token. Requires scope: `users:read`'
+          in: query
+          name: token
+          type: string
+        - description: User to get info on
+          in: query
+          name: user
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              user:
+                color: 9f69e7
+                deleted: false
+                has_2fa: false
+                id: W012A3CDE
+                is_admin: true
+                is_app_user: false
+                is_bot: false
+                is_owner: false
+                is_primary_owner: false
+                is_restricted: false
+                is_ultra_restricted: false
+                name: spengler
+                profile:
+                  avatar_hash: ge3b51ca72de
+                  display_name: spengler
+                  display_name_normalized: spengler
+                  email: spengler@ghostbusters.example.com
+                  image_192: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_24: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_32: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_48: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_512: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_72: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  real_name: Egon Spengler
+                  real_name_normalized: Egon Spengler
+                  status_emoji: ':books:'
+                  status_text: Print is dead
+                  team: T012AB3C4
+                real_name: Egon Spengler
+                team_id: T012AB3C4
+                tz: America/Los_Angeles
+                tz_label: Pacific Daylight Time
+                tz_offset: -25200
+                updated: 1502138686
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from users.info method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              user:
+                $ref: '#/definitions/objs_user'
+            required:
+              - ok
+              - user
+            title: users.info success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: user_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from users.info method
+            properties:
+              error:
+                enum:
+                  - user_not_found
+                  - user_not_visible
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.info error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users:read'
+      tags:
+        - users
+  /users.list:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Lists all users in a Slack team.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.list'
+      operationId: users_list
+      parameters:
+        - description: 'Deprecated. Whether to include presence data in the output. Defaults to `false`. Setting this to `true` reduces performance, especially with large teams.'
+          in: query
+          name: presence
+          type: boolean
+        - description: 'Paginate through collections of data by setting the `cursor` parameter to a `next_cursor` attribute returned by a previous request''s `response_metadata`. Default value fetches the first "page" of the collection. See [pagination](/docs/pagination) for more detail.'
+          in: query
+          name: cursor
+          type: string
+        - description: 'Authentication token. Requires scope: `users:read`'
+          in: query
+          name: token
+          type: string
+        - description: 'The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn''t been reached.'
+          in: query
+          name: limit
+          type: integer
+        - description: Set this to `true` to receive the locale for users. Defaults to `false`
+          in: query
+          name: include_locale
+          type: boolean
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              cache_ts: 1498777272
+              members:
+                - color: 9f69e7
+                  deleted: false
+                  has_2fa: false
+                  id: W012A3CDE
+                  is_admin: true
+                  is_app_user: false
+                  is_bot: false
+                  is_owner: false
+                  is_primary_owner: false
+                  is_restricted: false
+                  is_ultra_restricted: false
+                  name: spengler
+                  profile:
+                    avatar_hash: ge3b51ca72de
+                    display_name: spengler
+                    display_name_normalized: spengler
+                    email: spengler@ghostbusters.example.com
+                    image_192: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                    image_24: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                    image_32: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                    image_48: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                    image_512: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                    image_72: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                    real_name: Egon Spengler
+                    real_name_normalized: Egon Spengler
+                    status_emoji: ':books:'
+                    status_text: Print is dead
+                    team: T012AB3C4
+                  real_name: spengler
+                  team_id: T012AB3C4
+                  tz: America/Los_Angeles
+                  tz_label: Pacific Daylight Time
+                  tz_offset: -25200
+                  updated: 1502138686
+                - color: 9f69e7
+                  deleted: false
+                  has_2fa: false
+                  id: W07QCRPA4
+                  is_admin: true
+                  is_bot: false
+                  is_owner: false
+                  is_primary_owner: false
+                  is_restricted: false
+                  is_ultra_restricted: false
+                  name: glinda
+                  profile:
+                    avatar_hash: 8fbdd10b41c6
+                    display_name: Glinda the Fairly Good
+                    display_name_normalized: Glinda the Fairly Good
+                    email: glenda@south.oz.coven
+                    first_name: Glinda
+                    image_1024: 'https://a.slack-edge.com...png'
+                    image_192: 'https://a.slack-edge.com...png'
+                    image_24: 'https://a.slack-edge.com...png'
+                    image_32: 'https://a.slack-edge.com...png'
+                    image_48: 'https://a.slack-edge.com...png'
+                    image_512: 'https://a.slack-edge.com...png'
+                    image_72: 'https://a.slack-edge.com...png'
+                    image_original: 'https://a.slack-edge.com...png'
+                    last_name: Southgood
+                    phone: ''
+                    real_name: Glinda Southgood
+                    real_name_normalized: Glinda Southgood
+                    skype: ''
+                    title: Glinda the Good
+                  real_name: Glinda Southgood
+                  team_id: T0G9PQBBK
+                  tz: America/Los_Angeles
+                  tz_label: Pacific Daylight Time
+                  tz_offset: -25200
+                  updated: 1480527098
+              ok: true
+              response_metadata:
+                next_cursor: dXNlcjpVMEc5V0ZYTlo=
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from users.list method
+            properties:
+              cache_ts:
+                type: integer
+              members:
+                items:
+                  $ref: '#/definitions/objs_user'
+                minItems: 1
+                type: array
+                uniqueItems: true
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+              - members
+              - cache_ts
+            title: users.list schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_cursor
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from users.list method
+            properties:
+              error:
+                enum:
+                  - invalid_cursor
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.list error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users:read'
+      tags:
+        - users
+  /users.lookupByEmail:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Find a user with an email address.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.lookupByEmail'
+      operationId: users_lookupByEmail
+      parameters:
+        - description: 'Authentication token. Requires scope: `users:read.email`'
+          in: query
+          name: token
+          type: string
+        - description: An email address belonging to a user in the workspace
+          in: query
+          name: email
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              user:
+                color: 9f69e7
+                deleted: false
+                has_2fa: false
+                id: W012A3CDE
+                is_admin: true
+                is_app_user: false
+                is_bot: false
+                is_owner: false
+                is_primary_owner: false
+                is_restricted: false
+                is_ultra_restricted: false
+                name: spengler
+                profile:
+                  avatar_hash: ge3b51ca72de
+                  display_name: spengler
+                  display_name_normalized: spengler
+                  email: spengler@ghostbusters.example.com
+                  image_192: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_24: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_32: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_48: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_512: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  image_72: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                  real_name: Egon Spengler
+                  real_name_normalized: Egon Spengler
+                  status_emoji: ':books:'
+                  status_text: Print is dead
+                  team: T012AB3C4
+                real_name: Egon Spengler
+                team_id: T012AB3C4
+                tz: America/Los_Angeles
+                tz_label: Pacific Daylight Time
+                tz_offset: -25200
+                updated: 1502138686
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from users.lookupByEmail method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              user:
+                $ref: '#/definitions/objs_user'
+            required:
+              - ok
+              - user
+            title: users.lookupByEmail success schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: users_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from users.lookupByEmail method
+            properties:
+              error:
+                enum:
+                  - users_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - no_permission
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.lookupByEmail error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users:read.email'
+      tags:
+        - users
+  /users.profile.get:
+    get:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Retrieves a user's profile information.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.profile.get'
+      operationId: users_profile_get
+      parameters:
+        - description: 'Authentication token. Requires scope: `users.profile:read`'
+          in: query
+          name: token
+          type: string
+        - description: Include labels for each ID in custom profile fields
+          in: query
+          name: include_labels
+          type: boolean
+        - description: User to retrieve profile info for
+          in: query
+          name: user
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              profile:
+                avatar_hash: ge3b51ca72de
+                display_name: spengler
+                display_name_normalized: spengler
+                email: spengler@ghostbusters.example.com
+                image_192: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_24: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_32: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_48: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_512: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_72: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                real_name: Egon Spengler
+                real_name_normalized: Egon Spengler
+                status_emoji: ':books:'
+                status_text: Print is dead
+                team: T012AB3C4
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from users.profile.get method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              profile:
+                $ref: '#/definitions/objs_user_profile'
+            required:
+              - ok
+              - profile
+            title: users.profile.get schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: user_not_found
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from users.profile.get method
+            properties:
+              error:
+                enum:
+                  - user_not_found
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.profile.get error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users.profile:read'
+      tags:
+        - users.profile
+        - users
+  /users.profile.set:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Set the profile information for a user.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.profile.set'
+      operationId: users_profile_set
+      parameters:
+        - description: 'Collection of key:value pairs presented as a URL-encoded JSON hash.'
+          in: formData
+          name: profile
+          type: string
+        - description: 'Authentication token. Requires scope: `users.profile:write`'
+          in: header
+          name: token
+          type: string
+        - description: ID of user to change. This argument may only be specified by team admins on paid teams.
+          in: formData
+          name: user
+          type: string
+        - description: Value to set a single key to. Usable only if `profile` is not passed.
+          in: formData
+          name: value
+          type: string
+        - description: Name of a single key to set. Usable only if `profile` is not passed.
+          in: formData
+          name: name
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+              profile:
+                avatar_hash: ge3b51ca72de
+                display_name: spengler
+                display_name_normalized: spengler
+                email: spengler@ghostbusters.example.com
+                image_192: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_24: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_32: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_48: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_512: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                image_72: 'https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg'
+                real_name: Egon Spengler
+                real_name_normalized: Egon Spengler
+                status_emoji: ':books:'
+                status_text: Print is dead
+                team: T012AB3C4
+          schema:
+            additionalProperties: true
+            description: Schema for successful response from users.profile.set method
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+              profile:
+                $ref: '#/definitions/objs_user_profile'
+              username:
+                type: string
+            required:
+              - ok
+              - username
+              - profile
+            title: users.profile.set schema
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_profile
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Schema for error response from users.profile.set method
+            properties:
+              error:
+                enum:
+                  - reserved_name
+                  - invalid_profile
+                  - profile_set_failed
+                  - not_admin
+                  - not_app_admin
+                  - cannot_update_admin_user
+                  - not_authed
+                  - invalid_auth
+                  - account_inactive
+                  - token_revoked
+                  - no_permission
+                  - org_login_required
+                  - user_is_bot
+                  - invalid_arg_name
+                  - invalid_array_arg
+                  - invalid_charset
+                  - invalid_form_data
+                  - invalid_post_type
+                  - missing_post_type
+                  - team_added_to_org
+                  - invalid_json
+                  - json_not_object
+                  - request_timeout
+                  - upgrade_required
+                  - fatal_error
+                type: string
+              ok:
+                $ref: '#/definitions/defs_ok_false'
+            required:
+              - ok
+              - error
+            title: users.profile.set error schema
+            type: object
+      security:
+        - slackAuth:
+            - 'users.profile:write'
+      tags:
+        - users.profile
+        - users
+  /users.setActive:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Marked a user as active. Deprecated and non-functional.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.setActive'
+      operationId: users_setActive
+      parameters:
+        - description: 'Authentication token. Requires scope: `users:write`'
+          in: header
+          name: token
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'users:write'
+      tags:
+        - users
+  /users.setPhoto:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      description: Set the user profile photo
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.setPhoto'
+      operationId: users_setPhoto
+      parameters:
+        - description: File contents via `multipart/form-data`.
+          in: formData
+          name: image
+          type: string
+        - description: Width/height of crop box (always square)
+          in: formData
+          name: crop_w
+          type: integer
+        - description: 'Authentication token. Requires scope: `users.profile:write`'
+          in: formData
+          name: token
+          type: string
+        - description: Y coordinate of top-left corner of crop box
+          in: formData
+          name: crop_y
+          type: integer
+        - description: X coordinate of top-left corner of crop box
+          in: formData
+          name: crop_x
+          type: integer
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'users.profile:write'
+      tags:
+        - users
+  /users.setPresence:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/json
+      description: Manually sets user presence.
+      externalDocs:
+        description: API method documentation
+        url: 'https://api.slack.com/methods/users.setPresence'
+      operationId: users_setPresence
+      parameters:
+        - description: 'Authentication token. Requires scope: `users:write`'
+          in: header
+          name: token
+          type: string
+        - description: Either `auto` or `away`
+          in: formData
+          name: presence
+          type: string
+      responses:
+        '200':
+          description: Typical success response
+          examples:
+            application/json:
+              ok: true
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default success template
+            type: object
+        default:
+          description: Typical error response
+          examples:
+            application/json:
+              error: invalid_auth
+              ok: false
+          schema:
+            additionalProperties: true
+            description: Verbose schema not yet ready for this method.
+            properties:
+              ok:
+                $ref: '#/definitions/defs_ok_true'
+            required:
+              - ok
+            title: Default error template
+            type: object
+      security:
+        - slackAuth:
+            - 'users:write'
+      tags:
+        - users
+definitions:
+  defs_app_id:
+    pattern: '^A[A-Z0-9]{8}$'
+    title: App ID
+    type: string
+  defs_bot_id:
+    pattern: '^B[A-Z0-9]{8}$'
+    title: Bot User ID
+    type: string
+  defs_channel:
+    pattern: '^[CGD][A-Z0-9]{8}$'
+    title: Channel-like conversation ID
+    type: string
+  defs_channel_id:
+    pattern: '^[C][A-Z0-9]{8}$'
+    title: Channel ID
+    type: string
+  defs_channel_name:
+    title: Name of a channel
+    type: string
+  defs_comment_id:
+    pattern: '^Fc[A-Z0-9]{8}$'
+    title: File Comment ID
+    type: string
+  defs_dm_id:
+    pattern: '^[D][A-Z0-9]{8}$'
+    title: Direct Message Channel ID
+    type: string
+  defs_file_id:
+    pattern: '^[F][A-Z0-9]{8}$'
+    title: File ID
+    type: string
+  defs_group_id:
+    pattern: '^[G][A-Z0-9]{8}$'
+    title: Private Channel ID
+    type: string
+  defs_invite_id:
+    title: Invite ID for an external shared channel
+    type: integer
+  defs_ok_false:
+    enum:
+      - false
+    title: default failure response
+    type: boolean
+  defs_ok_true:
+    enum:
+      - true
+    title: default success response
+    type: boolean
+  defs_pinned_info:
+    additionalProperties:
+      additionalProperties: true
+      properties:
+        pinned_by:
+          $ref: '#/definitions/defs_user_id'
+        pinned_ts:
+          type: integer
+      required:
+        - pinned_by
+        - pinned_ts
+      type: object
+    title: Info for a pinned item
+    type: object
+  defs_room_id:
+    pattern: '^[R][A-Z0-9]{8}$'
+    title: Room ID for a slack call
+    type: string
+  defs_team:
+    pattern: '^[T][A-Z0-9]{8}$'
+    title: Team ID
+    type: string
+  defs_topic_purpose_creator:
+    pattern: '^[UW][A-Z0-9]{8}$|^$'
+    title: 'User ID or empty string, used for topic and purpose creation'
+    type: string
+  defs_ts:
+    pattern: '^\d{10}\.\d{6}$'
+    title: Timestamp in format 0123456789.012345
+    type: string
+  defs_user_id:
+    pattern: '^[UW][A-Z0-9]{8}$'
+    title: User ID
+    type: string
+  objs_channel:
+    additionalProperties: true
+    properties:
+      accepted_user:
+        $ref: '#/definitions/defs_user_id'
+      created:
+        type: integer
+      creator:
+        $ref: '#/definitions/defs_user_id'
+      id:
+        $ref: '#/definitions/defs_channel_id'
+      is_archived:
+        type: boolean
+      is_channel:
+        type: boolean
+      is_general:
+        type: boolean
+      is_member:
+        type: boolean
+      is_moved:
+        type: integer
+      is_mpim:
+        type: boolean
+      is_org_shared:
+        type: boolean
+      is_pending_ext_shared:
+        type: boolean
+      is_private:
+        type: boolean
+      is_read_only:
+        type: boolean
+      is_shared:
+        type: boolean
+      last_read:
+        $ref: '#/definitions/defs_ts'
+      latest:
+        items:
+          - $ref: '#/definitions/objs_message'
+          - type: 'null'
+      members:
+        items:
+          $ref: '#/definitions/defs_user_id'
+        minItems: 0
+        type: array
+        uniqueItems: true
+      name:
+        type: string
+      name_normalized:
+        type: string
+      num_members:
+        type: integer
+      pending_shared:
+        items:
+          $ref: '#/definitions/defs_team'
+        minItems: 0
+        type: array
+        uniqueItems: true
+      previous_names:
+        items:
+          $ref: '#/definitions/defs_channel_name'
+        minItems: 0
+        type: array
+        uniqueItems: true
+      priority:
+        type: integer
+      purpose:
+        additionalProperties: true
+        properties:
+          creator:
+            $ref: '#/definitions/defs_topic_purpose_creator'
+          last_set:
+            type: integer
+          value:
+            type: string
+        required:
+          - value
+          - creator
+          - last_set
+        type: object
+      topic:
+        additionalProperties: true
+        properties:
+          creator:
+            $ref: '#/definitions/defs_topic_purpose_creator'
+          last_set:
+            type: integer
+          value:
+            type: string
+        required:
+          - value
+          - creator
+          - last_set
+        type: object
+      unlinked:
+        title: Field to determine whether a channel has ever been shared/disconnected in the past
+        type: integer
+      unread_count:
+        type: integer
+      unread_count_display:
+        type: integer
+    required:
+      - id
+      - name
+      - created
+      - creator
+      - is_channel
+      - is_org_shared
+      - is_private
+      - is_mpim
+      - is_shared
+      - name_normalized
+      - members
+      - topic
+      - purpose
+    title: Channel Object
+    type: object
+  objs_comment:
+    additionalProperties: true
+    properties:
+      comment:
+        type: string
+      created:
+        type: integer
+      id:
+        $ref: '#/definitions/defs_comment_id'
+      is_intro:
+        type: boolean
+      pinned_info:
+        $ref: '#/definitions/defs_pinned_info'
+      pinned_to:
+        items:
+          $ref: '#/definitions/defs_channel'
+        type: array
+      reactions:
+        items:
+          $ref: '#/definitions/objs_reaction'
+        type: array
+      timestamp:
+        type: integer
+      user:
+        type: string
+    title: File Comment Object
+    type: object
+  objs_comments:
+    items: {}
+    title: file comments object
+    type: array
+  objs_conversation:
+    items:
+      - additionalProperties: true
+        properties:
+          accepted_user:
+            $ref: '#/definitions/defs_user_id'
+          created:
+            type: integer
+          creator:
+            $ref: '#/definitions/defs_user_id'
+          display_counts:
+            additionalProperties: true
+            properties:
+              display_counts:
+                type: integer
+              guest_counts:
+                type: integer
+            required:
+              - display_counts
+              - guest_counts
+            type: object
+          has_pins:
+            type: boolean
+          id:
+            $ref: '#/definitions/defs_channel'
+          is_archived:
+            type: boolean
+          is_channel:
+            type: boolean
+          is_ext_shared:
+            type: boolean
+          is_general:
+            type: boolean
+          is_group:
+            type: boolean
+          is_im:
+            type: boolean
+          is_member:
+            type: boolean
+          is_moved:
+            type: integer
+          is_mpim:
+            enum:
+              - false
+            type: boolean
+          is_open:
+            type: boolean
+          is_org_shared:
+            type: boolean
+          is_pending_ext_shared:
+            type: boolean
+          is_private:
+            type: boolean
+          is_read_only:
+            type: boolean
+          is_shared:
+            type: boolean
+          last_read:
+            $ref: '#/definitions/defs_ts'
+          latest:
+            items:
+              - $ref: '#/definitions/objs_message'
+              - type: 'null'
+          members:
+            items:
+              $ref: '#/definitions/defs_user_id'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          name:
+            type: string
+          name_normalized:
+            type: string
+          num_members:
+            type: integer
+          pending_shared:
+            items:
+              $ref: '#/definitions/defs_team'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          pin_count:
+            type: integer
+          previous_names:
+            items:
+              $ref: '#/definitions/defs_channel_name'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          priority:
+            type: integer
+          purpose:
+            additionalProperties: true
+            properties:
+              creator:
+                $ref: '#/definitions/defs_topic_purpose_creator'
+              last_set:
+                type: integer
+              value:
+                type: string
+            required:
+              - value
+              - creator
+              - last_set
+            type: object
+          shared_team_ids:
+            items:
+              $ref: '#/definitions/defs_team'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          shares:
+            items:
+              additionalProperties: true
+              properties:
+                accepted_user:
+                  $ref: '#/definitions/defs_user_id'
+                is_active:
+                  type: boolean
+                team:
+                  $ref: '#/definitions/objs_team'
+                user:
+                  $ref: '#/definitions/defs_user_id'
+              required:
+                - team
+                - user
+                - accepted_user
+                - is_active
+              type: object
+            minItems: 0
+            type: array
+            uniqueItems: true
+          timezone_count:
+            type: integer
+          topic:
+            additionalProperties: true
+            properties:
+              creator:
+                $ref: '#/definitions/defs_topic_purpose_creator'
+              last_set:
+                type: integer
+              value:
+                type: string
+            required:
+              - value
+              - creator
+              - last_set
+            type: object
+          unlinked:
+            title: Field to determine whether a channel has ever been shared/disconnected in the past
+            type: integer
+          unread_count:
+            type: integer
+          unread_count_display:
+            type: integer
+          user:
+            $ref: '#/definitions/defs_user_id'
+        required:
+          - id
+          - name
+          - created
+          - creator
+          - is_archived
+          - is_channel
+          - is_general
+          - is_mpim
+          - is_group
+          - is_org_shared
+          - is_im
+          - is_shared
+          - is_private
+          - name_normalized
+          - topic
+          - purpose
+        title: Conversation object
+        type: object
+      - additionalProperties: true
+        properties:
+          accepted_user:
+            $ref: '#/definitions/defs_user_id'
+          created:
+            type: integer
+          creator:
+            $ref: '#/definitions/defs_user_id'
+          display_counts:
+            additionalProperties: true
+            properties:
+              display_counts:
+                type: integer
+              guest_counts:
+                type: integer
+            required:
+              - display_counts
+              - guest_counts
+            type: object
+          id:
+            $ref: '#/definitions/defs_channel'
+          is_archived:
+            type: boolean
+          is_channel:
+            type: boolean
+          is_ext_shared:
+            type: boolean
+          is_general:
+            type: boolean
+          is_group:
+            type: boolean
+          is_im:
+            type: boolean
+          is_member:
+            type: boolean
+          is_moved:
+            type: integer
+          is_mpim:
+            enum:
+              - true
+            type: boolean
+          is_open:
+            type: boolean
+          is_org_shared:
+            type: boolean
+          is_pending_ext_shared:
+            type: boolean
+          is_private:
+            type: boolean
+          is_read_only:
+            type: boolean
+          is_shared:
+            type: boolean
+          last_read:
+            $ref: '#/definitions/defs_ts'
+          latest:
+            items:
+              - $ref: '#/definitions/objs_message'
+              - type: 'null'
+          members:
+            items:
+              $ref: '#/definitions/defs_user_id'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          name:
+            type: string
+          name_normalized:
+            type: string
+          num_members:
+            type: integer
+          pending_shared:
+            items:
+              $ref: '#/definitions/defs_team'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          pin_count:
+            type: string
+          previous_names:
+            items:
+              $ref: '#/definitions/defs_channel_name'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          priority:
+            type: integer
+          purpose:
+            additionalProperties: true
+            properties:
+              creator:
+                $ref: '#/definitions/defs_topic_purpose_creator'
+              last_set:
+                type: integer
+              value:
+                type: string
+            required:
+              - value
+              - creator
+              - last_set
+            type: object
+          shared_team_ids:
+            items:
+              $ref: '#/definitions/defs_team'
+            minItems: 0
+            type: array
+            uniqueItems: true
+          shares:
+            items:
+              additionalProperties: true
+              properties:
+                accepted_user:
+                  $ref: '#/definitions/defs_user_id'
+                is_active:
+                  type: boolean
+                team:
+                  $ref: '#/definitions/objs_team'
+                user:
+                  $ref: '#/definitions/defs_user_id'
+              required:
+                - team
+                - user
+                - accepted_user
+                - is_active
+              type: object
+            minItems: 0
+            type: array
+            uniqueItems: true
+          timezone_count:
+            type: integer
+          topic:
+            additionalProperties: true
+            properties:
+              creator:
+                $ref: '#/definitions/defs_topic_purpose_creator'
+              last_set:
+                type: integer
+              value:
+                type: string
+            required:
+              - value
+              - creator
+              - last_set
+            type: object
+          unlinked:
+            title: Field to determine whether a channel has ever been shared/disconnected in the past
+            type: integer
+          unread_count:
+            type: integer
+          unread_count_display:
+            type: integer
+          user:
+            $ref: '#/definitions/defs_user_id'
+        required:
+          - id
+          - name
+          - created
+          - creator
+          - is_archived
+          - is_channel
+          - is_general
+          - is_mpim
+          - is_group
+          - is_org_shared
+          - is_im
+          - is_shared
+          - is_private
+          - name_normalized
+          - topic
+          - purpose
+        title: Conversation MPIM Object
+        type: object
+      - additionalProperties: true
+        properties:
+          created:
+            type: integer
+          has_pins:
+            type: boolean
+          id:
+            $ref: '#/definitions/defs_dm_id'
+          is_ext_shared:
+            type: boolean
+          is_im:
+            type: boolean
+          is_open:
+            type: boolean
+          is_org_shared:
+            type: boolean
+          is_shared:
+            type: boolean
+          is_user_deleted:
+            type: boolean
+          last_read:
+            $ref: '#/definitions/defs_ts'
+          latest:
+            items:
+              - $ref: '#/definitions/objs_message'
+              - type: 'null'
+          priority:
+            type: integer
+          unread_count:
+            type: integer
+          unread_count_display:
+            type: integer
+          user:
+            $ref: '#/definitions/defs_user_id'
+        required:
+          - id
+          - created
+          - is_im
+          - is_org_shared
+          - user
+          - priority
+        title: Conversation IM Channel Object from conversations.* methods
+        type: object
+  objs_dnd:
+    additionalProperties: true
+    properties:
+      dnd_enabled:
+        type: boolean
+      next_dnd_end_ts:
+        type: integer
+      next_dnd_start_ts:
+        type: integer
+      snooze_enabled:
+        type: boolean
+    required:
+      - dnd_enabled
+      - next_dnd_end_ts
+      - next_dnd_start_ts
+      - snooze_enabled
+    type: object
+  objs_file:
+    additionalProperties: true
+    properties:
+      channels:
+        items:
+          $ref: '#/definitions/defs_channel_id'
+        type: array
+        uniqueItems: true
+      comments_count:
+        type: integer
+      created:
+        type: integer
+      display_as_bot:
+        type: boolean
+      editable:
+        type: boolean
+      external_type:
+        type: string
+      filetype:
+        type: string
+      groups:
+        items:
+          $ref: '#/definitions/defs_group_id'
+        type: array
+        uniqueItems: true
+      id:
+        $ref: '#/definitions/defs_file_id'
+      image_exif_rotation:
+        type: integer
+      ims:
+        items:
+          $ref: '#/definitions/defs_dm_id'
+        type: array
+        uniqueItems: true
+      is_external:
+        type: boolean
+      is_public:
+        type: boolean
+      mimetype:
+        type: string
+      mode:
+        type: string
+      name:
+        type: string
+      original_h:
+        type: integer
+      original_w:
+        type: integer
+      permalink:
+        format: uri
+        type: string
+      permalink_public:
+        format: uri
+        type: string
+      pinned_info:
+        $ref: '#/definitions/defs_pinned_info'
+      pinned_to:
+        items:
+          $ref: '#/definitions/defs_channel'
+        type: array
+      pretty_type:
+        type: string
+      public_url_shared:
+        type: boolean
+      reactions:
+        items:
+          $ref: '#/definitions/objs_reaction'
+        type: array
+      size:
+        type: integer
+      thumb_1024:
+        format: uri
+        type: string
+      thumb_1024_h:
+        type: integer
+      thumb_1024_w:
+        type: integer
+      thumb_160:
+        format: uri
+        type: string
+      thumb_360:
+        format: uri
+        type: string
+      thumb_360_h:
+        type: integer
+      thumb_360_w:
+        type: integer
+      thumb_480:
+        format: uri
+        type: string
+      thumb_480_h:
+        type: integer
+      thumb_480_w:
+        type: integer
+      thumb_64:
+        format: uri
+        type: string
+      thumb_720:
+        format: uri
+        type: string
+      thumb_720_h:
+        type: integer
+      thumb_720_w:
+        type: integer
+      thumb_80:
+        format: uri
+        type: string
+      thumb_800:
+        format: uri
+        type: string
+      thumb_800_h:
+        type: integer
+      thumb_800_w:
+        type: integer
+      thumb_960:
+        format: uri
+        type: string
+      thumb_960_h:
+        type: integer
+      thumb_960_w:
+        type: integer
+      timestamp:
+        type: integer
+      title:
+        type: string
+      url_private:
+        format: uri
+        type: string
+      url_private_download:
+        format: uri
+        type: string
+      user:
+        type: string
+      username:
+        type: string
+    title: file object
+    type: object
+  objs_file_object_with_id_only:
+    $ref: '#/definitions/defs_file_id'
+    additionalProperties: true
+    title: file object with ID only
+    type: string
+  objs_group:
+    additionalProperties: true
+    properties:
+      created:
+        type: integer
+      creator:
+        $ref: '#/definitions/defs_user_id'
+      id:
+        $ref: '#/definitions/defs_group_id'
+      is_archived:
+        type: boolean
+      is_group:
+        type: boolean
+      is_moved:
+        type: integer
+      is_mpim:
+        type: boolean
+      is_open:
+        type: boolean
+      is_pending_ext_shared:
+        type: boolean
+      last_read:
+        $ref: '#/definitions/defs_ts'
+      latest:
+        items:
+          - $ref: '#/definitions/objs_message'
+          - type: 'null'
+      members:
+        items:
+          $ref: '#/definitions/defs_user_id'
+        minItems: 1
+        type: array
+        uniqueItems: true
+      name:
+        type: string
+      name_normalized:
+        type: string
+      priority:
+        type: integer
+      purpose:
+        additionalProperties: true
+        properties:
+          creator:
+            $ref: '#/definitions/defs_topic_purpose_creator'
+          last_set:
+            type: integer
+          value:
+            type: string
+        required:
+          - value
+          - creator
+          - last_set
+        type: object
+      topic:
+        additionalProperties: true
+        properties:
+          creator:
+            $ref: '#/definitions/defs_topic_purpose_creator'
+          last_set:
+            type: integer
+          value:
+            type: string
+        required:
+          - value
+          - creator
+          - last_set
+        type: object
+      unread_count:
+        type: integer
+      unread_count_display:
+        type: integer
+    required:
+      - id
+      - name
+      - is_group
+      - created
+      - creator
+      - name_normalized
+      - members
+      - topic
+      - purpose
+    title: Group object
+    type: object
+  objs_im:
+    additionalProperties: true
+    properties:
+      created:
+        type: integer
+      id:
+        $ref: '#/definitions/defs_dm_id'
+      is_im:
+        type: boolean
+      is_org_shared:
+        type: boolean
+      is_user_deleted:
+        type: boolean
+      priority:
+        type: integer
+      user:
+        $ref: '#/definitions/defs_user_id'
+    required:
+      - id
+      - is_im
+      - is_org_shared
+      - user
+      - created
+      - is_user_deleted
+    title: IM Object
+    type: object
+  objs_inviting_user:
+    additionalProperties: true
+    properties:
+      id:
+        $ref: '#/definitions/defs_user_id'
+      is_app_user:
+        type: boolean
+      is_restricted:
+        type: boolean
+      is_ultra_restricted:
+        type: boolean
+      name:
+        type: string
+      profile:
+        $ref: '#/definitions/objs_user_profile_shortest'
+      real_name:
+        type: string
+      team_id:
+        $ref: '#/definitions/defs_team'
+      updated:
+        type: number
+    required:
+      - id
+      - team_id
+      - name
+      - profile
+      - is_restricted
+      - is_ultra_restricted
+      - updated
+      - is_app_user
+    type: object
+  objs_message:
+    additionalProperties: true
+    properties:
+      attachments:
+        items:
+          additionalProperties: true
+          properties:
+            fallback:
+              type: string
+            id:
+              type: integer
+            image_bytes:
+              type: integer
+            image_height:
+              type: integer
+            image_url:
+              type: string
+            image_width:
+              type: integer
+          required:
+            - id
+          type: object
+        minItems: 1
+        type: array
+        uniqueItems: true
+      bot_id:
+        items:
+          - $ref: '#/definitions/defs_bot_id'
+          - title: Nil bot_id set when display_as_bot is false
+            type: 'null'
+      comment:
+        $ref: '#/definitions/objs_comment'
+      display_as_bot:
+        type: boolean
+      file:
+        $ref: '#/definitions/objs_file'
+      icons:
+        additionalProperties: true
+        properties:
+          emoji:
+            type: string
+        type: object
+      inviter:
+        $ref: '#/definitions/defs_user_id'
+      is_intro:
+        type: boolean
+      last_read:
+        $ref: '#/definitions/defs_ts'
+      name:
+        type: string
+      old_name:
+        type: string
+      permalink:
+        format: uri
+        type: string
+      pinned_to:
+        items:
+          $ref: '#/definitions/defs_channel'
+        type: array
+      purpose:
+        type: string
+      reactions:
+        items:
+          $ref: '#/definitions/objs_reaction'
+        type: array
+      replies:
+        items:
+          additionalProperties: true
+          properties:
+            ts:
+              $ref: '#/definitions/defs_ts'
+            user:
+              $ref: '#/definitions/defs_user_id'
+          required:
+            - user
+            - ts
+          type: object
+        type: array
+      reply_count:
+        type: integer
+      source_team:
+        $ref: '#/definitions/defs_team'
+      subscribed:
+        type: boolean
+      subtype:
+        type: string
+      team:
+        $ref: '#/definitions/defs_team'
+      text:
+        type: string
+      thread_ts:
+        $ref: '#/definitions/defs_ts'
+      topic:
+        type: string
+      ts:
+        $ref: '#/definitions/defs_ts'
+      type:
+        type: string
+      unread_count:
+        type: integer
+      upload:
+        type: boolean
+      user:
+        $ref: '#/definitions/defs_user_id'
+      user_profile:
+        $ref: '#/definitions/objs_user_profile_short'
+      user_team:
+        $ref: '#/definitions/defs_team'
+      username:
+        type: string
+    required:
+      - text
+      - type
+      - ts
+    title: Message object
+    type: object
+  objs_paging:
+    additionalProperties: true
+    properties:
+      count:
+        type: integer
+      page:
+        type: integer
+      pages:
+        type: integer
+      total:
+        type: integer
+    required:
+      - count
+      - page
+      - total
+    title: paging object for files
+    type: object
+  objs_reaction:
+    additionalProperties: true
+    properties:
+      count:
+        type: integer
+      name:
+        type: string
+      users:
+        items:
+          $ref: '#/definitions/defs_user_id'
+        type: array
+    required:
+      - name
+      - users
+      - count
+    title: Reaction object
+    type: object
+  objs_scopes:
+    items:
+      title: Named OAuth scopes
+      type: string
+      x-examples:
+        - 'chat:write'
+        - 'im:history'
+        - 'im:read'
+    type: array
+  objs_team:
+    additionalProperties: true
+    properties:
+      avatar_base_url:
+        format: uri
+        type: string
+      domain:
+        type: string
+      email_domain:
+        type: string
+      enterprise_id:
+        type: string
+      enterprise_name:
+        type: string
+      has_compliance_export:
+        type: boolean
+      icon:
+        properties:
+          image_102:
+            type: string
+          image_132:
+            type: string
+          image_230:
+            type: string
+          image_34:
+            type: string
+          image_44:
+            type: string
+          image_68:
+            type: string
+          image_88:
+            type: string
+          image_default:
+            type: boolean
+        type: object
+      id:
+        $ref: '#/definitions/defs_team'
+      messages_count:
+        type: integer
+      msg_edit_window_mins:
+        type: integer
+      name:
+        type: string
+      over_integrations_limit:
+        type: boolean
+      over_storage_limit:
+        type: boolean
+      plan:
+        type: string
+      prefs:
+        $ref: '#/definitions/team_prefs_prefs'
+    required:
+      - id
+      - name
+      - domain
+      - email_domain
+      - icon
+    title: Team Object
+    type: object
+  objs_team_profile_field:
+    additionalProperties: true
+    properties:
+      field_name:
+        type: string
+      hint:
+        type: string
+      id:
+        pattern: '^X[a-zA-Z0-9]{9}$'
+        type: string
+      is_hidden:
+        type: boolean
+      label:
+        type: string
+      options:
+        items:
+          type: string
+        type: array
+      ordering:
+        type: number
+      possible_values:
+        items:
+          type: string
+        type: array
+      type:
+        enum:
+          - text
+          - date
+          - link
+          - mailto
+          - options_list
+          - user
+        type: string
+    required:
+      - id
+      - ordering
+      - label
+      - hint
+      - type
+      - options
+    type: object
+  objs_user:
+    additionalProperties: true
+    properties:
+      color:
+        pattern: '^[a-fA-F0-9]{6}$'
+        type: string
+      deleted:
+        type: boolean
+      has_2fa:
+        type: boolean
+      id:
+        $ref: '#/definitions/defs_user_id'
+      is_admin:
+        type: boolean
+      is_app_user:
+        type: boolean
+      is_bot:
+        type: boolean
+      is_owner:
+        type: boolean
+      is_primary_owner:
+        type: boolean
+      is_restricted:
+        type: boolean
+      is_ultra_restricted:
+        type: boolean
+      locale:
+        type: string
+      name:
+        type: string
+      presence:
+        type: string
+      profile:
+        $ref: '#/definitions/objs_user_profile'
+      real_name:
+        type: string
+      team_id:
+        $ref: '#/definitions/defs_team'
+      tz:
+        type: string
+      tz_label:
+        type: string
+      tz_offset:
+        type: number
+      updated:
+        type: number
+    required:
+      - id
+      - team_id
+      - name
+      - deleted
+      - color
+      - real_name
+      - tz
+      - tz_label
+      - tz_offset
+      - profile
+      - is_admin
+      - is_owner
+      - is_primary_owner
+      - is_restricted
+      - is_ultra_restricted
+      - is_bot
+      - updated
+      - is_app_user
+    type: object
+  objs_user_profile:
+    additionalProperties: true
+    properties:
+      always_active:
+        type: boolean
+      avatar_hash:
+        type: string
+      display_name:
+        type: string
+      display_name_normalized:
+        type: string
+      email:
+        format: email
+        type: string
+      fields:
+        type: object
+      first_name:
+        type: string
+      guest_channels:
+        type: string
+      image_192:
+        format: uri
+        type: string
+      image_24:
+        format: uri
+        type: string
+      image_32:
+        format: uri
+        type: string
+      image_48:
+        format: uri
+        type: string
+      image_512:
+        format: uri
+        type: string
+      image_72:
+        format: uri
+        type: string
+      image_original:
+        format: uri
+        type: string
+      last_name:
+        type: string
+      phone:
+        type: string
+      real_name:
+        type: string
+      real_name_normalized:
+        type: string
+      skype:
+        type: string
+      status_emoji:
+        type: string
+      status_expiration:
+        type: integer
+      status_text:
+        type: string
+      status_text_canonical:
+        type: string
+      team:
+        $ref: '#/definitions/defs_team'
+      title:
+        type: string
+    required:
+      - real_name
+      - display_name
+      - avatar_hash
+      - real_name_normalized
+      - display_name_normalized
+      - image_24
+      - image_32
+      - image_48
+      - image_72
+      - image_192
+    title: User profile object
+    type: object
+  objs_user_profile_short:
+    additionalProperties: true
+    properties:
+      avatar_hash:
+        type: string
+      display_name:
+        type: string
+      first_name:
+        type: string
+      image_72:
+        format: uri
+        type: string
+      is_restricted:
+        type: boolean
+      is_ultra_restricted:
+        type: boolean
+      name:
+        type: string
+      real_name:
+        type: string
+      team:
+        $ref: '#/definitions/defs_team'
+    required:
+      - avatar_hash
+      - image_72
+      - first_name
+      - real_name
+      - display_name
+      - team
+      - name
+      - is_restricted
+      - is_ultra_restricted
+    type: object
+  objs_user_profile_shortest:
+    additionalProperties: true
+    properties:
+      avatar_hash:
+        type: string
+      display_name:
+        type: string
+      first_name:
+        type: string
+      image_72:
+        format: uri
+        type: string
+      real_name:
+        type: string
+      team:
+        $ref: '#/definitions/defs_team'
+    required:
+      - avatar_hash
+      - image_72
+      - first_name
+      - real_name
+      - display_name
+      - team
+    type: object
+  prefs_prefs:
+    additionalProperties: true
+    properties:
+      a11y_animations:
+        type: boolean
+      a11y_font_size:
+        type: string
+      all_channels_loud:
+        type: boolean
+      all_notifications_prefs:
+        type: string
+      all_unreads_sort_order:
+        type: string
+      allow_calls_to_set_current_status:
+        type: boolean
+      allow_cmd_tab_iss:
+        type: boolean
+      analytics_upsell_coachmark_seen:
+        type: boolean
+      arrow_history:
+        type: boolean
+      at_channel_suppressed_channels:
+        type: string
+      box_enabled:
+        type: boolean
+      channel_sort:
+        type: string
+      client_logs_pri:
+        type: string
+      color_names_in_list:
+        type: boolean
+      confirm_clear_all_unreads:
+        type: boolean
+      confirm_sh_call_start:
+        type: boolean
+      confirm_user_marked_away:
+        type: boolean
+      convert_emoticons:
+        type: boolean
+      display_display_names:
+        type: boolean
+      display_real_names_override:
+        type: integer
+      dnd_enabled:
+        type: boolean
+      dnd_end_hour:
+        type: string
+      dnd_start_hour:
+        type: string
+      dropbox_enabled:
+        type: boolean
+      email_alerts:
+        type: string
+      email_alerts_sleep_until:
+        type: integer
+      email_developer:
+        type: boolean
+      email_misc:
+        type: boolean
+      email_offers:
+        type: boolean
+      email_research:
+        type: boolean
+      email_tips:
+        type: boolean
+      email_weekly:
+        type: boolean
+      emoji_autocomplete_big:
+        type: boolean
+      emoji_mode:
+        type: string
+      emoji_use:
+        type: string
+      enable_react_emoji_picker:
+        type: boolean
+      enable_unread_view:
+        type: boolean
+      enhanced_debugging:
+        type: boolean
+      ent_org_wide_channels_sidebar:
+        type: boolean
+      enter_is_special_in_tbt:
+        type: boolean
+      enterprise_excluded_app_teams:
+        type: 'null'
+      enterprise_mdm_custom_msg:
+        type: string
+      enterprise_migration_seen:
+        type: boolean
+      expand_inline_imgs:
+        type: boolean
+      expand_internal_inline_imgs:
+        type: boolean
+      expand_non_media_attachments:
+        type: boolean
+      expand_snippets:
+        type: boolean
+      f_key_search:
+        type: boolean
+      flannel_server_pool:
+        type: string
+      folder_data:
+        type: string
+      folders_enabled:
+        type: boolean
+      frecency_ent_jumper:
+        type: string
+      frecency_ent_jumper_backup:
+        type: string
+      frecency_jumper:
+        type: string
+      full_text_extracts:
+        type: boolean
+      fuller_timestamps:
+        type: boolean
+      gdrive_authed:
+        type: boolean
+      gdrive_enabled:
+        type: boolean
+      graphic_emoticons:
+        type: boolean
+      growls_enabled:
+        type: boolean
+      growth_all_banners_prefs:
+        type: string
+      growth_msg_limit_approaching_cta_count:
+        type: integer
+      growth_msg_limit_approaching_cta_ts:
+        type: integer
+      growth_msg_limit_long_reached_cta_count:
+        type: integer
+      growth_msg_limit_long_reached_cta_last_ts:
+        type: integer
+      growth_msg_limit_reached_cta_count:
+        type: integer
+      growth_msg_limit_reached_cta_last_ts:
+        type: integer
+      growth_msg_limit_sixty_day_banner_cta_count:
+        type: integer
+      growth_msg_limit_sixty_day_banner_cta_last_ts:
+        type: integer
+      has_created_channel:
+        type: boolean
+      has_invited:
+        type: boolean
+      has_recently_shared_a_channel:
+        type: boolean
+      has_searched:
+        type: boolean
+      has_uploaded:
+        type: boolean
+      hide_hex_swatch:
+        type: boolean
+      hide_user_group_info_pane:
+        type: boolean
+      highlight_words:
+        type: string
+      in_interactive_mas_migration_flow:
+        type: boolean
+      intro_to_apps_message_seen:
+        type: boolean
+      jumbomoji:
+        type: boolean
+      k_key_omnibox:
+        type: boolean
+      k_key_omnibox_auto_hide_count:
+        type: integer
+      keyboard:
+        type: 'null'
+      last_seen_at_channel_warning:
+        type: integer
+      last_snippet_type:
+        type: string
+      last_tos_acknowledged:
+        type: string
+      lessons_enabled:
+        type: boolean
+      load_lato_2:
+        type: boolean
+      locale:
+        type: string
+      locales_enabled:
+        additionalProperties: true
+        properties:
+          de-DE:
+            type: string
+          en-US:
+            type: string
+          es-ES:
+            type: string
+          fr-FR:
+            type: string
+          ja-JP:
+            type: string
+          pseudo:
+            type: string
+        type: object
+      loud_channels:
+        type: string
+      loud_channels_set:
+        type: string
+      ls_disabled:
+        type: boolean
+      mac_ssb_bounce:
+        type: string
+      mac_ssb_bullet:
+        type: boolean
+      mark_msgs_read_immediately:
+        type: boolean
+      measure_css_usage:
+        type: boolean
+      mentions_exclude_at_channels:
+        type: boolean
+      mentions_exclude_at_user_groups:
+        type: boolean
+      messages_theme:
+        type: string
+      msg_input_send_btn:
+        type: boolean
+      msg_input_send_btn_auto_set:
+        type: boolean
+      msg_preview:
+        type: boolean
+      msg_preview_persistent:
+        type: boolean
+      mute_sounds:
+        type: boolean
+      muted_channels:
+        type: string
+      never_channels:
+        type: string
+      new_msg_snd:
+        type: string
+      newxp_seen_last_message:
+        type: integer
+      no_created_overlays:
+        type: boolean
+      no_invites_widget_in_sidebar:
+        type: boolean
+      no_joined_overlays:
+        type: boolean
+      no_macelectron_banner:
+        type: boolean
+      no_macssb1_banner:
+        type: boolean
+      no_macssb2_banner:
+        type: boolean
+      no_omnibox_in_channels:
+        type: boolean
+      no_text_in_notifications:
+        type: boolean
+      no_winssb1_banner:
+        type: boolean
+      obey_inline_img_limit:
+        type: boolean
+      onboarding_cancelled:
+        type: boolean
+      onboarding_slackbot_conversation_step:
+        type: integer
+      overloaded_message_enabled:
+        type: boolean
+      pagekeys_handled:
+        type: boolean
+      posts_formatting_guide:
+        type: boolean
+      preferred_skin_tone:
+        type: string
+      privacy_policy_seen:
+        type: boolean
+      prompted_for_email_disabling:
+        type: boolean
+      purchaser:
+        type: boolean
+      push_at_channel_suppressed_channels:
+        type: string
+      push_dm_alert:
+        type: boolean
+      push_everything:
+        type: boolean
+      push_idle_wait:
+        type: integer
+      push_loud_channels:
+        type: string
+      push_loud_channels_set:
+        type: string
+      push_mention_alert:
+        type: boolean
+      push_mention_channels:
+        type: string
+      push_show_preview:
+        type: boolean
+      push_sound:
+        type: string
+      require_at:
+        type: boolean
+      search_exclude_bots:
+        type: boolean
+      search_exclude_channels:
+        type: string
+      search_only_current_team:
+        type: boolean
+      search_only_my_channels:
+        type: boolean
+      search_sort:
+        type: string
+      seen_administration_menu:
+        type: boolean
+      seen_app_space_coachmark:
+        type: boolean
+      seen_app_space_tutorial:
+        type: boolean
+      seen_calls_interactive_coachmark:
+        type: boolean
+      seen_channel_browser_admin_coachmark:
+        type: boolean
+      seen_custom_status_badge:
+        type: boolean
+      seen_custom_status_callout:
+        type: boolean
+      seen_domain_invite_reminder:
+        type: boolean
+      seen_emoji_update_overlay_coachmark:
+        type: boolean
+      seen_gdrive_coachmark:
+        type: boolean
+      seen_guest_admin_slackbot_announcement:
+        type: boolean
+      seen_highlights_arrows_coachmark:
+        type: boolean
+      seen_highlights_coachmark:
+        type: boolean
+      seen_highlights_warm_welcome:
+        type: boolean
+      seen_intl_channel_names_coachmark:
+        type: boolean
+      seen_japanese_locale_change_message:
+        type: boolean
+      seen_keyboard_shortcuts_coachmark:
+        type: boolean
+      seen_locale_change_message:
+        type: integer
+      seen_member_invite_reminder:
+        type: boolean
+      seen_name_tagging_coachmark:
+        type: boolean
+      seen_onboarding_banner:
+        type: boolean
+      seen_onboarding_channels:
+        type: boolean
+      seen_onboarding_direct_messages:
+        type: boolean
+      seen_onboarding_invites:
+        type: boolean
+      seen_onboarding_private_groups:
+        type: boolean
+      seen_onboarding_recent_mentions:
+        type: boolean
+      seen_onboarding_search:
+        type: boolean
+      seen_onboarding_slackbot_conversation:
+        type: boolean
+      seen_onboarding_starred_items:
+        type: boolean
+      seen_onboarding_start:
+        type: boolean
+      seen_shared_channels_coachmark:
+        type: boolean
+      seen_shared_channels_opt_in_change_message:
+        type: boolean
+      seen_shdep_slackbot_message:
+        type: boolean
+      seen_single_emoji_msg:
+        type: boolean
+      seen_ssb_prompt:
+        type: boolean
+      seen_threads_notification_banner:
+        type: boolean
+      seen_unread_view_coachmark:
+        type: boolean
+      seen_welcome_2:
+        type: boolean
+      separate_private_channels:
+        type: boolean
+      separate_shared_channels:
+        type: boolean
+      shdep_promo_code_submitted:
+        type: boolean
+      show_all_skin_tones:
+        type: boolean
+      show_ent_onboarding:
+        type: boolean
+      show_jumper_scores:
+        type: boolean
+      show_memory_instrument:
+        type: boolean
+      show_sidebar_quickswitcher_button:
+        type: boolean
+      show_typing:
+        type: boolean
+      sidebar_behavior:
+        type: string
+      sidebar_theme:
+        type: string
+      sidebar_theme_custom_values:
+        type: string
+      snippet_editor_wrap_long_lines:
+        type: boolean
+      spaces_new_xp_banner_dismissed:
+        type: boolean
+      ss_emojis:
+        type: boolean
+      ssb_space_window:
+        type: string
+      start_scroll_at_oldest:
+        type: boolean
+      tab_ui_return_selects:
+        type: boolean
+      threads_everything:
+        type: boolean
+      time24:
+        type: boolean
+      two_factor_auth_enabled:
+        type: boolean
+      two_factor_backup_type:
+        type: 'null'
+      two_factor_type:
+        type: 'null'
+      tz:
+        type: string
+      user_colors:
+        type: string
+      webapp_spellcheck:
+        type: boolean
+      welcome_message_hidden:
+        type: boolean
+      whats_new_read:
+        type: integer
+      winssb_run_from_tray:
+        type: boolean
+      winssb_window_flash_behavior:
+        type: string
+    title: User Prefs object
+    type: object
+  team_prefs_prefs:
+    additionalProperties: true
+    properties:
+      all_users_can_purchase:
+        type: boolean
+      allow_calls:
+        type: boolean
+      allow_calls_interactive_screen_sharing:
+        type: boolean
+      allow_message_deletion:
+        type: boolean
+      allow_retention_override:
+        type: boolean
+      allow_shared_channel_perms_override:
+        type: boolean
+      app_whitelist_enabled:
+        type: boolean
+      auth_mode:
+        type: string
+      calling_app_name:
+        type: string
+      can_receive_shared_channels_invites:
+        type: boolean
+      compliance_export_start:
+        type: integer
+      custom_status_default_emoji:
+        type: string
+      custom_status_presets:
+        items:
+          items:
+            type: string
+          minItems: 1
+          type: array
+          uniqueItems: true
+        minItems: 1
+        type: array
+        uniqueItems: true
+      custom_tos:
+        type: boolean
+      default_channels:
+        items:
+          $ref: '#/definitions/defs_channel'
+        type: array
+      default_rxns:
+        items:
+          type: string
+        type: array
+      disable_email_ingestion:
+        type: boolean
+      disable_file_deleting:
+        type: boolean
+      disable_file_editing:
+        type: boolean
+      disable_file_uploads:
+        type: string
+      disallow_public_file_urls:
+        type: boolean
+      discoverable:
+        type: string
+      display_email_addresses:
+        type: boolean
+      display_real_names:
+        type: boolean
+      dm_retention_duration:
+        type: integer
+      dm_retention_type:
+        type: integer
+      dnd_enabled:
+        type: boolean
+      dnd_end_hour:
+        type: string
+      dnd_start_hour:
+        type: string
+      enable_shared_channels:
+        type: integer
+      enterprise_default_channels:
+        items: {}
+        type: array
+      enterprise_mandatory_channels:
+        items: {}
+        type: array
+      enterprise_mdm_date_enabled:
+        type: integer
+      enterprise_mdm_level:
+        type: integer
+      enterprise_team_creation_request:
+        additionalProperties: true
+        properties:
+          is_enabled:
+            type: boolean
+        required:
+          - is_enabled
+        type: object
+      file_limit_whitelisted:
+        type: boolean
+      file_retention_duration:
+        type: integer
+      file_retention_type:
+        type: integer
+      gdrive_enabled_team:
+        type: boolean
+      group_retention_duration:
+        type: integer
+      group_retention_type:
+        type: integer
+      hide_referers:
+        type: boolean
+      invites_limit:
+        type: boolean
+      invites_only_admins:
+        type: boolean
+      locale:
+        type: string
+      loud_channel_mentions_limit:
+        type: integer
+      msg_edit_window_mins:
+        type: integer
+      require_at_for_mention:
+        type: boolean
+      retention_duration:
+        type: integer
+      retention_type:
+        type: integer
+      show_join_leave:
+        type: boolean
+      uses_customized_custom_status_presets:
+        type: boolean
+      warn_before_at_channel:
+        type: string
+      who_can_archive_channels:
+        type: string
+      who_can_at_channel:
+        type: string
+      who_can_at_everyone:
+        type: string
+      who_can_change_team_profile:
+        type: string
+      who_can_create_channels:
+        type: string
+      who_can_create_delete_user_groups:
+        type: string
+      who_can_create_groups:
+        type: string
+      who_can_create_shared_channels:
+        type: string
+      who_can_edit_user_groups:
+        type: string
+      who_can_kick_channels:
+        type: string
+      who_can_kick_groups:
+        type: string
+      who_can_manage_guests:
+        additionalProperties: true
+        properties:
+          type:
+            items:
+              type: string
+            type: array
+        required:
+          - type
+        type: object
+      who_can_manage_integrations:
+        additionalProperties: true
+        properties:
+          type:
+            items:
+              type: string
+            type: array
+        required:
+          - type
+        type: object
+      who_can_manage_shared_channels:
+        additionalProperties: true
+        properties:
+          type:
+            items:
+              type: string
+            type: array
+        required:
+          - type
+        type: object
+      who_can_post_general:
+        type: string
+      who_can_post_in_shared_channels:
+        additionalProperties: true
+        properties:
+          type:
+            items:
+              type: string
+            type: array
+        required:
+          - type
+        type: object
+      who_has_team_visibility:
+        type: string
+    required:
+      - default_channels
+    title: Team Prefs Object
+    type: object


### PR DESCRIPTION
As the `resources` folder is used across multiple tests (and not only the ones under `loaders`), I thought it makes sense to move it to a more generalized location.
Also adds the slack specification (so we can add more future tests with ease), and a non-parsed petstore specification (the only one had `$ref` resolved manually). I added a `TextError` reference to it so we can have a `text/plain` response as well.