### PR TITLE
[Fix] Default state without code

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "npm run lint-ts",
     "lint-ts": "tslint --project packages/unmock/ --config tslint.json && tslint --project packages/unmock-cli/ --config tslint.json && tslint --project packages/unmock-core/ --config tslint.json && tslint --project packages/unmock-jsdom/ --config tslint.json && tslint --project packages/unmock-node/ --config tslint.json",
     "test": "jest --verbose",
+    "test:debug": "DEBUG=unmock* jest --verbose",
     "test:clean": "jest --clearCache",
     "test:watch": "jest --verbose --watchAll",
     "testonly": "npm test",

--- a/packages/unmock-core/src/__tests__/__unmock__/filestackApi/spec.yaml
+++ b/packages/unmock-core/src/__tests__/__unmock__/filestackApi/spec.yaml
@@ -1,0 +1,47 @@
+
+servers:
+- url: https://cloud.filestackapi.com
+
+paths:
+  /prefetch:
+    options:
+      responses:
+        204:
+          description: Prefetch options
+          headers:
+            access-control-allow-headers:
+              schema:
+                type: array
+                items:
+                  type: string
+                default:
+                  - filestack-source
+                  - filestack-trace-id
+                  - filestack-trace-span
+            access-control-allow-methods:
+              schema:
+                type: string
+                default: "*"
+            access-control-allow-origin:
+              schema:
+                type: string
+                default: "*"
+          content:
+            text/plain:
+              schema:
+                type: string
+    get:
+      summary: Prefetch
+      parameters:
+        - name: apikey
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Prefetch get
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -43,19 +43,16 @@ describe("Tests generator", () => {
     stateStore.petstore({}); // should pass
     expect(() => stateStore.github({})).toThrow("service named 'github'"); // no github service
   });
-
   it("sets a state for swagger api converted to openapi", () => {
     const { stateStore } = responseCreatorFactory({
       serviceDefLoader,
       options: mockOptions,
     });
     stateStore.slack("/bots.info", { bot: { app_id: "A12345678" } }); // should pass
-
     expect(() =>
       stateStore.slack("/bots.info", { bot: { app_id: "A123456789" } }),
     ).toThrow("type is incorrect"); // Does not match the specified pattern
   });
-
   it("in non-flaky mode", () => {
     const { createResponse } = responseCreatorFactory({
       serviceDefLoader,
@@ -75,7 +72,6 @@ describe("Tests generator", () => {
       }
     }
   });
-
   it("in flaky mode", () => {
     const { createResponse } = responseCreatorFactory({
       serviceDefLoader,
@@ -98,5 +94,36 @@ describe("Tests generator", () => {
     }
     expect(counters[200]).toBeGreaterThan(0);
     expect(counters[201]).toBeGreaterThan(0);
+  });
+
+  it("Generates correct response from differing status codes", () => {
+    const { stateStore, createResponse } = responseCreatorFactory({
+      serviceDefLoader,
+      options: mockOptions,
+    });
+    stateStore.filestackApi("/prefetch", "prefetch");
+    let resp = createResponse({
+      host: "cloud.filestackapi.com",
+      method: "options",
+      path: "/prefetch",
+      protocol: "https",
+    });
+    expect(resp).toBeDefined();
+    if (resp !== undefined) {
+      expect(resp.statusCode).toEqual(204);
+      expect(resp.body).toEqual('"prefetch"');
+    }
+
+    resp = createResponse({
+      host: "cloud.filestackapi.com",
+      method: "get",
+      path: "/prefetch",
+      protocol: "https",
+    });
+    expect(resp).toBeDefined();
+    if (resp !== undefined) {
+      expect(resp.statusCode).toEqual(200);
+      expect(resp.body).toEqual('"prefetch"');
+    }
   });
 });

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -168,7 +168,7 @@ export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 
 // Used to define the simplify the types used
 type FluentStateStore = StateFacadeType & SetStateForSpecificMethod;
-type StateInput = IStateInputGenerator | UnmockServiceState;
+type StateInput = IStateInputGenerator | UnmockServiceState | string;
 
 // Used to incorporate the reset method when needed
 interface IResetState {

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -9,7 +9,7 @@ import {
   Operation,
 } from "../interfaces";
 import { IOperationForStateUpdate, IStateUpdate } from "./interfaces";
-import { filterStatesByOperation, getOperations } from "./utils";
+import { anyFn, filterStatesByOperation, getOperations } from "./utils";
 import { getValidStatesForOperationWithState } from "./validator";
 
 const debugLog = debug("unmock:state");
@@ -45,7 +45,7 @@ export class State {
       return;
     }
     debugLog(
-      `Found following operations: ${JSON.stringify(
+      `Found the following operations: ${JSON.stringify(
         ops.operations,
         undefined,
         1,
@@ -53,7 +53,8 @@ export class State {
     );
 
     let errorMsg: string | undefined;
-    const opsResult = ops.operations.some((op: IOperationForStateUpdate) => {
+    const opsResult = anyFn(ops.operations, (op: IOperationForStateUpdate) => {
+      debugLog(`Testing against ${JSON.stringify(op.operation)}`);
       // For each operation, verify the new state applies and save in `this.state`
       const stateResponses = getValidStatesForOperationWithState(
         op.operation,
@@ -61,7 +62,7 @@ export class State {
         stateUpdate.dereferencer,
       );
       if (stateResponses.error === undefined) {
-        debugLog(`Matched successfully for ${op.operation.operationId}`);
+        debugLog(`Matched successfully for ${JSON.stringify(op.operation)}`);
         const augmentedResponses = DSL.translateTopLevelToOAS(
           newState.top,
           stateResponses.responses,

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -9,7 +9,7 @@ import {
   Operation,
 } from "../interfaces";
 import { IOperationForStateUpdate, IStateUpdate } from "./interfaces";
-import { anyFn, filterStatesByOperation, getOperations } from "./utils";
+import { filterStatesByOperation, getOperations } from "./utils";
 import { getValidStatesForOperationWithState } from "./validator";
 
 const debugLog = debug("unmock:state");
@@ -53,7 +53,8 @@ export class State {
     );
 
     let errorMsg: string | undefined;
-    const opsResult = anyFn(ops.operations, (op: IOperationForStateUpdate) => {
+    let opsResult = false;
+    ops.operations.forEach((op: IOperationForStateUpdate) => {
       debugLog(`Testing against ${JSON.stringify(op.operation)}`);
       // For each operation, verify the new state applies and save in `this.state`
       const stateResponses = getValidStatesForOperationWithState(
@@ -68,14 +69,14 @@ export class State {
           stateResponses.responses,
         );
         this.updateStateInternal(endpoint, method, augmentedResponses);
-        return true;
+        opsResult = true;
+        return;
       }
       // failed path
       debugLog(
         `Couldn't match for ${op.operation.operationId} - received error ${stateResponses.error}`,
       );
       errorMsg = stateResponses.error;
-      return false;
     });
 
     if (opsResult === false) {

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -44,7 +44,13 @@ export class State {
       // No state given, no changes to make
       return;
     }
-    debugLog(`Found follow operations: ${ops.operations}`);
+    debugLog(
+      `Found following operations: ${JSON.stringify(
+        ops.operations,
+        undefined,
+        1,
+      )}`,
+    );
 
     let errorMsg: string | undefined;
     const opsResult = ops.operations.some((op: IOperationForStateUpdate) => {

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -6,6 +6,7 @@ import {
   Schema,
   UnmockServiceState,
 } from "../interfaces";
+import { anyFn } from "./utils";
 
 // These are specific to OAS and not part of json schema standard
 const ajv = new Ajv({ unknownFormats: ["int32", "int64"] });
@@ -118,7 +119,7 @@ const spreadStateFromService = (
 const NESTED_SCHEMA_ITEMS = ["properties", "items", "additionalProperties"];
 
 const hasNestedItems = (obj: any) =>
-  NESTED_SCHEMA_ITEMS.some((key: string) => obj[key] !== undefined);
+  anyFn(NESTED_SCHEMA_ITEMS, (key: string) => obj[key] !== undefined);
 
 const isConcreteValue = (obj: any) =>
   ["string", "number", "boolean"].includes(typeof obj);

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -7,7 +7,6 @@ import {
   Schema,
   UnmockServiceState,
 } from "../interfaces";
-import { anyFn } from "./utils";
 
 // These are specific to OAS and not part of json schema standard
 const ajv = new Ajv({ unknownFormats: ["int32", "int64"] });
@@ -153,7 +152,7 @@ const spreadStateFromService = (
 const NESTED_SCHEMA_ITEMS = ["properties", "items", "additionalProperties"];
 
 const hasNestedItems = (obj: any) =>
-  anyFn(NESTED_SCHEMA_ITEMS, (key: string) => obj[key] !== undefined);
+  NESTED_SCHEMA_ITEMS.some((key: string) => obj[key] !== undefined);
 
 const isConcreteValue = (obj: any) =>
   ["string", "number", "boolean"].includes(typeof obj);

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -27,22 +27,6 @@ interface ICodesToMediaTypes {
 const debugLog = debug("unmock:state:utils");
 
 /**
- * Works like array.some(), except it exhauses all array elements before returning.
- * @param arr
- * @param callbackfn
- */
-export const anyFn = <T>(
-  arr: T[],
-  callbackfn: (value: T, index: number, array: T[]) => boolean,
-): boolean => {
-  return arr.reduce(
-    (acc: boolean, elem: T, index: number, array: T[]) =>
-      callbackfn(elem, index, array) || acc,
-    false,
-  );
-};
-
-/**
  * Given a list of possibly relevent `states` (each being a mapping from
  * a status code, to a mediatype, to the state itself), and an `operation`,
  * filter and return only those states that are relevant for the request Operation.

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -27,6 +27,22 @@ interface ICodesToMediaTypes {
 const debugLog = debug("unmock:state:utils");
 
 /**
+ * Works like array.some(), except it exhauses all array elements before returning.
+ * @param arr
+ * @param callbackfn
+ */
+export const anyFn = <T>(
+  arr: T[],
+  callbackfn: (value: T, index: number, array: T[]) => boolean,
+): boolean => {
+  return arr.reduce(
+    (acc: boolean, elem: T, index: number, array: T[]) =>
+      callbackfn(elem, index, array) || acc,
+    false,
+  );
+};
+
+/**
  * Given a list of possibly relevent `states` (each being a mapping from
  * a status code, to a mediatype, to the state itself), and an `operation`,
  * filter and return only those states that are relevant for the request Operation.

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -143,6 +143,13 @@ const flattenCodeToMediaBySpreading = (nested: codeToMedia[]) => {
   return spreaded;
 };
 
+/**
+ * Attempts to match all media types from `allowedMediaTypes` with the `stateObj`.
+ * Assumption is that all codes in`statusCodes` appear in `allowedMediaTypes`.
+ * @param statusCodes
+ * @param stateObj
+ * @param allowedMediaTypes
+ */
 const filterByMediaType = (
   statusCodes: string[],
   stateObj: codeToMedia,

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -54,6 +54,11 @@ export const filterStatesByOperation = (
   states: codeToMedia[],
   operation: Operation,
 ): codeToMedia => {
+  debugLog(
+    `filterStatesByOperation: Filtering which states from ${JSON.stringify(
+      states,
+    )} are valid for ${JSON.stringify(operation)}`,
+  );
   const opResponses = operation.responses;
   const statusCodes = Object.keys(opResponses);
   // Types of 'MediaType' keys that are present in given Operation
@@ -70,6 +75,11 @@ export const filterStatesByOperation = (
       );
     },
     {},
+  );
+  debugLog(
+    `filterStatesByOperation: acceptable media types from operation: ${JSON.stringify(
+      mediaTypes,
+    )}`,
   );
   // Filter each state by status code and media type present in Operation
   const filtered = states.reduce(
@@ -100,16 +110,22 @@ export const filterStatesByOperation = (
     },
     [],
   );
+  debugLog(
+    `filterStatesByOperation: Matching state after filtering status codes and media types: ${JSON.stringify(
+      filtered,
+    )}`,
+  );
   // Spread out for each status code and each media type
-  return spreadNestedCodeToMedia(filtered);
+  return flattenCodeToMediaBySpreading(filtered);
 };
 
-const spreadNestedCodeToMedia = (nested: codeToMedia[]) => {
+const flattenCodeToMediaBySpreading = (nested: codeToMedia[]) => {
+  debugLog(`flattenCodeToMediaBySpreading: Flattening ${nested}...`);
   const spreaded: codeToMedia = {};
   for (const state of nested) {
     for (const code of Object.keys(state)) {
       const resp: Record<string, Schema> = state[code as codeKey] as any;
-      for (const mediaType of Object.keys(state[code])) {
+      for (const mediaType of Object.keys(resp)) {
         const content = resp[mediaType];
         if (content !== undefined) {
           const spreadSchema = {
@@ -132,11 +148,22 @@ const filterByMediaType = (
   stateObj: codeToMedia,
   allowedMediaTypes: ICodesToMediaTypes,
 ) => {
+  debugLog(
+    `filterByMediaType: Attempting to match media types from ${JSON.stringify(
+      allowedMediaTypes,
+    )} with ${JSON.stringify(stateObj)}`,
+  );
   const stateCodeToMedia: codeToMedia = {};
   for (const code of statusCodes) {
+    debugLog(`filterByMediaType: Filtering for status code ${code}`);
     const codeSchema = stateObj[code];
     const validMediaTypes = Object.keys(codeSchema).filter(
       (mediaType: string) => allowedMediaTypes[code].includes(mediaType),
+    );
+    debugLog(
+      `filterByMediaType: Valid media types for state and operation: ${JSON.stringify(
+        validMediaTypes,
+      )}`,
     );
     if (validMediaTypes.length === 0) {
       continue;
@@ -178,7 +205,9 @@ export const getOperations = ({
   });
 
   if (endpoint !== DEFAULT_STATE_ENDPOINT) {
-    debugLog(`Fetching operations for specific endpoint '${endpoint}'...`);
+    debugLog(
+      `getOperations: Fetching operations for specific endpoint '${endpoint}'...`,
+    );
     const pathItem = paths[schemaEndpoint];
     if (pathItem === undefined) {
       return err(`endpoint '${endpoint}'`);
@@ -186,7 +215,7 @@ export const getOperations = ({
 
     if (isDefMethod) {
       // Specific endpoint, all methods
-      debugLog(`Fetching operations for any REST method...`);
+      debugLog(`getOperations: Fetching operations for any REST method...`);
       const ops = getOperationsFromPathItem(pathItem, endpoint);
       return ops === undefined
         ? err(`any operations under '${endpoint}'`)
@@ -194,7 +223,9 @@ export const getOperations = ({
     }
 
     // Specific endpoint, specific method
-    debugLog(`Fetching operations for REST method '${method}'...`);
+    debugLog(
+      `getOperations: Fetching operations for REST method '${method}'...`,
+    );
     const op = pathItem[method as HTTPMethod];
     return op === undefined
       ? err(`response for '${method} ${endpoint}'`)
@@ -223,6 +254,11 @@ const getOperationsByMethod = (
   method: ExtendedHTTPMethod,
   paths: Paths,
 ): OperationsForStateUpdate | undefined => {
+  debugLog(
+    `getOperationsByMethod: Extracting all ${method} operations from ${JSON.stringify(
+      paths,
+    )}`,
+  );
   const anyMethod = method === DEFAULT_STATE_HTTP_METHOD;
   const filterFn = anyMethod
     ? (pathItemKey: string) => isRESTMethod(pathItemKey)
@@ -244,6 +280,7 @@ const getOperationsByMethod = (
     [],
   );
   if (operations.length === 0) {
+    debugLog(`getOperationsByMethod: No matching operations found`);
     return undefined;
   }
   return operations;
@@ -253,6 +290,11 @@ const getOperationsFromPathItem = (
   pathItem: PathItem,
   endpoint: string,
 ): OperationsForStateUpdate | undefined => {
+  debugLog(
+    `getOperationsFromPathItem: Extracting all operations from ${JSON.stringify(
+      pathItem,
+    )}`,
+  );
   const operations: OperationsForStateUpdate = [];
   for (const key of Object.keys(pathItem)) {
     if (isRESTMethod(key)) {
@@ -264,6 +306,7 @@ const getOperationsFromPathItem = (
     }
   }
   if (operations.length === 0) {
+    debugLog(`getOperationsFromPathItem: no operations found`);
     return undefined;
   }
   return operations;

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -14,7 +14,6 @@ import {
   Responses,
   Schema,
 } from "../interfaces";
-import { anyFn } from "./utils";
 
 const debugLog = debug("unmock:state:validator");
 
@@ -191,7 +190,8 @@ const getStateFromMedia = (
   );
   const errors: IMissingParam[] = [];
   const relevantResponses: IResponsesFromContent = {};
-  const success = anyFn(Object.keys(contentRecord), (contentType: string) => {
+  let success = false;
+  Object.keys(contentRecord).forEach((contentType: string) => {
     const content = contentRecord[contentType];
     if (content === undefined || content.schema === undefined) {
       debugLog(`getStateFromMedia: No schema defined in ${contentType}`);
@@ -199,7 +199,7 @@ const getStateFromMedia = (
         msg: `No schema defined in '${JSON.stringify(content)}'!`,
         nestedLevel: -1,
       });
-      return false;
+      return;
     }
     const spreadState = state.gen(deref<Schema>(content.schema));
 
@@ -215,11 +215,11 @@ const getStateFromMedia = (
           `${contentType} is invalid - ${spreadState}`,
       );
       errors.push(missingParam);
-      return false;
+      return;
     }
     debugLog(`getStateFromMedia: Spread state is valid for ${contentType}`);
     relevantResponses[contentType] = spreadState;
-    return true;
+    success = true;
   });
   return {
     responses: relevantResponses,

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -13,6 +13,7 @@ import {
   Responses,
   Schema,
 } from "../interfaces";
+import { anyFn } from "./utils";
 
 type codeType = keyof Responses;
 
@@ -107,7 +108,6 @@ const validStatesForStateWithoutCode = (
           : acc,
       {},
     );
-
     if (Object.keys(filteredStateMedia).length > 0) {
       relevantResponses[code] = filteredStateMedia;
     }
@@ -161,7 +161,7 @@ const getStateFromMedia = (
 } => {
   const errors: IMissingParam[] = [];
   const relevantResponses: IResponsesFromContent = {};
-  const success = Object.keys(contentRecord).some((contentType: string) => {
+  const success = anyFn(Object.keys(contentRecord), (contentType: string) => {
     const content = contentRecord[contentType];
     if (content === undefined || content.schema === undefined) {
       errors.push({


### PR DESCRIPTION
- Several places used `some` with the underlying assumptions that it iterates over all array elements. Since it does not, some possible states and media types were overlooked once a match was found. Fixed by introducing `anyFn` that acts like `some` but exhausts all array elements before returning.
- Adds many more debug logs.
- Adds typing to accept strings as states by default.
- Adds `test:debug` command (useful for testing a single file).
- Adds a test to verify the above logic, using filestack pseudo API (thanks @ksaaskil!)