### PR TITLE
Accept functions (accepts serialized request) for states + bug fixes

### DIFF
--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -135,9 +135,7 @@ describe("Tests generator", () => {
       serviceDefLoader,
       options: mockOptions,
     });
-    // TODO: need to re-verify $size across all options
-    // stateStore.petstore.get("/pets", { id: () => "foo", $size: 5, $code: 200 });
-    stateStore.petstore({ id: () => "foo" });
+    stateStore.petstore({ id: () => "foo", $size: 5, $code: 200 });
     let resp = createResponse({
       host: "petstore.swagger.io",
       method: "get",

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -278,4 +278,11 @@ describe("Test state management", () => {
       200: { "text/plain": { const: "foobar", type: "string" } },
     });
   });
+
+  it("Fails setting $size to a specific non-array item", () => {
+    const state = new State();
+    expect(() =>
+      updateState(state, "any", "**", objResponse({ foo: { $size: 5 } }), "**"),
+    ).toThrow("$size");
+  });
 });

--- a/packages/unmock-core/src/__tests__/transformers.test.ts
+++ b/packages/unmock-core/src/__tests__/transformers.test.ts
@@ -111,7 +111,7 @@ describe("Test object provider", () => {
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({ $code: 200 });
     expect(p.gen({}).spreadState).toEqual({});
-    expect(p.gen().error).toContain("'foo'"); // no schema to expand
+    expect(p.gen({}).error).toContain("'foo'"); // no schema to expand
     expect(p.gen({ properties: { foo: { type: "string" } } })).toEqual({
       spreadState: {
         properties: {

--- a/packages/unmock-core/src/__tests__/transformers.test.ts
+++ b/packages/unmock-core/src/__tests__/transformers.test.ts
@@ -1,5 +1,9 @@
 import { Schema } from "../service/interfaces";
-import { objResponse, textResponse } from "../service/state/transformers";
+import {
+  objResponse,
+  textResponse,
+  TEXT_RESPONSE_ERROR,
+} from "../service/state/transformers";
 
 const schema: Schema = {
   properties: {
@@ -38,7 +42,7 @@ describe("Test text provider", () => {
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
-    expect(p.gen()).toEqual({ "text/plain": null });
+    expect(p.gen()).toEqual({ spreadState: {}, error: TEXT_RESPONSE_ERROR });
   });
 
   it("returns empty object for empty state", () => {
@@ -46,7 +50,7 @@ describe("Test text provider", () => {
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
-    expect(p.gen()).toEqual({ "text/plain": null });
+    expect(p.gen()).toEqual({ spreadState: {}, error: TEXT_RESPONSE_ERROR });
   });
 
   it("returns empty object for empty schema", () => {
@@ -54,21 +58,26 @@ describe("Test text provider", () => {
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
     // @ts-ignore // deliberately checking with empty input
-    expect(p.gen()).toEqual({ "text/plain": null });
+    expect(p.gen()).toEqual({ spreadState: {}, error: TEXT_RESPONSE_ERROR });
   });
 
   it("returns empty object for non-text schema", () => {
     const p = textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
-    expect(p.gen({ type: "array", items: {} })).toEqual({ "text/plain": null });
+    expect(p.gen({ type: "array", items: {} })).toEqual({
+      spreadState: {},
+      error: TEXT_RESPONSE_ERROR,
+    });
   });
 
   it("returns correct state object for valid input", () => {
     const p = textResponse("foo");
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({});
-    expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
+    expect(p.gen({ type: "string" })).toEqual({
+      spreadState: { type: "string", const: "foo" },
+    });
   });
 
   it("top level DSL doesn't change response", () => {
@@ -76,35 +85,40 @@ describe("Test text provider", () => {
     const p = textResponse("foo", { $code: 200, notDSL: "a" });
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({ $code: 200 }); // non DSL is filtered out
-    expect(p.gen({ type: "string" })).toEqual({ type: "string", const: "foo" });
+    expect(p.gen({ type: "string" })).toEqual({
+      spreadState: { type: "string", const: "foo" },
+    });
   });
 });
 
-describe("Test default provider", () => {
+describe("Test object provider", () => {
   it("returns empty objects for undefined state", () => {
     const p = objResponse();
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
-    expect(p.gen({})).toEqual({});
+    expect(p.gen({})).toEqual({ spreadState: {} });
   });
 
   it("returns empty objects for empty state", () => {
     const p = objResponse({});
     expect(p.isEmpty).toBeTruthy();
     expect(p.top).toEqual({});
-    expect(p.gen({})).toEqual({});
+    expect(p.gen({})).toEqual({ spreadState: {} });
   });
 
   it("filters out top level DSL from state", () => {
     const p = objResponse({ $code: 200, foo: "bar" });
     expect(p.isEmpty).toBeFalsy();
     expect(p.top).toEqual({ $code: 200 });
-    expect(p.gen({})).toEqual({}); // no schema to expand
+    expect(p.gen({}).spreadState).toEqual({});
+    expect(p.gen().error).toContain("'foo'"); // no schema to expand
     expect(p.gen({ properties: { foo: { type: "string" } } })).toEqual({
-      properties: {
-        foo: {
-          type: "string",
-          const: "bar",
+      spreadState: {
+        properties: {
+          foo: {
+            type: "string",
+            const: "bar",
+          },
         },
       },
     });
@@ -112,33 +126,27 @@ describe("Test default provider", () => {
 
   it("with empty path", () => {
     const spreadState = objResponse({}).gen(schema);
-    expect(spreadState).toEqual({}); // Empty state => empty spread state
+    expect(spreadState).toEqual({ spreadState: {} }); // Empty state => empty spread state
   });
 
   it("with specific path", () => {
     const spreadState = objResponse({
       test: { id: "a" },
     }).gen(schema);
-    expect(spreadState).toEqual({
-      // Spreading from "test: { id : { ... " to also inlucde properties
-      properties: {
-        test: {
-          properties: {
-            id: null, // Will be removed due to wrong type
-          },
-        },
-      },
-    });
+    expect(spreadState.spreadState).toEqual({});
+    expect(spreadState.error).toContain("'id'");
   });
 
   it("with vague path", () => {
     const spreadState = objResponse({ id: 5 }).gen(schema);
     // no "id" in top-most level or immediately under properties\items
-    expect(spreadState).toEqual({ id: null });
+    expect(spreadState.spreadState).toEqual({});
+    expect(spreadState.error).toContain("'id'");
   });
 
   it("with missing parameters", () => {
     const spreadState = objResponse({ ida: "a" }).gen(schema);
-    expect(spreadState).toEqual({ ida: null }); // Nothing to spread
+    expect(spreadState.spreadState).toEqual({});
+    expect(spreadState.error).toContain("'ida'");
   });
 });

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -81,7 +81,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       }),
       deref,
     );
-    expect(spreadState.error).toContain("Can't find definition for 'boom'");
+    expect(spreadState.error.msg).toContain("Can't find definition for 'boom'");
   });
 
   it("empty schema returns error", () => {
@@ -94,7 +94,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       objResponse(),
       deref,
     );
-    expect(spreadState.error).toContain("No schema defined");
+    expect(spreadState.error.msg).toContain("No schema defined");
   });
 
   it("with $code specified", () => {
@@ -142,7 +142,7 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       deref,
     );
     expect(spreadState.responses).toBeUndefined();
-    expect(spreadState.error).toContain(
+    expect(spreadState.error.msg).toContain(
       "Can't find response for given status code '404'!",
     );
   });

--- a/packages/unmock-core/src/__tests__/validator.test.ts
+++ b/packages/unmock-core/src/__tests__/validator.test.ts
@@ -81,6 +81,8 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       }),
       deref,
     );
+    expect(spreadState.error).toBeDefined();
+    // @ts-ignore // will throw above if it's undefined...
     expect(spreadState.error.msg).toContain("Can't find definition for 'boom'");
   });
 
@@ -94,6 +96,8 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       objResponse(),
       deref,
     );
+    expect(spreadState.error).toBeDefined();
+    // @ts-ignore // will throw above if it's undefined...
     expect(spreadState.error.msg).toContain("No schema defined");
   });
 
@@ -142,6 +146,8 @@ describe("Tests getValidResponsesForOperationWithState", () => {
       deref,
     );
     expect(spreadState.responses).toBeUndefined();
+    expect(spreadState.error).toBeDefined();
+    // @ts-ignore // will throw above if it's undefined...
     expect(spreadState.error.msg).toContain(
       "Can't find response for given status code '404'!",
     );

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -61,6 +61,7 @@ export function responseCreatorFactory({
       setupJSFUnmockProperties(req);
       const res = generateMockFromTemplate(options, serviceStore.match(req));
       listeners.forEach((listener: IListener) => listener.notify({ req, res }));
+      jsf.reset(); // removes unmock-properties
       return res;
     },
   };
@@ -269,7 +270,6 @@ const generateMockFromTemplate = (
   jsf.option("alwaysFakeOptionals", true);
   jsf.option("useDefaultValue", false);
   const resolvedTemplate = jsf.generate(template);
-  jsf.reset();
 
   const body = JSON.stringify(resolvedTemplate);
   jsf.option("useDefaultValue", true);

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -22,6 +22,8 @@ export interface ITopLevelDSL {
  * DSL related parameters that can be found at any level in the schema
  */
 
+export const DSLKeys = [...Object.keys(TopLevelDSLKeys), "$size"];
+
 export interface IDSL {
   /**
    * Used to control and generate arrays of specific sizes.

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -71,6 +71,10 @@ export interface IStateInputGenerator {
    * Returns top-level DSL, if it exists.
    */
   top: ITopLevelDSL;
+  /**
+   * For debugging purposes, to retrieve the state used to instantiate the generator
+   */
+  readonly state: any;
 }
 export const isStateInputGenerator = (u: any): u is IStateInputGenerator =>
   u !== undefined &&

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -64,7 +64,9 @@ export interface IStateInputGenerator {
    * Generates a new state (copy) based on the given schema, so that
    * future processes can use it without modifying the original schema.
    */
-  gen: (schema: Schema) => Record<string, Schema> | Schema;
+  gen: (
+    schema: Schema,
+  ) => { spreadState: Record<string, Schema> | Schema; error?: string };
   /**
    * Returns top-level DSL, if it exists.
    */

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -9,7 +9,11 @@ import {
   MatcherResponse,
   UnmockServiceState,
 } from "./interfaces";
-import { objResponse, textResponse } from "./state/transformers";
+import {
+  functionResponse,
+  objResponse,
+  textResponse,
+} from "./state/transformers";
 
 export class ServiceStore {
   private readonly serviceMapping: IServiceMapping = {};
@@ -72,16 +76,14 @@ export class ServiceStore {
         }'!`,
       );
     }
-    let stateGen: IStateInputGenerator;
-    if (!isStateInputGenerator(state)) {
-      // Given an object, set default generator for state
-      stateGen =
-        typeof state === "string"
-          ? textResponse(state)
-          : objResponse(state as UnmockServiceState);
-    } else {
-      stateGen = state as IStateInputGenerator;
-    }
+    // Given an object, set default generator for state
+    const stateGen = isStateInputGenerator(state)
+      ? state
+      : typeof state === "string"
+      ? textResponse(state)
+      : typeof state === "function"
+      ? functionResponse(state)
+      : objResponse(state);
 
     this.serviceMapping[serviceName].updateState({
       endpoint,

--- a/packages/unmock-core/src/service/state/interfaces.ts
+++ b/packages/unmock-core/src/service/state/interfaces.ts
@@ -24,3 +24,8 @@ export interface IOperationForStateUpdate {
   operation: Operation;
 }
 export type OperationsForStateUpdate = IOperationForStateUpdate[];
+
+export interface IValidationError {
+  msg: string;
+  nestedLevel: number;
+}

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -1,5 +1,6 @@
 import Ajv from "ajv";
 import debug from "debug";
+import { ISerializedRequest } from "../../interfaces";
 import { DSL, filterTopLevelDSL, getTopLevelDSL, ITopLevelDSL } from "../dsl";
 import {
   isSchema,
@@ -20,6 +21,19 @@ export const objResponse = (
   top: getTopLevelDSL(state || {}),
   gen: (schema: Schema) =>
     spreadStateFromService(schema, filterTopLevelDSL(state || {})),
+});
+
+export const functionResponse = (
+  responseFunction: (sreq: ISerializedRequest, scm?: Schema) => any,
+  dsl?: ITopLevelDSL,
+): IStateInputGenerator => ({
+  isEmpty: responseFunction === undefined,
+  top: getTopLevelDSL((dsl || {}) as UnmockServiceState),
+  gen: (schema: Schema) =>
+    ({
+      "x-unmock-function": (req: ISerializedRequest) =>
+        responseFunction(req, schema),
+    } as any),
 });
 
 export const textResponse = (

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -105,6 +105,8 @@ const spreadStateFromService = (
           [key]:
             isSchema(scm) && ajv.validate(scm, stateValue)
               ? { ...scm, const: stateValue }
+              : typeof stateValue === "function"
+              ? { ...scm, "x-unmock-function": stateValue }
               : null,
         };
         matches = { ...matches, ...spread };
@@ -155,7 +157,7 @@ const hasNestedItems = (obj: any) =>
   NESTED_SCHEMA_ITEMS.some((key: string) => obj[key] !== undefined);
 
 const isConcreteValue = (obj: any) =>
-  ["string", "number", "boolean"].includes(typeof obj);
+  ["string", "number", "boolean", "function"].includes(typeof obj);
 
 const isNonEmptyObject = (obj: any) =>
   typeof obj === "object" && Object.keys(obj).length > 0;

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -44,7 +44,6 @@ export const filterStatesByOperation = (
     )} are valid for ${JSON.stringify(operation)}`,
   );
   const opResponses = operation.responses;
-  const statusCodes = Object.keys(opResponses);
   // Types of 'MediaType' keys that are present in given Operation
   const mediaTypes: ICodesToMediaTypes = Object.keys(opResponses).reduce(
     (types: ICodesToMediaTypes, code: string) => {
@@ -66,37 +65,14 @@ export const filterStatesByOperation = (
     )}`,
   );
   // Filter each state by status code and media type present in Operation
-  const filtered = states.reduce(
-    (stateAcc: codeToMedia[], state: codeToMedia) => {
-      // for every non-matching code, we use the default argument
-      const relCodesInState = Object.keys(state).filter((code: string) =>
-        statusCodes.includes(code),
-      );
-      if (relCodesInState.length === 0) {
-        if (Object.keys(state).length > 0) {
-          // Some error codes are not expressed explictily, so we use 'default' instead
-          stateAcc.push(
-            filterByMediaType(
-              ["default"],
-              Object.keys(state).reduce((obj: codeToMedia, code) => {
-                obj.default = { ...obj.default, ...state[code] };
-                return obj;
-              }, {}),
-              mediaTypes,
-            ),
-          );
-        }
-        // None match - we can safely ignore this state
-        return stateAcc;
-      }
-      stateAcc.push(filterByMediaType(relCodesInState, state, mediaTypes));
-      return stateAcc;
-    },
-    [],
+  const filtered = states.map((state: codeToMedia) =>
+    filterByMediaType(state, mediaTypes),
   );
   debugLog(
     `filterStatesByOperation: Matching state after filtering status codes and media types: ${JSON.stringify(
       filtered,
+      (_: string, value: any) =>
+        typeof value === "function" ? `Function()` : value,
     )}`,
   );
   // Spread out for each status code and each media type
@@ -129,13 +105,10 @@ const flattenCodeToMediaBySpreading = (nested: codeToMedia[]) => {
 
 /**
  * Attempts to match all media types from `allowedMediaTypes` with the `stateObj`.
- * Assumption is that all codes in`statusCodes` appear in `allowedMediaTypes`.
- * @param statusCodes
  * @param stateObj
  * @param allowedMediaTypes
  */
 const filterByMediaType = (
-  statusCodes: string[],
   stateObj: codeToMedia,
   allowedMediaTypes: ICodesToMediaTypes,
 ) => {
@@ -145,22 +118,29 @@ const filterByMediaType = (
     )} with ${JSON.stringify(stateObj)}`,
   );
   const stateCodeToMedia: codeToMedia = {};
-  for (const code of statusCodes) {
+  for (const code of Object.keys(stateObj)) {
     debugLog(`filterByMediaType: Filtering for status code ${code}`);
     const codeSchema = stateObj[code];
-    const validMediaTypes = Object.keys(codeSchema).filter(
-      (mediaType: string) => allowedMediaTypes[code].includes(mediaType),
-    );
+    const matchMediaTypes = (key: string) =>
+      allowedMediaTypes[key] === undefined
+        ? []
+        : Object.keys(codeSchema).filter((mediaType: string) =>
+            allowedMediaTypes[key].includes(mediaType),
+          );
+    const validMediaTypes = matchMediaTypes(code);
+    // if we couldn't find based on code, attempt to match against 'default'
+    const extendedValidMediaTypes =
+      validMediaTypes.length > 0 ? validMediaTypes : matchMediaTypes("default");
     debugLog(
       `filterByMediaType: Valid media types for state and operation: ${JSON.stringify(
-        validMediaTypes,
+        extendedValidMediaTypes,
       )}`,
     );
-    if (validMediaTypes.length === 0) {
+    if (extendedValidMediaTypes.length === 0) {
       continue;
     }
     // some are valid, add them to the list
-    stateCodeToMedia[code] = validMediaTypes.reduce(
+    stateCodeToMedia[code] = extendedValidMediaTypes.reduce(
       (filteredCodeToMedia: mediaTypeToSchema, mediaType: string) =>
         Object.assign(filteredCodeToMedia, {
           [mediaType]: codeSchema[mediaType],

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -20,8 +20,8 @@ import {
 } from "../interfaces";
 import {
   IStateUpdate,
-  OperationsForStateUpdate,
   IValidationError,
+  OperationsForStateUpdate,
 } from "./interfaces";
 
 type codeKey = keyof Responses;

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_STATE_ENDPOINT,
   DEFAULT_STATE_HTTP_METHOD,
 } from "../constants";
+import { DSLKeys } from "../dsl/interfaces";
 import {
   codeToMedia,
   ExtendedHTTPMethod,
@@ -17,7 +18,11 @@ import {
   Responses,
   Schema,
 } from "../interfaces";
-import { IStateUpdate, OperationsForStateUpdate } from "./interfaces";
+import {
+  IStateUpdate,
+  OperationsForStateUpdate,
+  IValidationError,
+} from "./interfaces";
 
 type codeKey = keyof Responses;
 interface ICodesToMediaTypes {
@@ -281,4 +286,25 @@ const getOperationsFromPathItem = (
     return undefined;
   }
   return operations;
+};
+
+const stringHasDSLKeys = (input: string) =>
+  DSLKeys.some((key: string) => input.includes(key));
+
+export const chooseBestMatchingError = (
+  firstError: IValidationError,
+  secondError?: IValidationError,
+) => {
+  if (secondError === undefined) {
+    return firstError;
+  }
+  const firstHasDSL = stringHasDSLKeys(firstError.msg);
+  const secondHasDSL = stringHasDSLKeys(secondError.msg);
+  return firstHasDSL && !secondHasDSL
+    ? firstError
+    : secondHasDSL && !firstHasDSL
+    ? secondError
+    : firstError.nestedLevel < secondError.nestedLevel
+    ? secondError
+    : firstError;
 };

--- a/packages/unmock-core/src/service/state/validator.ts
+++ b/packages/unmock-core/src/service/state/validator.ts
@@ -14,6 +14,8 @@ import {
   Responses,
   Schema,
 } from "../interfaces";
+import { IValidationError } from "./interfaces";
+import { chooseBestMatchingError } from "./utils";
 
 const debugLog = debug("unmock:state:validator");
 
@@ -25,23 +27,48 @@ interface IResponsesFromContent {
 
 interface IValidState {
   responses?: codeToMedia;
-  error?: IMissingParam;
+  error?: IValidationError;
 }
 
-interface IMissingParam {
-  msg: string;
-  nestedLevel: number;
-}
-
-const chooseDeepestMissingParam = (
-  errorList: IMissingParam[],
-  initError?: IMissingParam,
-) =>
-  errorList.reduce(
-    (err: IMissingParam | undefined, cerr: IMissingParam) =>
-      err === undefined || err.nestedLevel < cerr.nestedLevel ? cerr : err,
-    initError,
+/**
+ * Given a state and an operation, creates a copy of the requested state for each response that it matches.
+ * First-level filtering is done via $code (status code) if it exists,
+ * otherwise via matching the parameters set in `state`.
+ * @param operation
+ * @param state
+ */
+export const getValidStatesForOperationWithState = (
+  operation: Operation,
+  state: IStateInputGenerator,
+  deref: Dereferencer,
+): {
+  responses: codeToMedia | undefined;
+  error: IValidationError | undefined;
+} => {
+  debugLog(
+    `getValidStatesForOperationWithState: Attempting to match and copy a ` +
+      `partial state that matches ${JSON.stringify(
+        state.state,
+      )} from ${JSON.stringify(operation)}`,
   );
+  const resps = operation.responses;
+  const code = state.top.$code;
+  // If $code is defined, we fetch the response even if no other state was set
+  // If $code is not found, use the default response - "the default MAY be used as a
+  //    default response object for all HTTP codes that are not covered individually by the specification"
+  // (see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responsesObject)
+  const { responses, error } =
+    code !== undefined
+      ? validStatesForStateWithCode(
+          resps[String(code) as codeType] || resps.default,
+          state,
+          code,
+          deref,
+        )
+      : // Otherwise, iterate over all status codes and find the ones matching the given state
+        validStatesForStateWithoutCode(resps, state, deref);
+  return { responses, error };
+};
 
 /**
  * Given a response, state and code, attempts to fetch the copied, spread state that matches the different
@@ -98,7 +125,7 @@ const validStatesForStateWithoutCode = (
     )} with ${JSON.stringify(operationResponses)}`,
   );
   const relevantResponses: codeToMedia = {};
-  let err: IMissingParam | undefined;
+  let err: IValidationError | undefined;
 
   for (const code of Object.keys(operationResponses)) {
     debugLog(
@@ -110,7 +137,9 @@ const validStatesForStateWithoutCode = (
       code,
       deref,
     );
-    err = error === undefined ? err : chooseDeepestMissingParam([error], err);
+    if (error !== undefined) {
+      err = chooseBestMatchingError(error, err);
+    }
 
     if (responses === undefined) {
       debugLog(
@@ -134,47 +163,9 @@ const validStatesForStateWithoutCode = (
       relevantResponses[code] = filteredStateMedia;
     }
   }
-
   return Object.keys(relevantResponses).length > 0
     ? { responses: relevantResponses }
     : { error: err };
-};
-/**
- * Given a state and an operation, creates a copy of the requested state for each response that it matches.
- * First-level filtering is done via $code (status code) if it exists,
- * otherwise via matching the parameters set in `state`.
- * @param operation
- * @param state
- */
-export const getValidStatesForOperationWithState = (
-  operation: Operation,
-  state: IStateInputGenerator,
-  deref: Dereferencer,
-): {
-  responses: codeToMedia | undefined;
-  error: string | undefined;
-} => {
-  debugLog(
-    `getValidStatesForOperationWithState: Attempting to match and copy a ` +
-      `partial state that matches ${state} from ${operation}`,
-  );
-  const resps = operation.responses;
-  const code = state.top.$code;
-  // If $code is defined, we fetch the response even if no other state was set
-  // If $code is not found, use the default response - "the default MAY be used as a
-  //    default response object for all HTTP codes that are not covered individually by the specification"
-  // (see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responsesObject)
-  const { responses, error } =
-    code !== undefined
-      ? validStatesForStateWithCode(
-          resps[String(code) as codeType] || resps.default,
-          state,
-          code,
-          deref,
-        )
-      : // Otherwise, iterate over all status codes and find the ones matching the given state
-        validStatesForStateWithoutCode(resps, state, deref);
-  return { responses, error: error === undefined ? error : error.msg };
 };
 
 const getStateFromMedia = (
@@ -183,27 +174,30 @@ const getStateFromMedia = (
   deref: Dereferencer,
 ): {
   responses: IResponsesFromContent;
-  error?: IMissingParam;
+  error?: IValidationError;
 } => {
   debugLog(
     `getStateFromMedia: Attempting to copy a partial state for ${state} from given media types ${contentRecord}`,
   );
-  const errors: IMissingParam[] = [];
+  let err: IValidationError | undefined;
   const relevantResponses: IResponsesFromContent = {};
   let success = false;
   for (const contentType of Object.keys(contentRecord)) {
     const content = contentRecord[contentType];
     if (content === undefined || content.schema === undefined) {
       debugLog(`getStateFromMedia: No schema defined in ${contentType}`);
-      errors.push({
-        msg: `No schema defined in '${JSON.stringify(content)}'!`,
-        nestedLevel: -1,
-      });
+      err = chooseBestMatchingError(
+        {
+          msg: `No schema defined in '${JSON.stringify(content)}'!`,
+          nestedLevel: -1,
+        },
+        err,
+      );
       continue;
     }
     const { spreadState, error } = state.gen(deref<Schema>(content.schema));
     if (error !== undefined) {
-      errors.push({ msg: error, nestedLevel: 0 });
+      err = chooseBestMatchingError({ msg: error, nestedLevel: 0 }, err);
       continue;
     }
 
@@ -211,51 +205,12 @@ const getStateFromMedia = (
       `getStateFromMedia: Copied matching state, verifying all state elements exist (not null)`,
     );
 
-    const missingParam = DFSVerifyNoneAreNull(spreadState);
-
-    if (missingParam !== undefined) {
-      debugLog(
-        `getStateFromMedia: Some elements are missing in state, the spread state for ` +
-          `${contentType} is invalid - ${spreadState}`,
-      );
-      errors.push(missingParam);
-      continue;
-    }
     debugLog(`getStateFromMedia: Spread state is valid for ${contentType}`);
     relevantResponses[contentType] = spreadState;
     success = true;
   }
   return {
     responses: relevantResponses,
-    error: success ? undefined : chooseDeepestMissingParam(errors),
+    error: success ? undefined : err,
   };
-};
-
-/**
- * Recursively iterates over given `obj` and verifies all values are
- * properly defined.
- * @param obj Object to iterate over
- * @param prevPath (Used internaly) tracked the path to the key that might
- *                 be undefined.
- * @return An IMissingParam if some missing parameter is found, or undefined if no parameters are missing.
- */
-const DFSVerifyNoneAreNull = (
-  obj: any,
-  nestedLevel: number = 0,
-): IMissingParam | undefined => {
-  if (obj === undefined) {
-    return undefined;
-  }
-  for (const key of Object.keys(obj)) {
-    if (obj[key] === null) {
-      return {
-        msg: `Can't find definition for '${key}', or its type is incorrect`,
-        nestedLevel,
-      };
-    }
-    if (typeof obj[key] === "object") {
-      return DFSVerifyNoneAreNull(obj[key], nestedLevel + 1);
-    }
-  }
-  return undefined;
 };

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -118,5 +118,9 @@ describe("Node.js interceptor", () => {
         expect(err.response.data).toBe("baz");
       }
     });
+
+    test("fails setting an array size for non-array elements", async () => {
+      expect(() => states.petstore({ id: { $size: 5 } })).toThrow("$size");
+    });
   });
 });

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -93,8 +93,30 @@ describe("Node.js interceptor", () => {
 
     test("uses default response when setting textual response with DSL with non-existing status code", async () => {
       states.petstore(dsl.textResponse("foo", { $code: 400 }));
+      try {
+        await axios("http://petstore.swagger.io/v1/pets");
+        throw new Error("Expected a 400 response");
+      } catch (err) {
+        expect(err.response.status).toBe(400);
+        expect(err.response.data).toBe("foo");
+      }
+    });
+
+    test("sets an entire response from function", async () => {
+      states.petstore(() => "baz");
       const response = await axios("http://petstore.swagger.io/v1/pets");
-      expect(response.data).toBe("foo");
+      expect(response.data).toBe("baz");
+    });
+
+    test("sets an entire response from function with DSL", async () => {
+      states.petstore(dsl.functionResponse(() => "baz", { $code: 404 }));
+      try {
+        await axios("http://petstore.swagger.io/v1/pets");
+        throw new Error("Expected a 404 response");
+      } catch (err) {
+        expect(err.response.status).toBe(404);
+        expect(err.response.data).toBe("baz");
+      }
     });
   });
 });


### PR DESCRIPTION
Apologies in advance for a bigger-than-desired PR :frowning_face:
If really necessary, I could make 3 different PRs from this one, as it introduces 1 feature and resolves 2 bugs. To make things easier, each has the list of files (excluding test files) that are relevant.

- **Feature**: Accepts functions as states, either as entire state generator or as a value. When used as a state generator, it will also receive the schema (although it does not have to use it). Most importantly, this allows:
  1) Verifying requests and/or creating content dynamically
  2) Overriding default schema (no type checking is done for the result, although we could add that if we decide to?)
  Examples include:
  ```typescript
  // generate content dynamically
  states.someService({foo: { id: (req) => req.body.id } });
  // overrides media-types, schema, etc
  states.someService("/get/user", (req, schema) => "I shall ignore the schema");
  // verify request with expect
  states.someService("/get/users/*", { userid: (req) => { expect(req.body.id).toEqual(12345); return 
  req.body.id; } });
  // use with DSL:
  states.someService("/foo/bar", functionResponse((res, schema) => { /* do stuff */ }, { $code: 200 }));
  ```
  *Files*: `generator.ts` (stuff relating to `setupJSFUnmockProperties`), `serviceStore.ts`, `transformers.ts` (adding `functionResponse` and allowing `function` as a type), `utils.ts` (use default schema if the requested code does not explicitly exist)

- **Bugfix**: When setting a state with status code that does not exist, the *default* pattern should be used, but when accessing that state, it should still respond with the requested status code. Fixed this.
  *Files*: `generator.ts`

- **Bugfix**: When using `$size` in some cases it would either not recognize the schema array, or output a wrong error message. This was fixed, and also initiated some much needed refactoring (specifically, how to choose which error message are most relevant).
  *Files*: `dsl/interfaces.ts` (describe DSL keys), `service/interfaces.ts` (refactor to include an error response), `state/interfaces.ts` (refactor to include `IValidationError`), `state.ts` (small refactor to use loop instead of `forEach`, and adapt to new error handling), `transformers.ts` (adapt to return possible error alongside parsed schema, and move some responsibility from `validator.ts`), `utils.ts` (simplified), `validator.ts` (restructure, simplify)