### PR TITLE
Deserialize application/json body and do not force it to empty string when missing

### DIFF
--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -51,7 +51,7 @@ export interface IOutgoingHeaders {
 }
 
 export interface ISerializedRequest {
-  body?: string;
+  body?: string | object;
   headers?: IIncomingHeaders;
   host: string;
   method: string;

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -44,6 +44,14 @@ describe("Node.js interceptor", () => {
       }
     });
 
+    test("should get successful response for post request", async () => {
+      const response = await axios.post(
+        "http://petstore.swagger.io/v1/pets",
+        {},
+      );
+      expect(response.data).toBe("");
+    });
+
     test("emits an error for unknown url", async () => {
       try {
         await axios("http://example.org");

--- a/packages/unmock-node/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-node/src/__tests__/serialize/index.test.ts
@@ -62,7 +62,7 @@ describe("Request serializer", () => {
       const serializedRequest = await serializeRequest(req);
       expect(serializedRequest.host).toBe(testHost);
       expect(serializedRequest.method.toLowerCase()).toBe("post");
-      expect(serializedRequest.body).toBe(`{"message":"${message}"}`);
+      expect(serializedRequest.body).toEqual({ message });
       expect(serializedRequest.protocol).toBe("https");
       const requestHeaders = serializedRequest.headers;
       if (requestHeaders === undefined) {

--- a/packages/unmock-node/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-node/src/__tests__/serialize/index.test.ts
@@ -21,7 +21,7 @@ describe("Request serializer", () => {
       expect(serializedRequest.method.toLowerCase()).toBe("get");
       expect(serializedRequest.path).toBe("/");
       expect(serializedRequest.protocol).toBe("http");
-      expect(serializedRequest.body).toBe("");
+      expect(serializedRequest.body).toBeUndefined();
       done();
     });
     http.get(`http://${testHost}`);

--- a/packages/unmock-node/src/loggers/filesystem-logger.ts
+++ b/packages/unmock-node/src/loggers/filesystem-logger.ts
@@ -11,9 +11,11 @@ import { resolveServicesDirectory } from "../utils";
 const fileSizeLimitOnInit = 5 * 1024 ** 2; // 5 MB
 
 export default class FSLogger implements IListener {
-  private static toIndentedYaml(input: any) {
+  private static toIndentedYaml(
+    input: ISerializedRequest | ISerializedResponse,
+  ) {
     return yaml
-      .dump(input.body ? { ...input, body: JSON.parse(input.body) } : input)
+      .dump(input)
       .split("\n")
       .map(
         (line: string) =>

--- a/packages/unmock-node/src/serialize/index.ts
+++ b/packages/unmock-node/src/serialize/index.ts
@@ -26,11 +26,11 @@ class BodySerializer extends readable.Transform {
     return serializer.body;
   }
 
-  private body: string = "";
+  private body?: string;
 
   // TODO Encoding
   public _transform(chunk: Buffer, _: string, done: () => void) {
-    this.body += chunk.toString();
+    this.body = (this.body || "") + chunk.toString();
     this.push(chunk);
     done();
   }


### PR DESCRIPTION
- This ensures that `req.body` is an object when setting the state with a function with `states.github((req) => { // req.body is an object and not string }`
- Deserializes the body for `application/json` content type
- Do not force the body to be an empty string for empty body
- Do not `JSON.parse` body in the logging phase
- Add a test for `post` request