### PR TITLE
Fix compatibility with Node 8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:10.15.1
+    - image: circleci/node:8.12.0
 
 jobs:
   build:

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -122,7 +122,12 @@ export class OASMatcher {
       // Try and normalize the requested path...
       for (const server of servers) {
         const serverUrl = url.parse(server.url);
-        const serverPathname = serverUrl.pathname || "/";
+        if (serverUrl.pathname === undefined) {
+          // This should not happen if the URL makes sense
+          // For example, should be "/" for "https://google.com"
+          throw Error(`Got undefined pathname for server URL: ${server.url}`);
+        }
+        const serverPathname = serverUrl.pathname;
         if (reqPath.startsWith(serverPathname)) {
           reqPath = OASMatcher.normalizeRequestPathToServerPath(
             reqPath,
@@ -167,9 +172,6 @@ export class OASMatcher {
     }
     for (const server of servers) {
       const serverUrl = url.parse(server.url);
-      if (serverUrl === undefined) {
-        continue;
-      }
       if (serverUrl.protocol === undefined || !(/^https?:$/.test(serverUrl.protocol))) {
         throw new Error(`Unknown protocol: ${serverUrl.protocol}`);
       }

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -122,13 +122,11 @@ export class OASMatcher {
       // Try and normalize the requested path...
       for (const server of servers) {
         const serverUrl = url.parse(server.url);
-        if (serverUrl.pathname === undefined) {
-          throw Error("Got undefined pathname");
-        }
-        if (reqPath.startsWith(serverUrl.pathname)) {
+        const serverPathname = serverUrl.pathname || "/";
+        if (reqPath.startsWith(serverPathname)) {
           reqPath = OASMatcher.normalizeRequestPathToServerPath(
             reqPath,
-            serverUrl.pathname,
+            serverPathname,
           );
           break;
         }

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -121,7 +121,10 @@ export class OASMatcher {
     if (servers !== undefined && servers.length > 0) {
       // Try and normalize the requested path...
       for (const server of servers) {
-        const serverUrl = new URL(server.url);
+        const serverUrl = url.parse(server.url);
+        if (serverUrl.pathname === undefined) {
+          throw Error("Got undefined pathname");
+        }
         if (reqPath.startsWith(serverUrl.pathname)) {
           reqPath = OASMatcher.normalizeRequestPathToServerPath(
             reqPath,
@@ -172,7 +175,7 @@ export class OASMatcher {
       if (serverUrl.protocol === undefined || !(/^https?:$/.test(serverUrl.protocol))) {
         throw new Error(`Unknown protocol: ${serverUrl.protocol}`);
       }
-      const protocol = serverUrl.protocol ? serverUrl.protocol.replace(":", "") : "http";
+      const protocol = serverUrl.protocol.replace(":", "");
 
       debugLog(
         `Testing: ${protocol} vs. ${sreq.protocol}, ${serverUrl.hostname} ` +


### PR DESCRIPTION
- Use Node 8.12 in CircleCI to ensure compatibility (Node 8.10 does not have `npm ci` in the packaged `npm`)
- Remove references to `URL` global that is not available in Node 8
