### PR TITLE
WIP Allow requiring unmock-node without .default.

### DIFF
--- a/packages/unmock-node/src/__tests__/index.test.ts
+++ b/packages/unmock-node/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-const unmockRequireDefault = require("../").default;  // tslint:disable-line:no-var-requires
+const unmockRequire = require("../");  // tslint:disable-line:no-var-requires
 const dslRequire = require("../").dsl;  // tslint:disable-line:no-var-requires
 import unmockDefaultImport from "../";
 import { dsl } from "../";
@@ -6,8 +6,8 @@ import { dsl } from "../";
 describe("Imports", () => {
     describe("with require", () => {
         it("should have expected properties for unmock", () => {
-            expect(unmockRequireDefault).toBeDefined();
-            expect(unmockRequireDefault).toHaveProperty("on");
+            expect(unmockRequire).toBeDefined();
+            expect(unmockRequire).toHaveProperty("on");
         });
         it("should have expected properties for dsl object", () => {
             expect(dslRequire).toBeDefined();

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -1,7 +1,6 @@
-import { CorePackage } from "unmock-core";
+import { CorePackage, dsl } from "unmock-core";
 import NodeBackend from "./backend";
 import _WinstonLogger from "./loggers/winston-logger";
-export { dsl } from "unmock-core";
 
 const backend = new NodeBackend();
 
@@ -12,4 +11,8 @@ class UnmockNode extends CorePackage {
 }
 
 const unmock = new UnmockNode(backend, { logger: new _WinstonLogger() });
-export default unmock;
+
+module.exports = exports = unmock;
+
+exports.dsl = dsl;
+exports.default = unmock;


### PR DESCRIPTION
- TL;DR: We may not want to do this but just stick to `require("unmock-node").default`
- Trying to have both `const unmock = require("unmock-node")` and `import unmock from "unmock-node"` work
- This requires setting either `module.exports` or assigning stuff to `exports` object
- Note that our TS-to-JS transpilation adds the following lines at the top of JS:
```
"use strict";
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};
Object.defineProperty(exports, "__esModule", { value: true });
```
So it's NOT a good idea to directly re-assign `exports` with something like `module.exports = exports = ...` as all of that is lost.
- One could use [this](https://www.npmjs.com/package/babel-plugin-add-module-exports) Babel plugin to add module exports
- See [this discussion](https://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default) on why Babel 6 changed the behaviour on `module.exports`