### PR TITLE
Export Request from unmock-node.

### DIFF
--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -9,6 +9,9 @@ import { AllowedHosts, BooleanSetting } from "./settings";
 // top-level exports
 export * from "./interfaces";
 export * from "./generator";
+
+export { StateFacadeType as States } from "./service/interfaces";
+
 export const dsl = transformers;
 
 export abstract class CorePackage implements IUnmockPackage {

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
 import path from "path";
 import { CorePackage } from "unmock-core";
-import { dsl } from "../..";
+import { dsl, Request } from "../../..";
+
 import NodeBackend from "../../backend";
 
 class StateTestPackage extends CorePackage {
@@ -106,6 +107,12 @@ describe("Node.js interceptor", () => {
       states.petstore(() => "baz");
       const response = await axios("http://petstore.swagger.io/v1/pets");
       expect(response.data).toBe("baz");
+    });
+
+    test("sets an entire response from with request object", async () => {
+      states.petstore((req: Request) => req.host);
+      const response = await axios("http://petstore.swagger.io/v1/pets");
+      expect(response.data).toBe("petstore.swagger.io");
     });
 
     test("sets an entire response from function with DSL", async () => {

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -1,7 +1,9 @@
-import { CorePackage } from "unmock-core";
+import { CorePackage, ISerializedRequest } from "unmock-core";
 import NodeBackend from "./backend";
 import _WinstonLogger from "./loggers/winston-logger";
 export { dsl } from "unmock-core";
+
+export type Request = ISerializedRequest;
 
 const backend = new NodeBackend();
 

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -1,9 +1,12 @@
-import { CorePackage, ISerializedRequest } from "unmock-core";
+import { CorePackage } from "unmock-core";
 import NodeBackend from "./backend";
 import _WinstonLogger from "./loggers/winston-logger";
+
+// DSL
 export { dsl } from "unmock-core";
 
-export type Request = ISerializedRequest;
+// Types
+export * from "./types";
 
 const backend = new NodeBackend();
 

--- a/packages/unmock-node/src/types.ts
+++ b/packages/unmock-node/src/types.ts
@@ -1,4 +1,5 @@
 // Types and aliases exported from unmock-node
-import { ISerializedRequest } from "unmock-core";
-
-export type Request = ISerializedRequest;
+export {
+    ISerializedRequest as Request,
+    States,
+} from "unmock-core";

--- a/packages/unmock-node/src/types.ts
+++ b/packages/unmock-node/src/types.ts
@@ -1,0 +1,4 @@
+// Types and aliases exported from unmock-node
+import { ISerializedRequest } from "unmock-core";
+
+export type Request = ISerializedRequest;


### PR DESCRIPTION
- Because `Request` is exposed to the user via the DSL function syntax
- [x] Also export `type States = StateFacadeFactory`