### PR TITLE
Add typing to unmock.states.

### DIFF
--- a/packages/unmock-core/src/__tests__/corePackage.test.ts
+++ b/packages/unmock-core/src/__tests__/corePackage.test.ts
@@ -2,7 +2,7 @@ import { CorePackage, IBackend } from "..";
 
 class TestPackage extends CorePackage {
   public states() {
-    return;
+    return undefined;
   }
 }
 // tslint:disable-next-line: max-classes-per-file

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -9,8 +9,9 @@ import { AllowedHosts, BooleanSetting } from "./settings";
 // top-level exports
 export * from "./interfaces";
 export * from "./generator";
+import { StateFacadeType } from "./service/interfaces";
 
-export { StateFacadeType as States } from "./service/interfaces";
+export type States = StateFacadeType;
 
 export const dsl = transformers;
 
@@ -55,5 +56,5 @@ export abstract class CorePackage implements IUnmockPackage {
     this.backend.reset();
   }
 
-  public abstract states(): any;
+  public abstract states(): States | undefined;
 }

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -166,7 +166,6 @@ export interface IUnmockServiceState
  * the actual service specification.
  * Validation can be done either in runtime or via IDE extensions.
  */
-type FunctionInput = (req: ISerializedRequest) => any;
 export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 
 // ##########################
@@ -175,6 +174,8 @@ export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 
 // Used to define the simplify the types used
 type FluentStateStore = StateFacadeType & SetStateForSpecificMethod;
+// Used to define the response from intercepted request
+type FunctionInput = (req: ISerializedRequest) => any;
 type StateInput = IStateInputGenerator | UnmockServiceState | string | FunctionInput;
 
 // Used to incorporate the reset method when needed

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -166,6 +166,7 @@ export interface IUnmockServiceState
  * the actual service specification.
  * Validation can be done either in runtime or via IDE extensions.
  */
+type FunctionInput = (req: ISerializedRequest) => any;
 export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 
 // ##########################
@@ -174,7 +175,7 @@ export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 
 // Used to define the simplify the types used
 type FluentStateStore = StateFacadeType & SetStateForSpecificMethod;
-type StateInput = IStateInputGenerator | UnmockServiceState | string;
+type StateInput = IStateInputGenerator | UnmockServiceState | string | FunctionInput;
 
 // Used to incorporate the reset method when needed
 interface IResetState {

--- a/packages/unmock-jsdom/src/index.ts
+++ b/packages/unmock-jsdom/src/index.ts
@@ -1,11 +1,11 @@
-import { CorePackage, States } from "unmock-core";
+import { CorePackage } from "unmock-core";
 import JSDomBackend from "./backend";
 import BrowserLogger from "./logger/browser-logger";
 
 const backend = new JSDomBackend();
 
 class UnmockJSDOM extends CorePackage {
-  public states(): States {
+  public states(): never {
     throw new Error("Unmock JSDOM does not implement state management yet!");
   }
 }

--- a/packages/unmock-jsdom/src/index.ts
+++ b/packages/unmock-jsdom/src/index.ts
@@ -1,11 +1,11 @@
-import { CorePackage } from "unmock-core";
+import { CorePackage, States } from "unmock-core";
 import JSDomBackend from "./backend";
 import BrowserLogger from "./logger/browser-logger";
 
 const backend = new JSDomBackend();
 
 class UnmockJSDOM extends CorePackage {
-  public states() {
+  public states(): States {
     throw new Error("Unmock JSDOM does not implement state management yet!");
   }
 }

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import path from "path";
-import { CorePackage } from "unmock-core";
+import { CorePackage, States } from "unmock-core";
 import { dsl, Request } from "../../..";
 
 import NodeBackend from "../../backend";
@@ -17,7 +17,7 @@ describe("Node.js interceptor", () => {
   describe("with state requests in place", () => {
     let nodeInterceptor: NodeBackend;
     let unmock: StateTestPackage;
-    let states: any;
+    let states: States;
 
     beforeAll(() => {
       nodeInterceptor = new NodeBackend({ servicesDirectory });
@@ -27,7 +27,6 @@ describe("Node.js interceptor", () => {
 
     afterAll(() => {
       unmock.off();
-      states = undefined;
     });
 
     beforeEach(() => states.reset());

--- a/packages/unmock-node/src/backend/index.ts
+++ b/packages/unmock-node/src/backend/index.ts
@@ -15,6 +15,7 @@ import {
   ISerializedResponse,
   IUnmockOptions,
   responseCreatorFactory,
+  States,
 } from "unmock-core";
 import { FsServiceDefLoader } from "../loaders/fs-service-def-loader";
 import FSLogger from "../loggers/filesystem-logger";
@@ -77,7 +78,7 @@ interface IBypassableSocket extends net.Socket {
 export default class NodeBackend implements IBackend {
   private readonly config: INodeBackendOptions;
   private mitm: any;
-  private stateStore: any = undefined;
+  private stateStore?: States = undefined;
 
   public constructor(config?: INodeBackendOptions) {
     this.config = { ...nodeBackendDefaultOptions, ...config };


### PR DESCRIPTION
- [x]  Using function as `StateInput` does not type-check
- Define the type for function input as `type FunctionInput = (req: ISerializedRequest) => any;` even though it currently also accepts a template as second parameter but not sure if we need to expose that in the types