### PR TITLE
Check types on test files post-install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "compile:tests": "tsc --build tsconfig.test.json && tsc --build tsconfig.test.json --clean",
     "watch": "tsc --build tsconfig.build.json --watch",
     "release": "npm run clean && npm install && lerna publish from-package --exact --force-publish=unmock-core --include-merged-tags",
-    "postinstall": "lerna run prepare && npm run lint-ts && npm run compile",
+    "postinstall": "lerna run prepare && npm run lint-ts && npm run compile:tests && npm run compile",
     "format-check": "prettier-check '**/*.{js,ts}'",
     "format": "prettier '**/*.{js,ts}' --write",
     "lint": "npm run lint-ts",

--- a/tsconfig.test.base.json
+++ b/tsconfig.test.base.json
@@ -1,3 +1,6 @@
 {
   "extends": "./tsconfig.base",
+  "compilerOptions": {
+    "noEmit": true
+  }
 }


### PR DESCRIPTION
- Also add `noEmit: true` to `tsconfig.test.base.json` to avoid emitting on test files