### PR TITLE
Use babel runtime plugin to polyfill instead of requiring core-js.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,14 +2,13 @@ module.exports = {
     "presets": [
         ["@babel/env",
         {
-            targets: { node: 6 },
-            useBuiltIns: "usage",
-            corejs: 3,
+            targets: { node: 8 },
             modules: "cjs"
         }],
         "@babel/typescript"
     ],
     "plugins": [
+        ["@babel/plugin-transform-runtime", { corejs: 3 }],
         "@babel/proposal-class-properties",
         "@babel/proposal-object-rest-spread"
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -716,6 +716,18 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
+      "integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -12529,6 +12541,7 @@
     "unmock": {
       "version": "file:packages/unmock",
       "requires": {
+        "@babel/runtime": "^7.5.5",
         "core-js": "^3.2.1",
         "unmock-cli": "file:packages/unmock-cli"
       },
@@ -12543,6 +12556,7 @@
     "unmock-cli": {
       "version": "file:packages/unmock-cli",
       "requires": {
+        "@babel/runtime": "^7.5.5",
         "commander": "^2.20.0",
         "core-js": "^3.2.1",
         "glob": "^7.1.3",
@@ -12560,6 +12574,7 @@
     "unmock-core": {
       "version": "file:packages/unmock-core",
       "requires": {
+        "@babel/runtime": "^7.5.5",
         "ajv": "^6.10.0",
         "axios": "^0.18.0",
         "boxen": "3.2.0",
@@ -12639,6 +12654,7 @@
     "unmock-jsdom": {
       "version": "file:packages/unmock-jsdom",
       "requires": {
+        "@babel/runtime": "^7.5.5",
         "core-js": "^3.2.1",
         "js-yaml": "^3.13.1",
         "unmock-core": "file:packages/unmock-core"
@@ -12654,6 +12670,7 @@
     "unmock-node": {
       "version": "file:packages/unmock-node",
       "requires": {
+        "@babel/runtime": "^7.5.5",
         "app-root-path": "^2.2.1",
         "core-js": "^3.2.1",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12549,7 +12549,6 @@
     "unmock": {
       "version": "file:packages/unmock",
       "requires": {
-        "@babel/runtime": "^7.5.5",
         "@babel/runtime-corejs3": "^7.5.5",
         "unmock-cli": "file:packages/unmock-cli"
       },
@@ -12564,7 +12563,6 @@
     "unmock-cli": {
       "version": "file:packages/unmock-cli",
       "requires": {
-        "@babel/runtime": "^7.5.5",
         "@babel/runtime-corejs3": "^7.5.5",
         "commander": "^2.20.0",
         "glob": "^7.1.3",
@@ -12582,7 +12580,6 @@
     "unmock-core": {
       "version": "file:packages/unmock-core",
       "requires": {
-        "@babel/runtime": "^7.5.5",
         "@babel/runtime-corejs3": "^7.5.5",
         "ajv": "^6.10.0",
         "axios": "^0.18.0",
@@ -12662,7 +12659,6 @@
     "unmock-jsdom": {
       "version": "file:packages/unmock-jsdom",
       "requires": {
-        "@babel/runtime": "^7.5.5",
         "@babel/runtime-corejs3": "^7.5.5",
         "js-yaml": "^3.13.1",
         "unmock-core": "file:packages/unmock-core"
@@ -12678,7 +12674,6 @@
     "unmock-node": {
       "version": "file:packages/unmock-node",
       "requires": {
-        "@babel/runtime": "^7.5.5",
         "@babel/runtime-corejs3": "^7.5.5",
         "app-root-path": "^2.2.1",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -889,6 +889,15 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.5.5.tgz",
+      "integrity": "sha512-bNxHJ+w7RfLzZJtIZdEjFgL1twwZ6ozuOmsEjtyuTqfi1hb1fqsDYYyi3Fi3i+RgAO4S9+wkSG102+GCqdpr7w==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -4837,8 +4846,7 @@
     "core-js-pure": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
-      "dev": true
+      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -12542,7 +12550,7 @@
       "version": "file:packages/unmock",
       "requires": {
         "@babel/runtime": "^7.5.5",
-        "core-js": "^3.2.1",
+        "@babel/runtime-corejs3": "^7.5.5",
         "unmock-cli": "file:packages/unmock-cli"
       },
       "dependencies": {
@@ -12557,8 +12565,8 @@
       "version": "file:packages/unmock-cli",
       "requires": {
         "@babel/runtime": "^7.5.5",
+        "@babel/runtime-corejs3": "^7.5.5",
         "commander": "^2.20.0",
-        "core-js": "^3.2.1",
         "glob": "^7.1.3",
         "unmock-core": "file:packages/unmock-core",
         "unmock-node": "file:packages/unmock-node"
@@ -12575,11 +12583,11 @@
       "version": "file:packages/unmock-core",
       "requires": {
         "@babel/runtime": "^7.5.5",
+        "@babel/runtime-corejs3": "^7.5.5",
         "ajv": "^6.10.0",
         "axios": "^0.18.0",
         "boxen": "3.2.0",
         "chalk": "^2.4.2",
-        "core-js": "^3.2.1",
         "debug": "^4.1.1",
         "js-yaml": "^3.13.1",
         "json-pointer": "^0.6.0",
@@ -12655,7 +12663,7 @@
       "version": "file:packages/unmock-jsdom",
       "requires": {
         "@babel/runtime": "^7.5.5",
-        "core-js": "^3.2.1",
+        "@babel/runtime-corejs3": "^7.5.5",
         "js-yaml": "^3.13.1",
         "unmock-core": "file:packages/unmock-core"
       },
@@ -12671,8 +12679,8 @@
       "version": "file:packages/unmock-node",
       "requires": {
         "@babel/runtime": "^7.5.5",
+        "@babel/runtime-corejs3": "^7.5.5",
         "app-root-path": "^2.2.1",
-        "core-js": "^3.2.1",
         "debug": "^4.1.1",
         "expect": "^24.7.1",
         "ini": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-proposal-numeric-separator": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+    "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-typescript": "^7.3.3",
     "@types/app-root-path": "^1.2.4",

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.5",
     "@babel/runtime-corejs3": "^7.5.5",
     "commander": "^2.20.0",
     "glob": "^7.1.3",

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.5",
     "commander": "^2.20.0",
-    "core-js": "^3.2.1",
     "glob": "^7.1.3",
     "unmock-core": "file:../unmock-core",
     "unmock-node": "file:../unmock-node"

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "@babel/runtime-corejs3": "^7.5.5",
     "commander": "^2.20.0",
     "glob": "^7.1.3",
     "unmock-core": "file:../unmock-core",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.5",
     "@babel/runtime-corejs3": "^7.5.5",
     "ajv": "^6.10.0",
     "axios": "^0.18.0",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.5",
     "ajv": "^6.10.0",
     "axios": "^0.18.0",
     "boxen": "3.2.0",
     "chalk": "^2.4.2",
-    "core-js": "^3.2.1",
     "debug": "^4.1.1",
     "js-yaml": "^3.13.1",
     "json-pointer": "^0.6.0",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "@babel/runtime-corejs3": "^7.5.5",
     "ajv": "^6.10.0",
     "axios": "^0.18.0",
     "boxen": "3.2.0",

--- a/packages/unmock-jsdom/package.json
+++ b/packages/unmock-jsdom/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.5",
     "@babel/runtime-corejs3": "^7.5.5",
     "js-yaml": "^3.13.1",
     "unmock-core": "file:../unmock-core"

--- a/packages/unmock-jsdom/package.json
+++ b/packages/unmock-jsdom/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "@babel/runtime-corejs3": "^7.5.5",
     "js-yaml": "^3.13.1",
     "unmock-core": "file:../unmock-core"
   }

--- a/packages/unmock-jsdom/package.json
+++ b/packages/unmock-jsdom/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "core-js": "^3.2.1",
+    "@babel/runtime": "^7.5.5",
     "js-yaml": "^3.13.1",
     "unmock-core": "file:../unmock-core"
   }

--- a/packages/unmock-node/package.json
+++ b/packages/unmock-node/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.5",
     "@babel/runtime-corejs3": "^7.5.5",
     "app-root-path": "^2.2.1",
     "debug": "^4.1.1",

--- a/packages/unmock-node/package.json
+++ b/packages/unmock-node/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "@babel/runtime-corejs3": "^7.5.5",
     "app-root-path": "^2.2.1",
     "debug": "^4.1.1",
     "expect": "^24.7.1",

--- a/packages/unmock-node/package.json
+++ b/packages/unmock-node/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.5",
     "app-root-path": "^2.2.1",
-    "core-js": "^3.2.1",
     "debug": "^4.1.1",
     "expect": "^24.7.1",
     "ini": "^1.3.5",

--- a/packages/unmock/package.json
+++ b/packages/unmock/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "core-js": "^3.2.1",
+    "@babel/runtime": "^7.5.5",
     "unmock-cli": "file:../unmock-cli"
   }
 }

--- a/packages/unmock/package.json
+++ b/packages/unmock/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "@babel/runtime-corejs3": "^7.5.5",
     "unmock-cli": "file:../unmock-cli"
   }
 }

--- a/packages/unmock/package.json
+++ b/packages/unmock/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.5",
     "@babel/runtime-corejs3": "^7.5.5",
     "unmock-cli": "file:../unmock-cli"
   }


### PR DESCRIPTION
Apparently using `core-js` can pollute the global scope: https://babeljs.io/docs/en/babel-plugin-transform-runtime#why