### PR TITLE
Make DSL submodule more FP

### DIFF
--- a/packages/unmock-core/src/__tests__/dsl.test.ts
+++ b/packages/unmock-core/src/__tests__/dsl.test.ts
@@ -107,7 +107,7 @@ describe("Translates top level DSL to OAS", () => {
 
 describe("Translates non-top level DSL to OAS", () => {
   it("Returns empty translation for empty state", () => {
-    expect(DSL.translateDSLToOAS({}, {})).toEqual({});
+    expect(DSL.replaceDSLWithOAS({}, {})).toEqual({});
   });
 
   describe("Translates $size correctly", () => {
@@ -130,20 +130,20 @@ describe("Translates non-top level DSL to OAS", () => {
       DSL.STRICT_MODE = false;
       // Test with non-numeric
       const state: { $size: any } = { $size: "a" };
-      let translated = DSL.translateDSLToOAS(state, arraySchema);
+      let translated = DSL.replaceDSLWithOAS(state, arraySchema);
       expect(translated).toEqual({}); // Nothing was translated
       expect(state).toEqual({ $size: "a" });
 
       // Test with non-positive input
       state.$size = -1;
-      translated = DSL.translateDSLToOAS(state, arraySchema);
+      translated = DSL.replaceDSLWithOAS(state, arraySchema);
       expect(translated).toEqual({}); // Nothing was translated
       expect(state).toEqual({ $size: -1 });
 
       // Test with non-array input
       state.$size = 5;
       arraySchema.type = "object";
-      translated = DSL.translateDSLToOAS(state, arraySchema);
+      translated = DSL.replaceDSLWithOAS(state, arraySchema);
       expect(translated).toEqual({}); // Nothing was translated
       expect(state).toEqual({ $size: 5 });
     });
@@ -151,14 +151,14 @@ describe("Translates non-top level DSL to OAS", () => {
     it("Throws with non-numeric input in strict mode", () => {
       DSL.STRICT_MODE = true;
       const state = { $size: "a" };
-      const translated = () => DSL.translateDSLToOAS(state, arraySchema);
+      const translated = () => DSL.replaceDSLWithOAS(state, arraySchema);
       expect(translated).toThrow("non-numeric");
     });
 
     it("Throws with non-positive input in strict mode", () => {
       DSL.STRICT_MODE = true;
       const state = { $size: 0.3 }; // rounded to 0
-      const translated = () => DSL.translateDSLToOAS(state, arraySchema);
+      const translated = () => DSL.replaceDSLWithOAS(state, arraySchema);
       expect(translated).toThrow("non-positive");
     });
 
@@ -166,13 +166,13 @@ describe("Translates non-top level DSL to OAS", () => {
       DSL.STRICT_MODE = true;
       const state = { $size: 3 };
       arraySchema.type = "object";
-      const translated = () => DSL.translateDSLToOAS(state, arraySchema);
+      const translated = () => DSL.replaceDSLWithOAS(state, arraySchema);
       expect(translated).toThrow("non-array");
     });
 
     it("Translates $size correctly", () => {
       const state = { $size: 3, id: 5 };
-      const translated = DSL.translateDSLToOAS(state, arraySchema);
+      const translated = DSL.replaceDSLWithOAS(state, arraySchema);
       expect(state).toEqual({ id: 5 }); // $size element should be removed
       expect(translated).toEqual({ maxItems: 3, minItems: 3 });
     });

--- a/packages/unmock-core/src/service/dsl/actors.ts
+++ b/packages/unmock-core/src/service/dsl/actors.ts
@@ -1,5 +1,4 @@
 import debug from "debug";
-import { cloneDeep } from "lodash";
 import { mediaTypeToSchema } from "../interfaces";
 import { SCHEMA_TIMES } from "./constants";
 import { Actor, Props } from "./interfaces";
@@ -41,9 +40,9 @@ const actOn$times: Actor = (
     delete originalSchema[mediaType];
     return {};
   }
-  const copy = cloneDeep(originalSchema[mediaType]);
-  delete (copy.properties as Props)[SCHEMA_TIMES];
-  return copy;
+  const { properties, ...rest } = originalSchema[mediaType];
+  const { [SCHEMA_TIMES]: _, ...restProperties } = properties as Props;
+  return { properties: restProperties, ...rest };
 };
 
 export const actors: { [propertyName: string]: Actor } = {

--- a/packages/unmock-core/src/service/dsl/dsl.ts
+++ b/packages/unmock-core/src/service/dsl/dsl.ts
@@ -73,23 +73,19 @@ export abstract class DSL {
    * @param states
    */
   public static actTopLevelFromOAS(states: codeToMedia): codeToMedia {
-    const copy: codeToMedia = {};
-    for (const code of Object.keys(states)) {
-      copy[code] = Object.keys(states[code]).reduce(
+    const act = (mToS: mediaTypeToSchema) =>
+      Object.keys(mToS).reduce(
         (obj, mediaType) => ({
           ...obj,
-          [mediaType]: actOnSchema(states[code], mediaType),
+          [mediaType]: actOnSchema(mToS, mediaType),
         }),
         {},
       );
-      if (Object.keys(copy[code]).length === 0) {
-        debugLog(
-          `Entire response is empty, removing '${code}' from copied response`,
-        );
-        delete copy[code];
-      }
-    }
-    return copy;
+
+    return Object.keys(states).reduce(
+      (obj, code) => ({ ...obj, [code]: act(states[code]) }),
+      {},
+    );
   }
 }
 

--- a/packages/unmock-core/src/service/dsl/dsl.ts
+++ b/packages/unmock-core/src/service/dsl/dsl.ts
@@ -59,10 +59,20 @@ export abstract class DSL {
     // Handles top-level schema and injects the literals to responses.
     // $code is a special case, handled outside this function (acts as a key and not a value)
     Object.keys(topTranslators)
-      .filter(dslKey => top[dslKey] !== undefined)
-      .map(dslKey => topTranslators[dslKey](top[dslKey]))
-      .filter(translation => translation !== undefined)
-      .forEach(translation => injectUnmockProperty(responses, translation));
+      .filter(
+        dslKey => top[dslKey] !== undefined /* only valid top-level DSL keys */,
+      )
+      .map(
+        dslKey => topTranslators[dslKey](top[dslKey]) /* get the translation */,
+      )
+      .filter(
+        translation =>
+          translation !== undefined /* no undefined translations */,
+      )
+      .forEach(
+        translation =>
+          injectUnmockProperty(responses, translation) /* add to responses */,
+      );
     return responses;
   }
 

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -1,4 +1,4 @@
-import { Schema } from "../interfaces";
+import { mediaTypeToSchema, Schema } from "../interfaces";
 
 /**
  * DSL related parameters that can only be found at the top level
@@ -40,3 +40,12 @@ export interface IUnmockProperty {
     default: any;
   };
 }
+
+/**
+ * Stuff for general DSL submodule
+ */
+
+export type Actor = (
+  originalSchema: mediaTypeToSchema,
+  mediaType: string,
+) => Schema;

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -16,6 +16,7 @@ export interface ITopLevelDSL {
    */
   $code?: number;
   $times?: number;
+  [DSLKey: string]: any;
 }
 
 /**
@@ -49,3 +50,5 @@ export type Actor = (
   originalSchema: mediaTypeToSchema,
   mediaType: string,
 ) => Schema;
+export type Translator = (state: any, schema: Schema) => any;
+export type TopTranslator = (value: any) => any;

--- a/packages/unmock-core/src/service/dsl/translators.ts
+++ b/packages/unmock-core/src/service/dsl/translators.ts
@@ -1,14 +1,15 @@
 import debug from "debug";
 import { Schema } from "../interfaces";
 import { SCHEMA_TIMES } from "./constants";
-import { buildUnmockPropety } from "./utils";
+import { TopTranslator, Translator } from "./interfaces";
+import { buildUnmockPropety, throwOnErrorIfStrict } from "./utils";
 
 const debugLog = debug("unmock:dsl:translators");
 /*
  * Translators (translate$X) are found here. They translate a DSL instruction to OAS, without modifying any schemas.
  */
 
-export const translate$times = (times: any) => {
+const translate$times: TopTranslator = (times: any) => {
   if (typeof times !== "number") {
     throw new Error("Can't set response $times with non-numeric value!");
   }
@@ -25,7 +26,7 @@ export const translate$times = (times: any) => {
  * @param state
  * @param schema
  */
-export const translate$size = (state: any, schema: Schema): any => {
+const translate$size: Translator = (state: any, schema: Schema): any => {
   // assumes state.$size exists
   if (schema.type === undefined || schema.type !== "array") {
     throw new Error("Can't set '$size' for non-array elements!");
@@ -38,4 +39,14 @@ export const translate$size = (state: any, schema: Schema): any => {
     throw new Error("Can't request a non-positive size of array!");
   }
   return { minItems: nElements, maxItems: nElements };
+};
+
+export const translators: {
+  [DSLKey: string]: Translator;
+} = {
+  $size: (st, sc) => throwOnErrorIfStrict(() => translate$size(st, sc)),
+};
+
+export const topTranslators: { [DSLKey: string]: TopTranslator } = {
+  $times: val => throwOnErrorIfStrict(() => translate$times(val)),
 };

--- a/packages/unmock-core/src/service/dsl/utils.ts
+++ b/packages/unmock-core/src/service/dsl/utils.ts
@@ -32,13 +32,14 @@ export const filterTopLevelDSL = (state: UnmockServiceState) => {
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
 };
 
-export const throwOnErrorIfStrict = (fn: () => void) => {
+export const throwOnErrorIfStrict = (fn: () => any) => {
   try {
-    fn();
+    return fn();
   } catch (e) {
     if (DSL.STRICT_MODE) {
       throw e;
     }
+    return undefined;
   }
 };
 

--- a/packages/unmock-core/src/service/dsl/utils.ts
+++ b/packages/unmock-core/src/service/dsl/utils.ts
@@ -12,25 +12,23 @@ import { IUnmockProperty, TopLevelDSLKeys } from "./interfaces";
 
 const debugLog = debug("unmock:dsl:utils");
 
-export const getTopLevelDSL = (state: UnmockServiceState) => {
-  return Object.keys(state)
+export const getTopLevelDSL = (state: UnmockServiceState) =>
+  Object.keys(state)
     .filter(
       (key: string) =>
         TopLevelDSLKeys[key] !== undefined &&
         TopLevelDSLKeys[key] === typeof state[key],
     )
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
-};
 
-export const filterTopLevelDSL = (state: UnmockServiceState) => {
-  return Object.keys(state)
+export const filterTopLevelDSL = (state: UnmockServiceState) =>
+  Object.keys(state)
     .filter(
       (key: string) =>
         TopLevelDSLKeys[key] === undefined ||
         TopLevelDSLKeys[key] !== typeof state[key],
     )
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
-};
 
 export const throwOnErrorIfStrict = (fn: () => any) => {
   try {

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -129,7 +129,7 @@ const spreadStateFromService = (
         );
         // Option 1a: current schema has no matching key, but contains indirection (items/properties, etc)
         // `statePath` at this point may also contain DSL elements, so we parse them before moving onwards
-        const translated = DSL.translateDSLToOAS(statePath, serviceSchema);
+        const translated = DSL.replaceDSLWithOAS(statePath, serviceSchema);
         const spread = {
           ...oneLevelOfIndirectNestedness(serviceSchema, statePath),
           ...translated,
@@ -168,7 +168,7 @@ const spreadStateFromService = (
         );
         // Option 3: Current scheme has matching key, state specifies an object - traverse schema and indirection
         // `stateValue` at this point may also contain DSL elements, so we parse them before moving onwards
-        const translated = DSL.translateDSLToOAS(stateValue, scm);
+        const translated = DSL.replaceDSLWithOAS(stateValue, scm);
         const spread = {
           [key]: { ...spreadStateFromService(scm, stateValue), ...translated },
         };


### PR DESCRIPTION
Following the conversation in #124 (and out of my own personal wishes to improve my skills in FP :innocent: ), I thought to slowly transition stuff to have more FP-style.
Main goal is to find `for (` in the code and replace them as possible with the matching functional methods.

* `dsl.test.ts` modified because `DSL.translateDSLToOAS` was renamed to `DSL.replaceDSLWithOAS` to better reflect underlying processes.