### PR TITLE
Groundwork for a service call spy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1797,6 +1797,38 @@
         "url-template": "^2.0.8"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@types/app-root-path": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
@@ -1968,6 +2000,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.1.tgz",
       "integrity": "sha512-I9ouuzrWLcjM1wre7f0i780W3KHk5PxFAC5KOpvpOGNaTsaKLN8p7sqRh9THwV9cpdOA/YJC+yMhG1jonQFdRQ==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
+      "integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -2233,6 +2271,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-ify": {
       "version": "1.0.0",
@@ -4324,8 +4367,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "diff-sequences": {
       "version": "24.3.0",
@@ -7939,6 +7981,11 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -8147,6 +8194,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8639,6 +8691,33 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "nise": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.1.tgz",
+      "integrity": "sha512-edFWm0fsFG2n318rfEnKlTZTkjlbVOFF9XIA+fj+Ed+Qz1laYW2lobwavWoMzGrYDHH1EpiNJgDfvGnkZztR/g==",
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -10352,6 +10431,20 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "sinon": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.1.tgz",
+      "integrity": "sha512-7s9buHGHN/jqoy/v4bJgmt0m1XEkCEd/tqdHXumpBp0JSujaT4Ng84JU5wDdK4E85ZMq78NuDe0I3NAqXY8TFg==",
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.2",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.1",
+        "supports-color": "^5.5.0"
+      }
+    },
     "sisteransi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.2.tgz",
@@ -11352,6 +11445,11 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
     "type-fest": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
@@ -11505,6 +11603,7 @@
         "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "querystring": "^0.2.0",
+        "sinon": "^7.4.1",
         "swagger2openapi": "^5.3.0",
         "xregexp": "^4.2.4"
       },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^8.10.51",
     "@types/shimmer": "^1.0.1",
+    "@types/sinon": "^7.0.13",
     "@types/uuid": "^3.4.5",
     "@types/xregexp": "^3.0.30",
     "codecov": "^3.3.0",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.4",
     "@types/json-pointer": "^1.0.30",
-    "@types/sinon": "^7.0.13",
     "@types/xregexp": "^3.0.30"
   }
 }

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -26,12 +26,14 @@
     "lodash": "^4.17.14",
     "minimatch": "^3.0.4",
     "querystring": "^0.2.0",
+    "sinon": "^7.4.1",
     "swagger2openapi": "^5.3.0",
     "xregexp": "^4.2.4"
   },
   "devDependencies": {
     "@types/debug": "^4.1.4",
     "@types/json-pointer": "^1.0.30",
+    "@types/sinon": "^7.0.13",
     "@types/xregexp": "^3.0.30"
   }
 }

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -21,7 +21,7 @@ describe("Creating a spy", () => {
   });
   it("should record calls made via notify", () => {
     const spyable: IRecorder = createCallRecorder();
-    spyable.record(fakeRequest, fakeResponse);
+    spyable.record({ req: fakeRequest, res: fakeResponse });
     assert.calledOnce(spyable.spy);
     assert.calledWithExactly(spyable.spy, fakeRequest);
     expect(spyable.spy.firstCall.returnValue).toEqual(fakeResponse);
@@ -30,7 +30,7 @@ describe("Creating a spy", () => {
     const spyable: IRecorder = createCallRecorder();
     const attached = { a: 1 };
     const objWithSpy = Object.assign(attached, spyable);
-    objWithSpy.record(fakeRequest, fakeResponse);
+    objWithSpy.record({ req: fakeRequest, res: fakeResponse });
     assert.calledOnce(objWithSpy.spy);
     assert.calledWithExactly(objWithSpy.spy, fakeRequest);
     expect(objWithSpy.spy.firstCall.returnValue).toEqual(fakeResponse);

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -1,0 +1,29 @@
+import { assert } from "sinon";
+import { ISerializedRequest, ISerializedResponse } from "../interfaces";
+import { get } from "../service/spy";
+
+const fakeRequest: ISerializedRequest = {
+  method: "GET",
+  host: "github.com",
+  protocol: "https",
+  path: "/v3",
+};
+
+const fakeResponse: ISerializedResponse = {
+  statusCode: 200,
+  body: JSON.stringify({ foo: "bar" }),
+};
+
+describe("Creating a spy", () => {
+  it("should not be called after creation", () => {
+    const testObj = get();
+    assert.notCalled(testObj.spy);
+  });
+  it("should record calls", () => {
+    const testObj = get();
+    testObj.notify(fakeRequest, fakeResponse);
+    assert.calledOnce(testObj.spy);
+    assert.calledWithExactly(testObj.spy, fakeRequest);
+    expect(testObj.spy.firstCall.returnValue).toEqual(fakeResponse);
+  });
+});

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "sinon";
 import { ISerializedRequest, ISerializedResponse } from "../interfaces";
-import { createCallRecorder, ICallTracker } from "../service/spy";
+import { createCallTracker, ICallTracker } from "../service/spy";
 
 const fakeRequest: ISerializedRequest = {
   method: "GET",
@@ -16,11 +16,11 @@ const fakeResponse: ISerializedResponse = {
 
 describe("Creating a spy", () => {
   it("should not be called after creation", () => {
-    const spyable: ICallTracker = createCallRecorder();
-    assert.notCalled(spyable.spy);
+    const callTracker: ICallTracker = createCallTracker();
+    assert.notCalled(callTracker.spy);
   });
   it("should record calls made via notify", () => {
-    const callTracker: ICallTracker = createCallRecorder();
+    const callTracker: ICallTracker = createCallTracker();
     callTracker.track({ req: fakeRequest, res: fakeResponse });
     assert.calledOnce(callTracker.spy);
     assert.calledWithExactly(callTracker.spy, fakeRequest);

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -16,14 +16,23 @@ const fakeResponse: ISerializedResponse = {
 
 describe("Creating a spy", () => {
   it("should not be called after creation", () => {
-    const testObj: ISpyable = createRequestResponseSpy();
-    assert.notCalled(testObj.spy);
+    const spyable: ISpyable = createRequestResponseSpy();
+    assert.notCalled(spyable.spy);
   });
   it("should record calls made via notify", () => {
-    const testObj: ISpyable = createRequestResponseSpy();
-    testObj.notify(fakeRequest, fakeResponse);
-    assert.calledOnce(testObj.spy);
-    assert.calledWithExactly(testObj.spy, fakeRequest);
-    expect(testObj.spy.firstCall.returnValue).toEqual(fakeResponse);
+    const spyable: ISpyable = createRequestResponseSpy();
+    spyable.notify(fakeRequest, fakeResponse);
+    assert.calledOnce(spyable.spy);
+    assert.calledWithExactly(spyable.spy, fakeRequest);
+    expect(spyable.spy.firstCall.returnValue).toEqual(fakeResponse);
+  });
+  it("should be attachable to another object", () => {
+    const spyable: ISpyable = createRequestResponseSpy();
+    const attached = { a: 1 };
+    const objWithSpy = Object.assign(attached, spyable);
+    objWithSpy.notify(fakeRequest, fakeResponse);
+    assert.calledOnce(objWithSpy.spy);
+    assert.calledWithExactly(objWithSpy.spy, fakeRequest);
+    expect(objWithSpy.spy.firstCall.returnValue).toEqual(fakeResponse);
   });
 });

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "sinon";
 import { ISerializedRequest, ISerializedResponse } from "../interfaces";
-import { createRequestResponseSpy, ISpyable } from "../service/spy";
+import { createCallRecorder, IRecorder } from "../service/spy";
 
 const fakeRequest: ISerializedRequest = {
   method: "GET",
@@ -16,21 +16,21 @@ const fakeResponse: ISerializedResponse = {
 
 describe("Creating a spy", () => {
   it("should not be called after creation", () => {
-    const spyable: ISpyable = createRequestResponseSpy();
+    const spyable: IRecorder = createCallRecorder();
     assert.notCalled(spyable.spy);
   });
   it("should record calls made via notify", () => {
-    const spyable: ISpyable = createRequestResponseSpy();
-    spyable.notify(fakeRequest, fakeResponse);
+    const spyable: IRecorder = createCallRecorder();
+    spyable.record(fakeRequest, fakeResponse);
     assert.calledOnce(spyable.spy);
     assert.calledWithExactly(spyable.spy, fakeRequest);
     expect(spyable.spy.firstCall.returnValue).toEqual(fakeResponse);
   });
   it("should be attachable to another object", () => {
-    const spyable: ISpyable = createRequestResponseSpy();
+    const spyable: IRecorder = createCallRecorder();
     const attached = { a: 1 };
     const objWithSpy = Object.assign(attached, spyable);
-    objWithSpy.notify(fakeRequest, fakeResponse);
+    objWithSpy.record(fakeRequest, fakeResponse);
     assert.calledOnce(objWithSpy.spy);
     assert.calledWithExactly(objWithSpy.spy, fakeRequest);
     expect(objWithSpy.spy.firstCall.returnValue).toEqual(fakeResponse);

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "sinon";
 import { ISerializedRequest, ISerializedResponse } from "../interfaces";
-import { get } from "../service/spy";
+import { createRequestResponseSpy, ISpyable } from "../service/spy";
 
 const fakeRequest: ISerializedRequest = {
   method: "GET",
@@ -16,11 +16,11 @@ const fakeResponse: ISerializedResponse = {
 
 describe("Creating a spy", () => {
   it("should not be called after creation", () => {
-    const testObj = get();
+    const testObj: ISpyable = createRequestResponseSpy();
     assert.notCalled(testObj.spy);
   });
-  it("should record calls", () => {
-    const testObj = get();
+  it("should record calls made via notify", () => {
+    const testObj: ISpyable = createRequestResponseSpy();
     testObj.notify(fakeRequest, fakeResponse);
     assert.calledOnce(testObj.spy);
     assert.calledWithExactly(testObj.spy, fakeRequest);

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "sinon";
 import { ISerializedRequest, ISerializedResponse } from "../interfaces";
-import { createCallRecorder, IRecorder } from "../service/spy";
+import { createCallRecorder, ICallTracker } from "../service/spy";
 
 const fakeRequest: ISerializedRequest = {
   method: "GET",
@@ -16,23 +16,14 @@ const fakeResponse: ISerializedResponse = {
 
 describe("Creating a spy", () => {
   it("should not be called after creation", () => {
-    const spyable: IRecorder = createCallRecorder();
+    const spyable: ICallTracker = createCallRecorder();
     assert.notCalled(spyable.spy);
   });
   it("should record calls made via notify", () => {
-    const spyable: IRecorder = createCallRecorder();
-    spyable.record({ req: fakeRequest, res: fakeResponse });
-    assert.calledOnce(spyable.spy);
-    assert.calledWithExactly(spyable.spy, fakeRequest);
-    expect(spyable.spy.firstCall.returnValue).toEqual(fakeResponse);
-  });
-  it("should be attachable to another object", () => {
-    const spyable: IRecorder = createCallRecorder();
-    const attached = { a: 1 };
-    const objWithSpy = Object.assign(attached, spyable);
-    objWithSpy.record({ req: fakeRequest, res: fakeResponse });
-    assert.calledOnce(objWithSpy.spy);
-    assert.calledWithExactly(objWithSpy.spy, fakeRequest);
-    expect(objWithSpy.spy.firstCall.returnValue).toEqual(fakeResponse);
+    const callTracker: ICallTracker = createCallRecorder();
+    callTracker.track({ req: fakeRequest, res: fakeResponse });
+    assert.calledOnce(callTracker.spy);
+    assert.calledWithExactly(callTracker.spy, fakeRequest);
+    expect(callTracker.spy.firstCall.returnValue).toEqual(fakeResponse);
   });
 });

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -176,7 +176,11 @@ export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 type FluentStateStore = StateFacadeType & SetStateForSpecificMethod;
 // Used to define the response from intercepted request
 type FunctionInput = (req: ISerializedRequest) => any;
-type StateInput = IStateInputGenerator | UnmockServiceState | string | FunctionInput;
+type StateInput =
+  | IStateInputGenerator
+  | UnmockServiceState
+  | string
+  | FunctionInput;
 
 // Used to incorporate the reset method when needed
 interface IResetState {

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -176,11 +176,7 @@ export type UnmockServiceState = IUnmockServiceState & ITopLevelDSL | IDSL;
 type FluentStateStore = StateFacadeType & SetStateForSpecificMethod;
 // Used to define the response from intercepted request
 type FunctionInput = (req: ISerializedRequest) => any;
-type StateInput =
-  | IStateInputGenerator
-  | UnmockServiceState
-  | string
-  | FunctionInput;
+type StateInput = IStateInputGenerator | UnmockServiceState | string | FunctionInput;
 
 // Used to incorporate the reset method when needed
 interface IResetState {

--- a/packages/unmock-core/src/service/spy/index.ts
+++ b/packages/unmock-core/src/service/spy/index.ts
@@ -59,5 +59,5 @@ class CallTracker<TArg = any, TReturnValue = any> {
   }
 }
 
-export const createCallRecorder = (): ICallTracker =>
+export const createCallTracker = (): ICallTracker =>
   new CallTracker<ISerializedRequest, ISerializedResponse>();

--- a/packages/unmock-core/src/service/spy/index.ts
+++ b/packages/unmock-core/src/service/spy/index.ts
@@ -8,33 +8,69 @@ export type RequestResponseSpy = SinonSpy<
 >;
 
 export interface ISpyable {
+  /**
+   * Keep track of calls, added via the `notify` method
+   */
   spy: RequestResponseSpy;
+  /**
+   * Add new call to the spy object
+   * @param req Request
+   * @param res Response
+   */
   notify(req: ISerializedRequest, res: ISerializedResponse): void;
+  reset(): void;
 }
 
-class SpyContainer {
-  public readonly spy: RequestResponseSpy;
-  private response?: ISerializedResponse;
+export type RequestResponseSpyNotifier = SpyContainer<
+  ISerializedRequest,
+  ISerializedResponse
+>;
+
+/**
+ * Container for adding spy calls with `notify` method.
+ */
+class SpyContainer<TArg = any, TReturnValue = any> {
+  public readonly spy: SinonSpy<[TArg], TReturnValue>;
+  private returnValue?: TReturnValue;
   constructor() {
     // @ts-ignore
-    this.spy = sinonSpy(this, "gen");
+    this.spy = sinonSpy(this, "spiedFn");
   }
 
-  public notify(sreq: ISerializedRequest, sres: ISerializedResponse) {
+  public notify(targs: TArg, tret: TReturnValue) {
     // Ugly hack to predefine what the spied function should return
-    this.response = sres;
-    this.gen(sreq);
-    this.response = undefined;
+    this.returnValue = tret;
+    this.spiedFn(targs);
+    this.returnValue = undefined;
   }
 
-  private gen(_: ISerializedRequest): ISerializedResponse {
-    return this.response!;
+  public reset(): void {
+    this.spy.resetHistory();
+  }
+
+  private spiedFn(_: TArg): TReturnValue {
+    return this.returnValue!;
   }
 }
 
-export const createRequestResponseSpy = (): ISpyable => new SpyContainer();
+export const createRequestResponseSpy = (): ISpyable =>
+  new SpyContainer<ISerializedRequest, ISerializedResponse>();
 
 export const attach = (service: IService): IService & ISpyable => {
   const spyable = new SpyContainer();
   return Object.assign(service, spyable);
 };
+/*
+export interface Service {
+  spy: Spy;
+  state: State;
+  generate(req: Request): Response;
+}
+ */
+
+/* type ServiceCore = {
+  generate(sreq: ISerializedRequest): ISerializedResponse;
+};
+
+export type Service = ServiceCore & Pick<ISpyable, "spy" | "reset">;
+ */

--- a/packages/unmock-core/src/service/spy/index.ts
+++ b/packages/unmock-core/src/service/spy/index.ts
@@ -1,18 +1,18 @@
 import { SinonSpy, spy as sinonSpy } from "sinon";
 import { ISerializedRequest, ISerializedResponse } from "../../interfaces";
-// import { IService } from "../interfaces";
+import { IService } from "../interfaces";
 
 export type RequestResponseSpy = SinonSpy<
   [ISerializedRequest],
   ISerializedResponse
 >;
 
-interface ISpyable {
+export interface ISpyable {
   spy: RequestResponseSpy;
   notify(req: ISerializedRequest, res: ISerializedResponse): void;
 }
 
-export class SpyContainer {
+class SpyContainer {
   public readonly spy: RequestResponseSpy;
   private response?: ISerializedResponse;
   constructor() {
@@ -21,20 +21,20 @@ export class SpyContainer {
   }
 
   public notify(sreq: ISerializedRequest, sres: ISerializedResponse) {
+    // Ugly hack to predefine what the spied function should return
     this.response = sres;
     this.gen(sreq);
     this.response = undefined;
   }
 
-  protected gen(_: ISerializedRequest): ISerializedResponse {
+  private gen(_: ISerializedRequest): ISerializedResponse {
     return this.response!;
   }
 }
 
-export const get = (): ISpyable => new SpyContainer();
+export const createRequestResponseSpy = (): ISpyable => new SpyContainer();
 
-export const attach = <T>(service: T): T & ISpyable => {
-  const spyObj2 = new SpyContainer();
-  // const fakeObj = new FakeSpied();
-  return Object.assign(service, spyObj2);
+export const attach = (service: IService): IService & ISpyable => {
+  const spyable = new SpyContainer();
+  return Object.assign(service, spyable);
 };

--- a/packages/unmock-core/src/service/spy/index.ts
+++ b/packages/unmock-core/src/service/spy/index.ts
@@ -47,28 +47,19 @@ export class NotifiableSpyable<TArg = any, TReturnValue = any> {
 
 class SpyContainer<TArg = any, TReturnValue = any> {
   // tslint:disable-line
-  // @ts-ignore
-  public notify: (targ: TArg, tret: TReturnValue) => void;
-  // @ts-ignore
-  public reset: () => void;
+  public readonly notify: (targ: TArg, tret: TReturnValue) => void;
+  public readonly reset: () => void;
   public readonly spy: SinonSpy<[TArg], TReturnValue>;
-  private readonly notifyableSpyable: NotifiableSpyable<TArg, TReturnValue>;
+  private readonly notifiableSpyable: NotifiableSpyable<TArg, TReturnValue>;
   constructor() {
-    // @ts-ignore
-    this.notifyableSpyable = new NotifiableSpyable<TArg, TReturnValue>();
-    this.spy = sinonSpy(this.notifyableSpyable, "spiedFn");
-    Object.defineProperty(this, "notify", {
-      value: (targ: TArg, tret: TReturnValue) => {
-        this.notifyableSpyable.notify(targ, tret);
-      },
-      enumerable: true,
-    });
-    Object.defineProperty(this, "reset", {
-      value: () => {
-        return this.spy.resetHistory();
-      },
-      enumerable: true,
-    });
+    this.notifiableSpyable = new NotifiableSpyable<TArg, TReturnValue>();
+    this.spy = sinonSpy(this.notifiableSpyable, "spiedFn");
+    this.notify = (targ: TArg, tret: TReturnValue) => {
+      this.notifiableSpyable.notify(targ, tret);
+    };
+    this.reset = () => {
+      this.spy.resetHistory();
+    };
   }
 }
 

--- a/packages/unmock-core/src/service/spy/index.ts
+++ b/packages/unmock-core/src/service/spy/index.ts
@@ -1,0 +1,40 @@
+import { SinonSpy, spy as sinonSpy } from "sinon";
+import { ISerializedRequest, ISerializedResponse } from "../../interfaces";
+// import { IService } from "../interfaces";
+
+export type RequestResponseSpy = SinonSpy<
+  [ISerializedRequest],
+  ISerializedResponse
+>;
+
+interface ISpyable {
+  spy: RequestResponseSpy;
+  notify(req: ISerializedRequest, res: ISerializedResponse): void;
+}
+
+export class SpyContainer {
+  public readonly spy: RequestResponseSpy;
+  private response?: ISerializedResponse;
+  constructor() {
+    // @ts-ignore
+    this.spy = sinonSpy(this, "gen");
+  }
+
+  public notify(sreq: ISerializedRequest, sres: ISerializedResponse) {
+    this.response = sres;
+    this.gen(sreq);
+    this.response = undefined;
+  }
+
+  protected gen(_: ISerializedRequest): ISerializedResponse {
+    return this.response!;
+  }
+}
+
+export const get = (): ISpyable => new SpyContainer();
+
+export const attach = <T>(service: T): T & ISpyable => {
+  const spyObj2 = new SpyContainer();
+  // const fakeObj = new FakeSpied();
+  return Object.assign(service, spyObj2);
+};

--- a/packages/unmock-core/src/service/spy/index.ts
+++ b/packages/unmock-core/src/service/spy/index.ts
@@ -1,12 +1,12 @@
-import { SinonSpy, spy as sinonSpy } from "sinon";
+import { SinonSpy as SinonSpyType, spy as sinonSpy } from "sinon";
 import { ISerializedRequest, ISerializedResponse } from "../../interfaces";
 
-export type RequestResponseSpy = SinonSpy<
+export type RequestResponseSpy = SinonSpyType<
   [ISerializedRequest],
   ISerializedResponse
 >;
 
-interface IRequestResponsePair {
+export interface IRequestResponsePair {
   req: ISerializedRequest;
   res: ISerializedResponse;
 }
@@ -23,18 +23,13 @@ export interface ICallTracker {
   reset(): void;
 }
 
-export type RequestResponseSpyNotifier = CallTracker<
-  ISerializedRequest,
-  ISerializedResponse
->;
-
 /**
  * Container for tracking spy calls via `track` method,
  * calls are exposed via `spy` property.
  */
 class CallTracker<TArg = any, TReturnValue = any> {
   // tslint:disable-line:max-classes-per-file
-  public readonly spy: SinonSpy<[TArg], TReturnValue>;
+  public readonly spy: SinonSpyType<[TArg], TReturnValue>;
   private returnValue?: TReturnValue;
   constructor() {
     this.spy = sinonSpy(this.spyFn.bind(this));

--- a/packages/unmock-core/src/service/spy/index.ts
+++ b/packages/unmock-core/src/service/spy/index.ts
@@ -7,6 +7,11 @@ export type RequestResponseSpy = SinonSpy<
   ISerializedResponse
 >;
 
+interface IRequestResponsePair {
+  req: ISerializedRequest;
+  res: ISerializedResponse;
+}
+
 export interface IRecorder {
   /**
    * Keep track of calls, added via the `notify` method
@@ -14,10 +19,8 @@ export interface IRecorder {
   spy: RequestResponseSpy;
   /**
    * Add new call to the spy object
-   * @param req Request
-   * @param res Response
    */
-  record(req: ISerializedRequest, res: ISerializedResponse): void;
+  record(pair: IRequestResponsePair): void;
   reset(): void;
 }
 
@@ -51,15 +54,21 @@ export class RecorderHelper<TArg = any, TReturnValue = any> {
  */
 class CallRecorder<TArg = any, TReturnValue = any> {
   // tslint:disable-line
-  public readonly record: (targ: TArg, tret: TReturnValue) => void;
+  public readonly record: ({
+    req,
+    res,
+  }: {
+    req: TArg;
+    res: TReturnValue;
+  }) => void;
   public readonly reset: () => void;
   public readonly spy: SinonSpy<[TArg], TReturnValue>;
   private readonly recorderHelper: RecorderHelper<TArg, TReturnValue>;
   constructor() {
     this.recorderHelper = new RecorderHelper<TArg, TReturnValue>();
     this.spy = sinonSpy(this.recorderHelper, "record");
-    this.record = (targ: TArg, tret: TReturnValue) => {
-      this.recorderHelper.notify(targ, tret);
+    this.record = ({ req, res }: { req: TArg; res: TReturnValue }) => {
+      this.recorderHelper.notify(req, res);
     };
     this.reset = () => {
       this.spy.resetHistory();


### PR DESCRIPTION
- Create a `CallTracker` that one should be able to attach to a service
- `callTracker.track({ req, res })` indirectly adds spied calls to `callTracker.spy`
- This should work until services have methods to spy on themselves, if we decide to go that way