### PR TITLE
Export UnmockRequest and UnmockResponse

### DIFF
--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import path from "path";
 import { CorePackage, States } from "unmock-core";
-import { dsl, Request } from "../../..";
+import { dsl, UnmockRequest } from "../../..";
 
 import NodeBackend from "../../backend";
 
@@ -109,7 +109,7 @@ describe("Node.js interceptor", () => {
     });
 
     test("sets an entire response from with request object", async () => {
-      states.petstore((req: Request) => req.host);
+      states.petstore((req: UnmockRequest) => req.host);
       const response = await axios("http://petstore.swagger.io/v1/pets");
       expect(response.data).toBe("petstore.swagger.io");
     });

--- a/packages/unmock-node/src/__tests__/index.test.ts
+++ b/packages/unmock-node/src/__tests__/index.test.ts
@@ -1,26 +1,39 @@
-const unmockRequireDefault = require("../").default;  // tslint:disable-line:no-var-requires
-const dslRequire = require("../").dsl;  // tslint:disable-line:no-var-requires
+const unmockRequireDefault = require("../").default; // tslint:disable-line:no-var-requires
+const dslRequire = require("../").dsl; // tslint:disable-line:no-var-requires
 import unmockDefaultImport from "../";
-import { dsl } from "../";
+import { dsl, UnmockRequest, UnmockResponse } from "../";
 
 describe("Imports", () => {
-    describe("with require", () => {
-        it("should have expected properties for unmock", () => {
-            expect(unmockRequireDefault).toBeDefined();
-            expect(unmockRequireDefault).toHaveProperty("on");
-        });
-        it("should have expected properties for dsl object", () => {
-            expect(dslRequire).toBeDefined();
-        });
+  describe("with require", () => {
+    it("should have expected properties for unmock", () => {
+      expect(unmockRequireDefault).toBeDefined();
+      expect(unmockRequireDefault).toHaveProperty("on");
     });
-    describe("with ES6 import", () => {
-        it("should have expected properties for unmock", () => {
-            expect(unmockDefaultImport).toBeDefined();
-            expect(unmockDefaultImport).toHaveProperty("on");
-        });
-        it("should have expected properties for dsl object", () => {
-            expect(dsl).toBeDefined();
-            expect(dsl).toHaveProperty("textResponse");
-        });
+    it("should have expected properties for dsl object", () => {
+      expect(dslRequire).toBeDefined();
     });
+  });
+  describe("with ES6 import", () => {
+    it("should have expected properties for unmock", () => {
+      expect(unmockDefaultImport).toBeDefined();
+      expect(unmockDefaultImport).toHaveProperty("on");
+    });
+    it("should have expected properties for dsl object", () => {
+      expect(dsl).toBeDefined();
+      expect(dsl).toHaveProperty("textResponse");
+    });
+  });
+  describe("for types", () => {
+    it("should have UnmockRequest and UnmockResponse", () => {
+      const request: UnmockRequest = {
+        host: "github.com",
+        method: "get",
+        path: "/v1",
+        protocol: "http",
+      };
+      const response: UnmockResponse = { body: "asdf", statusCode: 200 };
+      expect(request).toBeDefined();
+      expect(response).toBeDefined();
+    });
+  });
 });

--- a/packages/unmock-node/src/types.ts
+++ b/packages/unmock-node/src/types.ts
@@ -1,5 +1,6 @@
 // Types and aliases exported from unmock-node
 export {
+  ISerializedRequest as Request,
   ISerializedRequest as UnmockRequest,
   ISerializedResponse as UnmockResponse,
   States,

--- a/packages/unmock-node/src/types.ts
+++ b/packages/unmock-node/src/types.ts
@@ -1,5 +1,6 @@
 // Types and aliases exported from unmock-node
 export {
-    ISerializedRequest as Request,
-    States,
+  ISerializedRequest as UnmockRequest,
+  ISerializedResponse as UnmockResponse,
+  States,
 } from "unmock-core";


### PR DESCRIPTION
- Exporting `Request` seems a bit wrong as it clashes with the `Request` contained in TypeScript lib for `fetch` so renamed to `UnmockRequest`
- Export `UnmockResponse` as it's exposed by the upcoming list of calls
- Kept the old `Request` export as removing it first needs updating everything that refers to it:
  - [ ]  Updating docs
  - [ ]  Updating examples
  - [ ]  Updating PRs