### PR TITLE
Functional DSL Part 2

### DIFF
--- a/packages/unmock-core/src/__tests__/dsl.test.ts
+++ b/packages/unmock-core/src/__tests__/dsl.test.ts
@@ -107,7 +107,10 @@ describe("Translates top level DSL to OAS", () => {
 
 describe("Translates non-top level DSL to OAS", () => {
   it("Returns empty translation for empty state", () => {
-    expect(DSL.replaceDSLWithOAS({}, {})).toEqual({});
+    expect(DSL.replaceDSLWithOAS({}, {})).toEqual({
+      translated: {},
+      cleaned: {},
+    });
   });
 
   describe("Translates $size correctly", () => {
@@ -130,22 +133,25 @@ describe("Translates non-top level DSL to OAS", () => {
       DSL.STRICT_MODE = false;
       // Test with non-numeric
       const state: { $size: any } = { $size: "a" };
-      let translated = DSL.replaceDSLWithOAS(state, arraySchema);
-      expect(translated).toEqual({}); // Nothing was translated
-      expect(state).toEqual({ $size: "a" });
+      let result = DSL.replaceDSLWithOAS(state, arraySchema);
+      expect(result.translated).toEqual({}); // Nothing was translated
+      expect(result.cleaned).toEqual({ $size: "a" });
+      expect(state).toEqual({ $size: "a" }); // should not be changed
 
       // Test with non-positive input
       state.$size = -1;
-      translated = DSL.replaceDSLWithOAS(state, arraySchema);
-      expect(translated).toEqual({}); // Nothing was translated
-      expect(state).toEqual({ $size: -1 });
+      result = DSL.replaceDSLWithOAS(state, arraySchema);
+      expect(result.translated).toEqual({}); // Nothing was translated
+      expect(result.cleaned).toEqual({ $size: -1 });
+      expect(state).toEqual({ $size: -1 }); // should not be changed
 
       // Test with non-array input
       state.$size = 5;
       arraySchema.type = "object";
-      translated = DSL.replaceDSLWithOAS(state, arraySchema);
-      expect(translated).toEqual({}); // Nothing was translated
-      expect(state).toEqual({ $size: 5 });
+      result = DSL.replaceDSLWithOAS(state, arraySchema);
+      expect(result.translated).toEqual({}); // Nothing was translated
+      expect(result.cleaned).toEqual({ $size: 5 });
+      expect(state).toEqual({ $size: 5 }); // should not be changed
     });
 
     it("Throws with non-numeric input in strict mode", () => {
@@ -172,9 +178,10 @@ describe("Translates non-top level DSL to OAS", () => {
 
     it("Translates $size correctly", () => {
       const state = { $size: 3, id: 5 };
-      const translated = DSL.replaceDSLWithOAS(state, arraySchema);
-      expect(state).toEqual({ id: 5 }); // $size element should be removed
-      expect(translated).toEqual({ maxItems: 3, minItems: 3 });
+      const result = DSL.replaceDSLWithOAS(state, arraySchema);
+      expect(state).toEqual({ $size: 3, id: 5 }); // state should not be changed
+      expect(result.translated).toEqual({ maxItems: 3, minItems: 3 });
+      expect(result.cleaned).toEqual({ id: 5 }); // $size element should be removed
     });
   });
 });

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -92,7 +92,7 @@ const updateState = (
   });
 
 const getState = (state: State, method: HTTPMethod, endpoint: string) =>
-  state.getState(method, endpoint, fullSchema.paths["/test/{test_id}"].get);
+  state.getState(method, endpoint);
 
 describe("Test state management", () => {
   it("returns undefined when setting empty state", () => {

--- a/packages/unmock-core/src/service/dsl/dsl.ts
+++ b/packages/unmock-core/src/service/dsl/dsl.ts
@@ -4,7 +4,7 @@ import { codeToMedia, mediaTypeToSchema, Schema } from "../interfaces";
 import { actWithAllActors } from "./actors";
 import { ITopLevelDSL } from "./interfaces";
 import { topTranslators, translators } from "./translators";
-import { hasUnmockProperty, injectUnmockProperty } from "./utils";
+import { injectUnmockProperty } from "./utils";
 
 const debugLog = debug("unmock:dsl");
 

--- a/packages/unmock-core/src/service/dsl/dsl.ts
+++ b/packages/unmock-core/src/service/dsl/dsl.ts
@@ -122,7 +122,9 @@ const actOnSchema = (
   const newStateAndResult = actWithAllActors(schema);
 
   const parsed = defaultsDeep({}, ...newStateAndResult.parsed);
-  const newState = defaultsDeep({}, ...newStateAndResult.newState);
+  const newState = newStateAndResult.newState.includes(undefined) // undefined means state is marked for deletion
+    ? undefined
+    : defaultsDeep({}, ...newStateAndResult.newState);
 
   const maybeProperties = parsed.properties;
   if (
@@ -137,8 +139,5 @@ const actOnSchema = (
     delete parsed.properties;
   }
 
-  return {
-    parsed,
-    newState: Object.keys(newState).length > 0 ? newState : undefined,
-  };
+  return { parsed, newState };
 };

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -47,8 +47,7 @@ export interface IUnmockProperty {
  */
 
 export type Actor = (
-  originalSchema: mediaTypeToSchema,
-  mediaType: string,
-) => Schema;
+  originalSchema: Schema,
+) => { parsed: Schema; newState: Schema | undefined };
 export type Translator = (state: any, schema: Schema) => any;
 export type TopTranslator = (value: any) => any;

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -1,4 +1,4 @@
-import { mediaTypeToSchema, Schema } from "../interfaces";
+import { Schema } from "../interfaces";
 
 /**
  * DSL related parameters that can only be found at the top level

--- a/packages/unmock-core/src/service/dsl/translators.ts
+++ b/packages/unmock-core/src/service/dsl/translators.ts
@@ -28,7 +28,11 @@ const translate$times: TopTranslator = (times: any) => {
  */
 const translate$size: Translator = (state: any, schema: Schema): any => {
   // assumes state.$size exists
-  if (schema.type === undefined || schema.type !== "array") {
+  if (
+    schema.type === undefined ||
+    schema.type !== "array" ||
+    schema.items === undefined
+  ) {
     throw new Error("Can't set '$size' for non-array elements!");
   }
   if (typeof state.$size !== "number") {

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -93,16 +93,7 @@ export class Service implements IService {
     if (realEndpoint === undefined) {
       return undefined;
     }
-    const schemaEndpoint = realEndpoint.schemaEndpoint;
-    const operationSchema = this.schema.paths[schemaEndpoint][method];
-    if (operationSchema === undefined) {
-      return undefined;
-    }
 
-    return this.state.getState(
-      method,
-      realEndpoint.normalizedEndpoint,
-      operationSchema,
-    );
+    return this.state.getState(method, realEndpoint.normalizedEndpoint);
   }
 }

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -152,9 +152,10 @@ export class State {
 
     // Filter all the states that do not match the operation schema
     const filteredStates = filterStatesByOperation(states, operation);
-    const parsedTopLevel = DSL.actTopLevelFromOAS(filteredStates);
+    const { parsed, newState } = DSL.actTopLevelFromOAS(filteredStates);
+    console.log(newState);
     // TODO: After parsing, do we want to see if we need to remove items from the current state?
-    return Object.keys(parsedTopLevel).length > 0 ? parsedTopLevel : undefined;
+    return Object.keys(parsed).length > 0 ? parsed : undefined;
   }
 
   public reset() {

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -129,9 +129,12 @@ const spreadStateFromService = (
         );
         // Option 1a: current schema has no matching key, but contains indirection (items/properties, etc)
         // `statePath` at this point may also contain DSL elements, so we parse them before moving onwards
-        const translated = DSL.replaceDSLWithOAS(statePath, serviceSchema);
+        const { translated, cleaned } = DSL.translateDSLToOAS(
+          statePath,
+          serviceSchema,
+        );
         const spread = {
-          ...oneLevelOfIndirectNestedness(serviceSchema, statePath),
+          ...oneLevelOfIndirectNestedness(serviceSchema, cleaned),
           ...translated,
         };
         if (Object.keys(spread).length === 0) {
@@ -168,9 +171,9 @@ const spreadStateFromService = (
         );
         // Option 3: Current scheme has matching key, state specifies an object - traverse schema and indirection
         // `stateValue` at this point may also contain DSL elements, so we parse them before moving onwards
-        const translated = DSL.replaceDSLWithOAS(stateValue, scm);
+        const { translated, cleaned } = DSL.translateDSLToOAS(stateValue, scm);
         const spread = {
-          [key]: { ...spreadStateFromService(scm, stateValue), ...translated },
+          [key]: { ...spreadStateFromService(scm, cleaned), ...translated },
         };
         matches = {
           ...matches,

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -5,18 +5,13 @@ import {
 } from "../constants";
 import { DSLKeys } from "../dsl/interfaces";
 import {
-  codeToMedia,
   ExtendedHTTPMethod,
   HTTPMethod,
-  isReference,
   isRESTMethod,
-  mediaTypeToSchema,
   OASMethodKey,
   Operation,
   PathItem,
   Paths,
-  Responses,
-  Schema,
 } from "../interfaces";
 import {
   IStateUpdate,
@@ -24,137 +19,7 @@ import {
   OperationsForStateUpdate,
 } from "./interfaces";
 
-type codeKey = keyof Responses;
-interface ICodesToMediaTypes {
-  [code: string]: string[];
-}
-
 const debugLog = debug("unmock:state:utils");
-
-/**
- * Given a list of possibly relevent `states` (each being a mapping from
- * a status code, to a mediatype, to the state itself), and an `operation`,
- * filter and return only those states that are relevant for the request Operation.
- * If multiple states apply, spread them into a single state - `states` is expected
- * to be sorted so that the first element is the "widest" match, and the last element
- * is the most specific match.
- */
-export const filterStatesByOperation = (
-  states: codeToMedia[],
-  operation: Operation,
-): codeToMedia => {
-  debugLog(
-    `filterStatesByOperation: Filtering which states from ${JSON.stringify(
-      states,
-    )} are valid for ${JSON.stringify(operation)}`,
-  );
-  const opResponses = operation.responses;
-  // Types of 'MediaType' keys that are present in given Operation
-  const mediaTypes: ICodesToMediaTypes = Object.keys(opResponses).reduce(
-    (types: ICodesToMediaTypes, code: string) => {
-      const response = opResponses[code as codeKey];
-      return Object.assign(
-        types,
-        response === undefined ||
-        isReference(response) || // Checked for typing purposes, there are no $refs in states.
-          response.content === undefined
-          ? { [code]: [] }
-          : { [code]: Object.keys(response.content) },
-      );
-    },
-    {},
-  );
-  debugLog(
-    `filterStatesByOperation: acceptable media types from operation: ${JSON.stringify(
-      mediaTypes,
-    )}`,
-  );
-  // Filter each state by status code and media type present in Operation
-  const filtered = states.map((state: codeToMedia) =>
-    filterByMediaType(state, mediaTypes),
-  );
-  debugLog(
-    `filterStatesByOperation: Matching state after filtering status codes and media types: ${JSON.stringify(
-      filtered,
-      (_: string, value: any) =>
-        typeof value === "function" ? `Function()` : value,
-    )}`,
-  );
-  // Spread out for each status code and each media type
-  return flattenCodeToMediaBySpreading(filtered);
-};
-
-const flattenCodeToMediaBySpreading = (nested: codeToMedia[]) => {
-  debugLog(`flattenCodeToMediaBySpreading: Flattening ${nested}...`);
-  const spreaded: codeToMedia = {};
-  for (const state of nested) {
-    for (const code of Object.keys(state)) {
-      const resp: Record<string, Schema> = state[code as codeKey] as any;
-      for (const mediaType of Object.keys(resp)) {
-        const content = resp[mediaType];
-        if (content !== undefined) {
-          const spreadSchema = {
-            ...(spreaded[code] || {})[mediaType],
-            ...content,
-          };
-          spreaded[code] = {
-            ...spreaded[code],
-            ...{ [mediaType]: spreadSchema },
-          };
-        }
-      }
-    }
-  }
-  return spreaded;
-};
-
-/**
- * Attempts to match all media types from `allowedMediaTypes` with the `stateObj`.
- * @param stateObj
- * @param allowedMediaTypes
- */
-const filterByMediaType = (
-  stateObj: codeToMedia,
-  allowedMediaTypes: ICodesToMediaTypes,
-) => {
-  debugLog(
-    `filterByMediaType: Attempting to match media types from ${JSON.stringify(
-      allowedMediaTypes,
-    )} with ${JSON.stringify(stateObj)}`,
-  );
-  const stateCodeToMedia: codeToMedia = {};
-  for (const code of Object.keys(stateObj)) {
-    debugLog(`filterByMediaType: Filtering for status code ${code}`);
-    const codeSchema = stateObj[code];
-    const matchMediaTypes = (key: string) =>
-      allowedMediaTypes[key] === undefined
-        ? []
-        : Object.keys(codeSchema).filter((mediaType: string) =>
-            allowedMediaTypes[key].includes(mediaType),
-          );
-    const validMediaTypes = matchMediaTypes(code);
-    // if we couldn't find based on code, attempt to match against 'default'
-    const extendedValidMediaTypes =
-      validMediaTypes.length > 0 ? validMediaTypes : matchMediaTypes("default");
-    debugLog(
-      `filterByMediaType: Valid media types for state and operation: ${JSON.stringify(
-        extendedValidMediaTypes,
-      )}`,
-    );
-    if (extendedValidMediaTypes.length === 0) {
-      continue;
-    }
-    // some are valid, add them to the list
-    stateCodeToMedia[code] = extendedValidMediaTypes.reduce(
-      (filteredCodeToMedia: mediaTypeToSchema, mediaType: string) =>
-        Object.assign(filteredCodeToMedia, {
-          [mediaType]: codeSchema[mediaType],
-        }),
-      {},
-    );
-  }
-  return stateCodeToMedia;
-};
 
 /**
  * Gets relevant operations for given method and endpoint, filtering out


### PR DESCRIPTION
- Move state management to be solely in `State` -> actors and DSL do not change state but rather return a copy of "state to return" and possibly updated state. `undefined` is used to denote a "state-to-be-delete".

- Removes the idea that multiple states apply to a single endpoint (e.g. previously if `/pets/*` was set with `{ type: "dog" }` and `/pets/3` was set to `{ name: "sparkie" }`, then hitting `/pets/3` would return `{ name: "sparkie", type: "dog" }`). This is still nice IMO, but might not the expected result for many users. Moreover, it gets messier when using a DSL keyword, and most importantly, it proves quite hacky when updating a state based on the DSL response. So now, only the most relevant endpoint is chosen.