### PR TITLE
Export `sinon` from unmock-core and unmock-node

### DIFF
--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -14,7 +14,8 @@ export {
   CustomConsole as UnmockConsole,
 } from "./console";
 
-export { default as sinon } from "sinon";
+import sinon from "sinon";
+export { sinon };
 
 import { StateFacadeType } from "./service/interfaces";
 export type States = StateFacadeType;

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -14,6 +14,8 @@ export {
   CustomConsole as UnmockConsole,
 } from "./console";
 
+export { default as sinon } from "sinon";
+
 import { StateFacadeType } from "./service/interfaces";
 export type States = StateFacadeType;
 

--- a/packages/unmock-node/src/__tests__/index.test.ts
+++ b/packages/unmock-node/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 const unmockRequireDefault = require("../").default; // tslint:disable-line:no-var-requires
 const dslRequire = require("../").dsl; // tslint:disable-line:no-var-requires
 import unmockDefaultImport from "../";
-import { dsl, UnmockRequest, UnmockResponse } from "../";
+import { dsl, sinon, UnmockRequest, UnmockResponse } from "../";
 
 describe("Imports", () => {
   describe("with require", () => {
@@ -34,6 +34,13 @@ describe("Imports", () => {
       const response: UnmockResponse = { body: "asdf", statusCode: 200 };
       expect(request).toBeDefined();
       expect(response).toBeDefined();
+    });
+  });
+  describe("for sinon", () => {
+    it("should have assert and match", () => {
+      const fooMatcher = sinon.match("foo");
+      expect(fooMatcher.test("foo")).toBe(true);
+      sinon.assert.match("foo", fooMatcher);
     });
   });
 });

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -5,6 +5,9 @@ import _WinstonLogger from "./loggers/winston-logger";
 // DSL
 export { dsl } from "unmock-core";
 
+// Sinon for asserts and matchers
+export { sinon } from "unmock-core";
+
 // Types
 export * from "./types";
 


### PR DESCRIPTION
This allows doing 
```js
import { sinon: { assert, match }} from "unmock-node";
assert.wasCalledOnce(github.spy);
assert.wasCalledWithMatch(github.spy, { path: match(/^\/v3/) });
```
I think that's already quite powerful (though not 100% readable) before we have implemented any custom asserts or matchers maybe allowing stuff like `expect(github).calledOnceWith(matchPath(/^\/v3/)`.

Exposing `sinon` could be a temporary solution, but I don't see harm in exposing that. At least not until we have `unmock-expect` implemented.

Alternative would be to expose `import { assert, match } from "unmock-node"` but I'm a bit worried it might turn out a mess: is `unmock.match` then `sinon.match`, superset of `sinon.match`, or a set disjoint of `sinon.match`? I'd maybe reserve `unmock.match` for future for clarity 🤔 