### PR TITLE
Return this from unmock.on, add more type exports.

### DIFF
--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -9,6 +9,7 @@ import { AllowedHosts, BooleanSetting } from "./settings";
 // top-level exports
 export * from "./interfaces";
 export * from "./generator";
+export { IService } from "./service/interfaces";
 export {
   default as unmockConsole,
   CustomConsole as UnmockConsole,
@@ -48,7 +49,7 @@ export class CorePackage implements IUnmockPackage {
       flaky: () => this.flaky.get(),
     };
     this.backend.initialize(opts);
-    return this.services;
+    return this;
   }
   public init() {
     return this.on();

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -32,9 +32,9 @@ export interface IBackend {
 export interface IUnmockPackage {
   allowedHosts: AllowedHosts;
   services: ServiceStoreType;
-  on(): ServiceStoreType;
-  init(): ServiceStoreType;
-  initialize(): ServiceStoreType;
+  on(): IUnmockPackage;
+  init(): IUnmockPackage;
+  initialize(): IUnmockPackage;
   off(): void;
 }
 

--- a/packages/unmock-node/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/states.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import path from "path";
 import { CorePackage } from "unmock-core";
-import { dsl, UnmockRequest } from "../../..";
+import { dsl, Service, UnmockRequest } from "../../..";
 import NodeBackend from "../../backend";
 
 const servicesDirectory = path.join(__dirname, "..", "resources");
@@ -11,12 +11,12 @@ describe("Node.js interceptor", () => {
     const nodeInterceptor = new NodeBackend({ servicesDirectory });
     const unmock = new CorePackage(nodeInterceptor);
 
-    beforeAll(() => unmock.on());
-
     afterAll(() => unmock.off());
 
     beforeEach(() =>
-      Object.values(unmock.services).forEach(core => core.state.reset()),
+      Object.values(unmock.services).forEach((core: Service) =>
+        core.state.reset(),
+      ),
     );
 
     test("Throws when asking for non existing method/path", async () => {

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -14,4 +14,6 @@ export * from "./types";
 const backend = new NodeBackend();
 
 const unmock = new CorePackage(backend, { logger: new _WinstonLogger() });
+export type UnmockNode = typeof unmock;
+
 export default unmock;

--- a/packages/unmock-node/src/index.ts
+++ b/packages/unmock-node/src/index.ts
@@ -1,4 +1,4 @@
-import { CorePackage } from "unmock-core";
+import { CorePackage, IUnmockPackage } from "unmock-core";
 import NodeBackend from "./backend";
 import _WinstonLogger from "./loggers/winston-logger";
 
@@ -13,7 +13,10 @@ export * from "./types";
 
 const backend = new NodeBackend();
 
-const unmock = new CorePackage(backend, { logger: new _WinstonLogger() });
+const unmock: IUnmockPackage = new CorePackage(backend, {
+  logger: new _WinstonLogger(),
+});
+
 export type UnmockNode = typeof unmock;
 
 export default unmock;

--- a/packages/unmock-node/src/types.ts
+++ b/packages/unmock-node/src/types.ts
@@ -4,5 +4,6 @@ export {
   ISerializedRequest as UnmockRequest,
   ISerializedResponse as UnmockResponse,
   ServiceStoreType as UnmockServices,
+  IService as UnmockService,
   IService as Service,
 } from "unmock-core";

--- a/packages/unmock-node/src/types.ts
+++ b/packages/unmock-node/src/types.ts
@@ -4,4 +4,5 @@ export {
   ISerializedRequest as UnmockRequest,
   ISerializedResponse as UnmockResponse,
   ServiceStoreType as UnmockServices,
+  IService as Service,
 } from "unmock-core";


### PR DESCRIPTION
- Export `Service` (interface) and `UnmockNode` (alias for `IUnmockPackage`)
- Exporting types is becoming a bit of a mess: I think `unmock-core` should have `types.ts` for all exposed types and export it as e.g. `types` so that `unmock-node` could simply export everything from there. I can try and work on that.