### PR TITLE
[Fix] Setting state with reserved OAS keywords

### DIFF
--- a/packages/unmock-core/src/__tests__/__unmock__/petstore/spec.yaml
+++ b/packages/unmock-core/src/__tests__/__unmock__/petstore/spec.yaml
@@ -72,7 +72,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Pets"
+                $ref: "#/components/schemas/Pet"
         default:
           description: unexpected error
           content:
@@ -89,6 +89,11 @@ components:
         id:
           type: integer
           format: int64
+        properties:
+          type: object
+          properties:
+            isCat:
+              type: boolean
         name:
           type: string
         tag:

--- a/packages/unmock-core/src/__tests__/service.util.test.ts
+++ b/packages/unmock-core/src/__tests__/service.util.test.ts
@@ -33,6 +33,10 @@ describe("Tests deref", () => {
           },
           name: { type: "string" },
           tag: { type: "string" },
+          properties: {
+            type: "object",
+            properties: { isCat: { type: "boolean" } },
+          },
         },
       },
     });
@@ -54,6 +58,10 @@ describe("Tests deref", () => {
           },
           name: { type: "string" },
           tag: { type: "string" },
+          properties: {
+            type: "object",
+            properties: { isCat: { type: "boolean" } },
+          },
         },
       },
     });

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -119,7 +119,7 @@ describe("Test state management", () => {
   it("saves state from any endpoint and get method as expected", () => {
     const state = new State();
     updateState(state, "get", "**", objResponse({ foo: { id: 5 } }), "**");
-    const stateResult = getState(state, "get", "/");
+    const stateResult = getState(state, "get", "/test/bar");
     expect(stateResult).toEqual({
       200: {
         "application/json": {
@@ -143,7 +143,7 @@ describe("Test state management", () => {
   it("parses $times on specific endpoint as expected", () => {
     const state = new State();
     updateState(state, "get", "**", objResponse({ id: 5, $times: 2 }), "**");
-    const getRes = () => getState(state, "get", "/");
+    const getRes = () => getState(state, "get", "/test/bar");
     expect(getRes()).toEqual({
       200: {
         "application/json": {
@@ -195,7 +195,7 @@ describe("Test state management", () => {
   it("saves state from any endpoint and any method as expected", () => {
     const state = new State();
     updateState(state, "any", "**", objResponse({ id: 5 }), "**");
-    const stateResult = getState(state, "get", "/");
+    const stateResult = getState(state, "get", "/test/bar");
     expect(stateResult).toEqual({
       200: {
         "application/json": {
@@ -249,7 +249,7 @@ describe("Test state management", () => {
   it("saves nested state correctly", () => {
     const state = new State();
     updateState(state, "any", "**", objResponse({ foo: { id: 5 } }), "**");
-    const stateResult = getState(state, "get", "/");
+    const stateResult = getState(state, "get", "/test/bar");
     expect(stateResult).toEqual({
       200: {
         "application/json": {
@@ -273,7 +273,7 @@ describe("Test state management", () => {
   it("Handles textual state correctly", () => {
     const state = new State();
     updateState(state, "any", "**", textResponse("foobar"), "**");
-    const stateResult = getState(state, "get", "/");
+    const stateResult = getState(state, "get", "/test/bar");
     expect(stateResult).toEqual({
       200: { "text/plain": { const: "foobar", type: "string" } },
     });

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -55,7 +55,8 @@ export function responseCreatorFactory({
   const match = (sreq: ISerializedRequest) =>
     coreServices
       .map(service => service.match(sreq))
-      .filter(res => res !== undefined)[0];
+      .filter(res => res !== undefined)
+      .shift();
   const services = ServiceStore(coreServices);
 
   return {

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -193,8 +193,7 @@ const matchWithNonConcreteValue = (
       ...translated,
     },
   };
-  const x = oneLevelOfIndirectNestedness(schema, state, spread);
-  return x;
+  return oneLevelOfIndirectNestedness(schema, state, spread);
 };
 
 /**

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -193,7 +193,8 @@ const matchWithNonConcreteValue = (
       ...translated,
     },
   };
-  return oneLevelOfIndirectNestedness(schema, state, spread);
+  const x = oneLevelOfIndirectNestedness(schema, state, spread);
+  return x;
 };
 
 /**
@@ -273,7 +274,13 @@ const oneLevelOfIndirectNestedness = (
       Object.keys(maybeContents).every(
         (k: string) => maybeContents[k] !== null,
       );
-    return { ...o, ...(hasContents ? { [key]: maybeContents } : {}) };
+    return hasContents
+      ? o[key] !== undefined
+        ? // `key` already exists in original object, we don't want to replace it.
+          // this usually happens if e.g. a real property is named 'properties'
+          { ...o, [key]: { ...o[key], [key]: maybeContents } }
+        : { ...o, [key]: maybeContents }
+      : o;
   }, initObj);
 
 /**

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -102,8 +102,8 @@ const getOperationsByMethod = (
   );
   const anyMethod = method === DEFAULT_STATE_HTTP_METHOD;
   const filterFn = anyMethod
-    ? (pathItemKey: string) => isRESTMethod(pathItemKey)
-    : (pathItemKey: string) => pathItemKey === method;
+    ? (pathMethod: string) => isRESTMethod(pathMethod)
+    : (pathMethod: string) => pathMethod === method;
 
   const operations: OperationsForStateUpdate = Object.keys(paths).reduce(
     (ops: OperationsForStateUpdate, path: string) => {
@@ -179,3 +179,11 @@ export const chooseErrorFromList = (
     (e, c) => (c === undefined ? e : chooseBestMatchingError(c, e)),
     undefined,
   );
+
+/**
+ * Converts an OpenAPI parameter to a wildcard without validating against the schema.
+ * @example /pets/{pet_id} -> /pets/*
+ * @param endpoint
+ */
+export const convertEndpointToWildcard = (endpoint: string) =>
+  endpoint.replace(/\{[^}]*?\}/g, "*");


### PR DESCRIPTION
Treats #113.

Changes:
- Paths are saved concretely based on the matching operation (no `**` is saved in path, for example).
  - OpenAPI path parameters are replaced with asterisks (`/pets/{pet_id} -> /pets/*`). They are validated beforehand (e.g. when instantiating a service).
  - The side-effect can be seen in e.g. the changes to `state.test.ts`. To me, that feels like a more logical outcome.
- Modified the petstore spec file so I can add a test for the issue. This cascaded down to updating `state.utils.test.ts`.
- Prefer to use `shift()` instead of indexing `[0]`.