### PR TITLE
resolve issue #183: Body in UnmockResponse is string when should be JSON

### DIFF
--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -116,7 +116,7 @@ describe("Tests generator", () => {
     expect(resp).toBeDefined();
     if (resp !== undefined) {
       expect(resp.statusCode).toEqual(204);
-      expect(resp.body).toEqual('"prefetch"');
+      expect(resp.body).toEqual("prefetch");
     }
 
     resp = createResponse({
@@ -128,7 +128,7 @@ describe("Tests generator", () => {
     expect(resp).toBeDefined();
     if (resp !== undefined) {
       expect(resp.statusCode).toEqual(200);
-      expect(resp.body).toEqual('"prefetch"');
+      expect(resp.body).toEqual("prefetch");
     }
   });
 
@@ -146,9 +146,11 @@ describe("Tests generator", () => {
     });
     expect(resp).toBeDefined();
     if (resp && resp.body !== undefined) {
-      JSON.parse(resp.body).forEach((pet: any) =>
-        expect(pet.id).toEqual("foo"),
-      );
+      if (!(resp.body instanceof Array)) {
+        throw new Error("Response body was not an object but a string");
+      }
+
+      resp.body.forEach((pet: any) => expect(pet.id).toEqual("foo"));
     } else {
       throw new Error("Response body was undefined?");
     }
@@ -162,7 +164,10 @@ describe("Tests generator", () => {
     });
     expect(resp).toBeDefined();
     if (resp && resp.body !== undefined) {
-      JSON.parse(resp.body).forEach((pet: any) => expect(pet.id).toEqual(1));
+      if (!(resp.body instanceof Array)) {
+        throw new Error("Response body was not an object but a string");
+      }
+      resp.body.forEach((pet: any) => expect(pet.id).toEqual(1));
     } else {
       throw new Error("Response body was undefined?");
     }

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -31,7 +31,7 @@ const respondFromSerializedResponse = (
   res: ServerResponse,
 ) => {
   res.writeHead(serializedResponse.statusCode, serializedResponse.headers);
-  res.end(serializedResponse.body);
+  res.end(JSON.stringify(serializedResponse.body));
 };
 
 const errorForMissingTemplate = (sreq: ISerializedRequest) => {
@@ -147,6 +147,7 @@ export default class NodeBackend implements IBackend {
     this.mitm.on("request", (req: IncomingMessage, res: ServerResponse) =>
       this.mitmOnRequest(createResponse, req, res),
     );
+
     this.serviceStore = services;
   }
 

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -302,7 +302,7 @@ const generateMockFromTemplate = (
   jsf.option("useDefaultValue", false);
   const resolvedTemplate = jsf.generate(template);
 
-  const body = JSON.stringify(resolvedTemplate);
+  const body = resolvedTemplate;
   jsf.option("useDefaultValue", true);
   const resHeaders = jsf.generate(normalizeHeaders(headers));
   jsf.option("useDefaultValue", false);

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -64,7 +64,7 @@ export interface ISerializedRequest {
 }
 
 export interface ISerializedResponse {
-  body?: string;
+  body?: string | object;
   headers?: IOutgoingHeaders;
   statusCode: number;
 }


### PR DESCRIPTION
- Adjust the type of body in ISerializedResponse interface to `string | object`

-  remove casting to string in the `generator.ts` (line 305)

- adjust test case in `generator.test.ts`