### PR TITLE
Enumerate method in UnmockRequest

### DIFF
--- a/packages/unmock-core/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/index.test.ts
@@ -93,7 +93,7 @@ describe("Unmock node package", () => {
     test("should track a successful request-response pair", async () => {
       await axios.post("http://petstore.swagger.io/v1/pets", {});
       sinon.assert.calledOnce(petstore.spy);
-      sinon.assert.calledWith(petstore.spy, sinon.match({ method: "POST" }));
+      sinon.assert.calledWith(petstore.spy, sinon.match({ method: "post" }));
       expect(petstore.spy.firstCall.returnValue).toEqual(
         expect.objectContaining({ statusCode: 201 }),
       );

--- a/packages/unmock-core/src/__tests__/matcher.test.ts
+++ b/packages/unmock-core/src/__tests__/matcher.test.ts
@@ -7,7 +7,7 @@ describe("OASMatcher", () => {
     const matcher = new OASMatcher({ schema });
     const validRequest: UnmockRequest = {
       host: "petstore.swagger.io",
-      method: "GET",
+      method: "get",
       path: "/v1/pets",
       protocol: "http",
     };

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -3,7 +3,7 @@ import { ISerializedRequest, ISerializedResponse } from "../interfaces";
 import { createCallTracker, ICallTracker } from "../service/spy";
 
 const fakeRequest: ISerializedRequest = {
-  method: "GET",
+  method: "get",
   host: "github.com",
   protocol: "https",
   path: "/v3",

--- a/packages/unmock-core/src/__tests__/state.test.ts
+++ b/packages/unmock-core/src/__tests__/state.test.ts
@@ -1,6 +1,7 @@
+import { HTTPMethod } from "../interfaces";
+
 import {
   ExtendedHTTPMethod,
-  HTTPMethod,
   IStateInputGenerator,
 } from "../service/interfaces";
 import { State } from "../service/state/state";

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -68,7 +68,7 @@ export interface ISerializedRequest {
   body?: string | object;
   headers?: IIncomingHeaders;
   host: string;
-  method: string;
+  method: HTTPMethod;
   path: string;
   protocol: "http" | "https";
 }

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -3,6 +3,22 @@ import { AllowedHosts } from "./settings/allowedHosts";
 
 export { ServiceStoreType };
 
+const RESTMethodTypes = [
+  "get",
+  "head",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "trace",
+] as const;
+
+export type HTTPMethod = typeof RESTMethodTypes[number];
+
+export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
+  RESTMethodTypes.toString().includes(maybeMethod.toLowerCase());
+
 export interface ILogger {
   log(message: string): void;
 }

--- a/packages/unmock-core/src/serialize/index.ts
+++ b/packages/unmock-core/src/serialize/index.ts
@@ -5,10 +5,10 @@ import * as http from "http";
 const readable = require("readable-stream"); // tslint:disable-line:no-var-requires
 import url from "url";
 import {
+  HTTPMethod,
   IIncomingHeaders,
   ISerializedRequest,
   isRESTMethod,
-  HTTPMethod,
 } from "../interfaces";
 
 /**

--- a/packages/unmock-core/src/serialize/index.ts
+++ b/packages/unmock-core/src/serialize/index.ts
@@ -4,7 +4,12 @@ import * as http from "http";
 // @ts-ignore
 const readable = require("readable-stream"); // tslint:disable-line:no-var-requires
 import url from "url";
-import { IIncomingHeaders, ISerializedRequest } from "../interfaces";
+import {
+  IIncomingHeaders,
+  ISerializedRequest,
+  isRESTMethod,
+  HTTPMethod,
+} from "../interfaces";
 
 /**
  * Network serializers
@@ -41,7 +46,7 @@ class BodySerializer extends readable.Transform {
 function extractVars(
   interceptedRequest: http.IncomingMessage,
 ): {
-  method: string;
+  method: HTTPMethod;
   host: string;
   path: string;
   headers: IIncomingHeaders;
@@ -56,11 +61,11 @@ function extractVars(
 
   const host = hostWithPort.split(":")[0];
 
-  const { method, url: requestUrl } = interceptedRequest;
+  const { method: methodNode, url: requestUrl } = interceptedRequest;
   if (!requestUrl) {
     throw new Error("Missing request url.");
   }
-  if (!method) {
+  if (!methodNode) {
     throw new Error("Missing method");
   }
 
@@ -68,6 +73,13 @@ function extractVars(
 
   if (!path) {
     throw new Error("Could not parse path");
+  }
+
+  // https://nodejs.org/api/http.html#http_message_method
+  const method = methodNode.toLowerCase();
+
+  if (!isRESTMethod(method)) {
+    throw new Error(`Unknown REST method: ${method}`);
   }
 
   return {

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -4,7 +4,7 @@ import {
   PathItem,
   Schema,
 } from "loas3/dist/generated/full";
-import { ISerializedRequest } from "../interfaces";
+import { HTTPMethod, ISerializedRequest } from "../interfaces";
 import { DEFAULT_STATE_HTTP_METHOD } from "./constants";
 import { IDSL, ITopLevelDSL } from "./dsl/interfaces";
 import { IRequestResponsePair, RequestResponseSpy } from "./spy";
@@ -26,27 +26,12 @@ export {
   Responses,
 } from "loas3/dist/generated/full";
 
-const RESTMethodTypes = [
-  "get",
-  "head",
-  "post",
-  "put",
-  "patch",
-  "delete",
-  "options",
-  "trace",
-] as const;
-
 const DEF_REST_METHOD = [DEFAULT_STATE_HTTP_METHOD] as const;
 
 type DEFAULT_HTTP_METHOD_AS_TYPE = typeof DEF_REST_METHOD[number];
-export type HTTPMethod = typeof RESTMethodTypes[number];
 export type ExtendedHTTPMethod = HTTPMethod | DEFAULT_HTTP_METHOD_AS_TYPE;
 
 export type OASMethodKey = keyof PathItem & HTTPMethod;
-
-export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
-  RESTMethodTypes.toString().includes(maybeMethod.toLowerCase());
 
 export interface IStateInputGenerator {
   /**

--- a/packages/unmock-core/src/service/service.ts
+++ b/packages/unmock-core/src/service/service.ts
@@ -1,9 +1,9 @@
+import { isRESTMethod } from "../interfaces";
 import { DEFAULT_STATE_ENDPOINT, DEFAULT_STATE_HTTP_METHOD } from "./constants";
 import {
   ExtendedHTTPMethod,
   IService,
   IServiceCore,
-  isRESTMethod,
   isStateInputGenerator,
   StateInput,
   StateType,

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -1,8 +1,7 @@
-import { ISerializedRequest } from "../interfaces";
+import { HTTPMethod, ISerializedRequest } from "../interfaces";
 import { DEFAULT_STATE_ENDPOINT } from "./constants";
 import {
   Dereferencer,
-  HTTPMethod,
   IServiceCore,
   IStateInput,
   MatcherResponse,

--- a/packages/unmock-core/src/service/state/interfaces.ts
+++ b/packages/unmock-core/src/service/state/interfaces.ts
@@ -1,10 +1,5 @@
-import {
-  Dereferencer,
-  HTTPMethod,
-  IStateInput,
-  Operation,
-  Paths,
-} from "../interfaces";
+import { HTTPMethod } from "../../interfaces";
+import { Dereferencer, IStateInput, Operation, Paths } from "../interfaces";
 
 export interface IStateUpdate {
   stateInput: IStateInput;

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -1,8 +1,9 @@
 import debug from "debug";
 import minimatch from "minimatch";
+import { HTTPMethod } from "../../interfaces";
 import { DEFAULT_STATE_HTTP_METHOD } from "../constants";
 import { DSL } from "../dsl";
-import { codeToMedia, ExtendedHTTPMethod, HTTPMethod } from "../interfaces";
+import { codeToMedia, ExtendedHTTPMethod } from "../interfaces";
 import { IStateUpdate } from "./interfaces";
 import {
   chooseErrorFromList,

--- a/packages/unmock-core/src/service/state/utils.ts
+++ b/packages/unmock-core/src/service/state/utils.ts
@@ -1,13 +1,13 @@
 import debug from "debug";
+import { HTTPMethod, isRESTMethod } from "../../interfaces";
 import {
   DEFAULT_STATE_ENDPOINT,
   DEFAULT_STATE_HTTP_METHOD,
 } from "../constants";
 import { DSLKeys } from "../dsl/interfaces";
+
 import {
   ExtendedHTTPMethod,
-  HTTPMethod,
-  isRESTMethod,
   OASMethodKey,
   Operation,
   PathItem,


### PR DESCRIPTION
- Change `method` to be enumeration
- Move `HTTPMethod` and some other helpers one level higher as they're not service-specific