### PR TITLE
Add pathname and query to request.

### DIFF
--- a/packages/unmock-core/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/index.test.ts
@@ -82,6 +82,9 @@ describe("Node.js interceptor", () => {
 describe("Unmock node package", () => {
   const nodeInterceptor = new NodeBackend({ servicesDirectory });
   const unmock = new UnmockPackage(nodeInterceptor);
+  afterAll(() => {
+    unmock.off();
+  });
   describe("service spy", () => {
     let petstore: Service;
     beforeAll(() => {

--- a/packages/unmock-core/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/states.test.ts
@@ -77,6 +77,15 @@ describe("Node.js interceptor", () => {
       expect(response.data).toBe("foo");
     });
 
+    test("gets correct state with query parameter when setting textual response", async () => {
+      filestackApi.state("foo");
+      const response = await axios(
+        "https://cloud.filestackapi.com/prefetch?apikey=fake",
+      );
+      expect(response.status).toBe(200);
+      expect(response.data).toBe("foo");
+    });
+
     test("gets correct state when setting textual response with path", async () => {
       filestackApi.state("/prefetch", "bar");
       const response = await axios("https://cloud.filestackapi.com/prefetch");

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -47,7 +47,9 @@ describe("Tests generator", () => {
         host: "petstore.swagger.io",
         method: "post",
         path: "/v1/pets",
+        pathname: "/v1/pets",
         protocol: "http",
+        query: {},
       });
       expect(resp).toBeDefined();
       if (resp !== undefined) {
@@ -68,7 +70,9 @@ describe("Tests generator", () => {
         host: "petstore.swagger.io",
         method: "post",
         path: "/v1/pets",
+        pathname: "/v1/pets",
         protocol: "http",
+        query: {},
       });
       expect(resp).toBeDefined();
       if (resp !== undefined) {
@@ -91,7 +95,9 @@ describe("Tests generator", () => {
       host: "cloud.filestackapi.com",
       method: "options",
       path: "/prefetch",
+      pathname: "/prefetch",
       protocol: "https",
+      query: {},
     });
     expect(resp).toBeDefined();
     if (resp !== undefined) {
@@ -103,7 +109,9 @@ describe("Tests generator", () => {
       host: "cloud.filestackapi.com",
       method: "get",
       path: "/prefetch",
+      pathname: "/prefetch",
       protocol: "https",
+      query: {},
     });
     expect(resp).toBeDefined();
     if (resp !== undefined) {
@@ -122,7 +130,9 @@ describe("Tests generator", () => {
       host: "petstore.swagger.io",
       method: "get",
       path: "/v1/pets",
+      pathname: "/v1/pets",
       protocol: "http",
+      query: {},
     });
     expect(resp).toBeDefined();
     if (resp && resp.body !== undefined) {
@@ -138,7 +148,9 @@ describe("Tests generator", () => {
       host: "petstore.swagger.io",
       method: "get",
       path: "/v1/pets",
+      pathname: "/v1/pets",
       protocol: "http",
+      query: {},
     });
     expect(resp).toBeDefined();
     if (resp && resp.body !== undefined) {

--- a/packages/unmock-core/src/__tests__/index.test.ts
+++ b/packages/unmock-core/src/__tests__/index.test.ts
@@ -29,7 +29,9 @@ describe("Imports", () => {
         host: "github.com",
         method: "get",
         path: "/v1",
+        pathname: "/v1",
         protocol: "http",
+        query: {},
       };
       const response: UnmockResponse = { body: "asdf", statusCode: 200 };
       expect(request).toBeDefined();

--- a/packages/unmock-core/src/__tests__/matcher.test.ts
+++ b/packages/unmock-core/src/__tests__/matcher.test.ts
@@ -9,7 +9,9 @@ describe("OASMatcher", () => {
       host: "petstore.swagger.io",
       method: "get",
       path: "/v1/pets",
+      pathname: "/v1/pets",
       protocol: "http",
+      query: {},
     };
     it("matches a correct request", () => {
       const sreq: UnmockRequest = validRequest;
@@ -29,6 +31,7 @@ describe("OASMatcher", () => {
       const sreq: UnmockRequest = {
         ...validRequest,
         path: "/v1",
+        pathname: "/v1",
       };
       const responseTemplate = matcher.matchToOperationObject(sreq);
       expect(responseTemplate).toBeUndefined();

--- a/packages/unmock-core/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-core/src/__tests__/serialize/index.test.ts
@@ -14,17 +14,22 @@ describe("Request serializer", () => {
 
   test("serializes GET request", done => {
     const testHost = "example.org";
+    const testPath = "/v1?name=erkki";
 
     mitm.on("request", async (req: IncomingMessage) => {
       const serializedRequest = await serializeRequest(req);
       expect(serializedRequest.host).toBe(testHost);
       expect(serializedRequest.method.toLowerCase()).toBe("get");
-      expect(serializedRequest.path).toBe("/");
+      expect(serializedRequest.pathname).toBe("/v1");
+      // FIXME: Path should be the full path including query
+      // expect(serializedRequest.path).toBe("/v1?name=erkki");
+      expect(serializedRequest.path).toBe("/v1");
+      expect(serializedRequest.query).toEqual({ name: "erkki" });
       expect(serializedRequest.protocol).toBe("http");
       expect(serializedRequest.body).toBeUndefined();
       done();
     });
-    http.get(`http://${testHost}`);
+    http.get(`http://${testHost}${testPath}`);
   });
 
   function sendHttpsPostRequest(host: string, body: any) {

--- a/packages/unmock-core/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-core/src/__tests__/serialize/index.test.ts
@@ -21,9 +21,7 @@ describe("Request serializer", () => {
       expect(serializedRequest.host).toBe(testHost);
       expect(serializedRequest.method.toLowerCase()).toBe("get");
       expect(serializedRequest.pathname).toBe("/v1");
-      // FIXME: Path should be the full path including query
-      // expect(serializedRequest.path).toBe("/v1?name=erkki");
-      expect(serializedRequest.path).toBe("/v1");
+      expect(serializedRequest.path).toBe(testPath);
       expect(serializedRequest.query).toEqual({ name: "erkki" });
       expect(serializedRequest.protocol).toBe("http");
       expect(serializedRequest.body).toBeUndefined();

--- a/packages/unmock-core/src/__tests__/spy.test.ts
+++ b/packages/unmock-core/src/__tests__/spy.test.ts
@@ -7,6 +7,8 @@ const fakeRequest: ISerializedRequest = {
   host: "github.com",
   protocol: "https",
   path: "/v3",
+  pathname: "/v3",
+  query: {},
 };
 
 const fakeResponse: ISerializedResponse = {

--- a/packages/unmock-core/src/__tests__/utils.ts
+++ b/packages/unmock-core/src/__tests__/utils.ts
@@ -98,8 +98,10 @@ export const PetstoreServiceWithDynamicPaths = (
 export const testRequest: ISerializedRequest = {
   method: "get",
   path: "/v3",
+  pathname: "/v3",
   host: "api.github.com",
   protocol: "https",
+  query: {},
 };
 
 export const testResponse: ISerializedResponse = {

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -38,14 +38,14 @@ const errorForMissingTemplate = (sreq: ISerializedRequest) => {
   return `No matching template found for intercepted request. Please ensure that
 
   1. You have defined a service for host ${serverUrl}
-  2. The service has a path matching "${sreq.method} ${sreq.path}"
+  2. The service has a path matching "${sreq.method} ${sreq.pathname}"
 
   For example, add the following to your service:
 
   servers:
     - url: ${sreq.protocol}://${sreq.host}
   paths:
-    ${sreq.path}:
+    ${sreq.pathname}:
       ${sreq.method.toLowerCase()}:
         // OpenAPI operation object
         responses:

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -64,12 +64,27 @@ export interface IOutgoingHeaders {
   [header: string]: string | string[] | number | undefined;
 }
 
+export interface IIncomingQuery {
+  [key: string]: string | string[] | undefined;
+}
+
 export interface ISerializedRequest {
   body?: string | object;
   headers?: IIncomingHeaders;
   host: string;
   method: HTTPMethod;
+  /**
+   * Full path containing query parameters
+   */
   path: string;
+  /**
+   * Path name not containing query parameters
+   */
+  pathname: string;
+  /**
+   * Query parameters
+   */
+  query: IIncomingQuery;
   protocol: "http" | "https";
 }
 

--- a/packages/unmock-core/src/serialize/index.ts
+++ b/packages/unmock-core/src/serialize/index.ts
@@ -9,6 +9,7 @@ import {
   IIncomingHeaders,
   ISerializedRequest,
   isRESTMethod,
+  IIncomingQuery,
 } from "../interfaces";
 
 /**
@@ -46,10 +47,12 @@ class BodySerializer extends readable.Transform {
 function extractVars(
   interceptedRequest: http.IncomingMessage,
 ): {
+  headers: IIncomingHeaders;
   method: HTTPMethod;
   host: string;
   path: string;
-  headers: IIncomingHeaders;
+  pathname: string;
+  query: IIncomingQuery;
 } {
   const headers = interceptedRequest.headers;
 
@@ -69,10 +72,14 @@ function extractVars(
     throw new Error("Missing method");
   }
 
-  const { pathname: path } = url.parse(requestUrl, true);
+  const { path, pathname, query } = url.parse(requestUrl, true);
 
   if (!path) {
     throw new Error("Could not parse path");
+  }
+
+  if (!pathname) {
+    throw new Error("Could not parse pathname");
   }
 
   // https://nodejs.org/api/http.html#http_message_method
@@ -86,7 +93,9 @@ function extractVars(
     headers,
     host,
     method,
-    path,
+    path: pathname, // FIXME: Hack until we support full paths
+    pathname,
+    query,
   };
 }
 
@@ -110,7 +119,9 @@ const safelyParseJson = (body: string): string | object => {
 export const serializeRequest = async (
   interceptedRequest: http.IncomingMessage,
 ): Promise<ISerializedRequest> => {
-  const { headers, host, method, path } = extractVars(interceptedRequest);
+  const { headers, host, method, path, pathname, query } = extractVars(
+    interceptedRequest,
+  );
 
   const isEncrypted = (interceptedRequest.connection as any).encrypted;
   const protocol = isEncrypted ? "https" : "http";
@@ -128,7 +139,9 @@ export const serializeRequest = async (
     host,
     method,
     path,
+    pathname,
     protocol,
+    query,
   };
   return serializedRequest;
 };

--- a/packages/unmock-core/src/serialize/index.ts
+++ b/packages/unmock-core/src/serialize/index.ts
@@ -7,9 +7,9 @@ import url from "url";
 import {
   HTTPMethod,
   IIncomingHeaders,
+  IIncomingQuery,
   ISerializedRequest,
   isRESTMethod,
-  IIncomingQuery,
 } from "../interfaces";
 
 /**

--- a/packages/unmock-core/src/serialize/index.ts
+++ b/packages/unmock-core/src/serialize/index.ts
@@ -93,7 +93,7 @@ function extractVars(
     headers,
     host,
     method,
-    path: pathname, // FIXME: Hack until we support full paths
+    path,
     pathname,
     query,
   };

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -190,10 +190,10 @@ export class OASMatcher {
       if (
         protocol === sreq.protocol &&
         serverUrl.hostname === sreq.host &&
-        sreq.path.startsWith(serverUrl.pathname)
+        sreq.pathname.startsWith(serverUrl.pathname)
       ) {
         const reqPathWithoutServerPrefix = OASMatcher.normalizeRequestPathToServerPath(
-          sreq.path,
+          sreq.pathname,
           serverUrl.pathname,
         );
 

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -182,7 +182,7 @@ export class OASMatcher {
 
       debugLog(
         `Testing: ${protocol} vs. ${sreq.protocol}, ${serverUrl.hostname} ` +
-          `vs ${sreq.host}, ${sreq.path} vs ${serverUrl.pathname}`,
+          `vs ${sreq.host}, ${sreq.pathname} vs ${serverUrl.pathname}`,
       );
       if (serverUrl.pathname === undefined) {
         throw new Error("Got undefined pathname");

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -64,7 +64,7 @@ export class ServiceCore implements IServiceCore {
       return undefined;
     }
 
-    const state = this.getState(sreq.method as HTTPMethod, sreq.pathname);
+    const state = this.getState(sreq.method, sreq.pathname);
     return {
       operation: maybeOp,
       state,
@@ -101,7 +101,6 @@ export class ServiceCore implements IServiceCore {
 
   public getState(method: HTTPMethod, endpoint: string) {
     // TODO at some point we'd probably want to move to regex for case insensitivity
-    method = method.toLowerCase() as HTTPMethod;
     endpoint = endpoint.toLowerCase();
     const realEndpoint = this.matcher.findEndpoint(endpoint);
     if (realEndpoint === undefined) {

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -64,7 +64,7 @@ export class ServiceCore implements IServiceCore {
       return undefined;
     }
 
-    const state = this.getState(sreq.method as HTTPMethod, sreq.path);
+    const state = this.getState(sreq.method as HTTPMethod, sreq.pathname);
     return {
       operation: maybeOp,
       state,


### PR DESCRIPTION
- Add `pathname` and `query` to `ISerializedRequest` so that it more closely resembles the [parsed URL object](https://nodejs.org/api/http.html#http_message_url) from Node.js
- [x]  I'm not completely sure we're using `pathname` and `path` correctly everywhere but added a test where query parameters are included.