### PR TITLE
Disable esModuleInterop.

### DIFF
--- a/packages/unmock-cli/src/index.ts
+++ b/packages/unmock-cli/src/index.ts
@@ -1,4 +1,4 @@
-import program from "commander";
+import * as program from "commander";
 
 export default () => {
   program.usage("unmock <command>");

--- a/packages/unmock-core/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/index.test.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import path from "path";
+import * as path from "path";
 import { Service, sinon, UnmockPackage } from "../../";
 import NodeBackend from "../../backend";
 

--- a/packages/unmock-core/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/states.test.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import path from "path";
+import * as path from "path";
 import { dsl, Service, UnmockPackage, UnmockRequest } from "../..";
 import NodeBackend from "../../backend";
 

--- a/packages/unmock-core/src/__tests__/fs-service-def-loader.test.ts
+++ b/packages/unmock-core/src/__tests__/fs-service-def-loader.test.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import * as path from "path";
 import { FsServiceDefLoader } from "../fs-service-def-loader";
 import { IServiceDef } from "../interfaces";
 

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import * as path from "path";
 import { FsServiceDefLoader } from "../fs-service-def-loader";
 import { responseCreatorFactory } from "../generator";
 

--- a/packages/unmock-core/src/__tests__/parser.test.ts
+++ b/packages/unmock-core/src/__tests__/parser.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import * as fs from "fs";
+import * as path from "path";
 import { IServiceDef } from "../interfaces";
 import { ServiceParser } from "../parser";
 

--- a/packages/unmock-core/src/__tests__/serialize/index.test.ts
+++ b/packages/unmock-core/src/__tests__/serialize/index.test.ts
@@ -1,6 +1,6 @@
-import http, { IncomingMessage } from "http";
-import https from "https";
-import Mitm from "mitm";
+import * as http from "http";
+import * as https from "https";
+import Mitm = require("mitm");
 import { serializeRequest } from "../../serialize";
 
 describe("Request serializer", () => {
@@ -16,7 +16,7 @@ describe("Request serializer", () => {
     const testHost = "example.org";
     const testPath = "/v1?name=erkki";
 
-    mitm.on("request", async (req: IncomingMessage) => {
+    mitm.on("request", async (req: http.IncomingMessage) => {
       const serializedRequest = await serializeRequest(req);
       expect(serializedRequest.host).toBe(testHost);
       expect(serializedRequest.method.toLowerCase()).toBe("get");
@@ -61,7 +61,7 @@ describe("Request serializer", () => {
       message,
     });
 
-    mitm.on("request", async (req: IncomingMessage) => {
+    mitm.on("request", async (req: http.IncomingMessage) => {
       const serializedRequest = await serializeRequest(req);
       expect(serializedRequest.host).toBe(testHost);
       expect(serializedRequest.method.toLowerCase()).toBe("post");

--- a/packages/unmock-core/src/__tests__/service.util.test.ts
+++ b/packages/unmock-core/src/__tests__/service.util.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import * as path from "path";
-import * as XRegExp from "xregexp";
+import XRegExp = require("xregexp");
 import { Parameter } from "../service/interfaces";
 import {
   buildPathRegexStringFromParameters,

--- a/packages/unmock-core/src/__tests__/service.util.test.ts
+++ b/packages/unmock-core/src/__tests__/service.util.test.ts
@@ -1,7 +1,7 @@
-import fs from "fs";
-import yaml from "js-yaml";
-import path from "path";
-import XRegExp from "xregexp";
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+import * as path from "path";
+import * as XRegExp from "xregexp";
 import { Parameter } from "../service/interfaces";
 import {
   buildPathRegexStringFromParameters,

--- a/packages/unmock-core/src/__tests__/utils.ts
+++ b/packages/unmock-core/src/__tests__/utils.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import jsYaml from "js-yaml";
-import path from "path";
+import * as fs from "fs";
+import * as jsYaml from "js-yaml";
+import * as path from "path";
 import { ISerializedRequest, ISerializedResponse } from "../interfaces";
 import { OpenAPIObject } from "../service/interfaces";
 import { ServiceCore } from "../service/serviceCore";

--- a/packages/unmock-core/src/backend/client-request-tracker.ts
+++ b/packages/unmock-core/src/backend/client-request-tracker.ts
@@ -1,7 +1,7 @@
 import debug from "debug";
 import { ClientRequest, IncomingMessage } from "http";
 import * as net from "net";
-import * as shimmer from "shimmer";
+import shimmer = require("shimmer");
 import { v4 as uuidv4 } from "uuid";
 
 const debugLog = debug("unmock:client-request-tracker");

--- a/packages/unmock-core/src/backend/client-request-tracker.ts
+++ b/packages/unmock-core/src/backend/client-request-tracker.ts
@@ -1,7 +1,7 @@
 import debug from "debug";
 import { ClientRequest, IncomingMessage } from "http";
-import net from "net";
-import shimmer from "shimmer";
+import * as net from "net";
+import * as shimmer from "shimmer";
 import { v4 as uuidv4 } from "uuid";
 
 const debugLog = debug("unmock:client-request-tracker");

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -5,9 +5,9 @@ import {
   RequestOptions,
   ServerResponse,
 } from "http";
-import _ from "lodash";
-import Mitm from "mitm";
-import net from "net";
+import * as _ from "lodash";
+import Mitm = require("mitm");
+import * as net from "net";
 import { CustomConsole } from "../console";
 import { FsServiceDefLoader } from "../fs-service-def-loader";
 import { responseCreatorFactory } from "../generator";

--- a/packages/unmock-core/src/fs-service-def-loader.ts
+++ b/packages/unmock-core/src/fs-service-def-loader.ts
@@ -1,7 +1,7 @@
 import debug from "debug";
-import fs from "fs";
+import * as fs from "fs";
 import { flatMap } from "lodash";
-import path from "path";
+import * as path from "path";
 import { IServiceDef } from "./interfaces";
 
 const debugLog = debug("unmock:fs-service-def-loader");

--- a/packages/unmock-core/src/loggers/filesystem-logger.ts
+++ b/packages/unmock-core/src/loggers/filesystem-logger.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import yaml from "js-yaml";
-import path from "path";
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+import * as path from "path";
 import {
   IListener,
   ISerializedRequest,

--- a/packages/unmock-core/src/loggers/winston-logger.ts
+++ b/packages/unmock-core/src/loggers/winston-logger.ts
@@ -1,4 +1,4 @@
-import winston from "winston";
+import * as winston from "winston";
 import { ILogger } from "../interfaces";
 
 const logger = winston.createLogger({

--- a/packages/unmock-core/src/parser.ts
+++ b/packages/unmock-core/src/parser.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { isLeft } from "fp-ts/lib/Either";
-import jsYaml from "js-yaml";
+import * as jsYaml from "js-yaml";
 import loas3 from "loas3";
 import { IServiceDef, IServiceDefFile } from "./interfaces";
 import { ServiceCore } from "./service/serviceCore";

--- a/packages/unmock-core/src/serialize/deserializer/form.ts
+++ b/packages/unmock-core/src/serialize/deserializer/form.ts
@@ -1,4 +1,4 @@
-import querystring from "querystring";
+import * as querystring from "querystring";
 import { IDeserializer } from "../interfaces";
 
 export default class FormDeserializer implements IDeserializer {

--- a/packages/unmock-core/src/serialize/index.ts
+++ b/packages/unmock-core/src/serialize/index.ts
@@ -3,7 +3,7 @@ import * as http from "http";
 // @types/readable-stream not compatible with @types/node@8?
 // @ts-ignore
 const readable = require("readable-stream"); // tslint:disable-line:no-var-requires
-import url from "url";
+import * as url from "url";
 import {
   HTTPMethod,
   IIncomingHeaders,

--- a/packages/unmock-core/src/serialize/serializer/form.ts
+++ b/packages/unmock-core/src/serialize/serializer/form.ts
@@ -1,4 +1,4 @@
-import querystring from "querystring";
+import * as querystring from "querystring";
 import { ISerializer } from "../interfaces";
 
 export default class FormSerializer implements ISerializer {

--- a/packages/unmock-core/src/service/constants.ts
+++ b/packages/unmock-core/src/service/constants.ts
@@ -1,4 +1,4 @@
-import XRegExp from "xregexp";
+import XRegExp = require("xregexp");
 
 export const DEFAULT_STATE_HTTP_METHOD = "any";
 export const DEFAULT_STATE_ENDPOINT = "**";

--- a/packages/unmock-core/src/service/matcher.ts
+++ b/packages/unmock-core/src/service/matcher.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
-import url from "url";
-import XRegExp from "xregexp";
+import * as url from "url";
+import XRegExp = require("xregexp");
 import { ISerializedRequest } from "../interfaces";
 import { OASMethodKey, OpenAPIObject, PathItem } from "./interfaces";
 import {

--- a/packages/unmock-core/src/service/state/state.ts
+++ b/packages/unmock-core/src/service/state/state.ts
@@ -1,5 +1,5 @@
 import debug from "debug";
-import minimatch from "minimatch";
+import minimatch = require("minimatch");
 import { HTTPMethod } from "../../interfaces";
 import { DEFAULT_STATE_HTTP_METHOD } from "../constants";
 import { DSL } from "../dsl";

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -1,4 +1,4 @@
-import * as Ajv from "ajv";
+import Ajv = require("ajv");
 import debug from "debug";
 import { ISerializedRequest } from "../../interfaces";
 import { DSL, filterTopLevelDSL, getTopLevelDSL, ITopLevelDSL } from "../dsl";

--- a/packages/unmock-core/src/service/state/transformers.ts
+++ b/packages/unmock-core/src/service/state/transformers.ts
@@ -1,4 +1,4 @@
-import Ajv from "ajv";
+import * as Ajv from "ajv";
 import debug from "debug";
 import { ISerializedRequest } from "../../interfaces";
 import { DSL, filterTopLevelDSL, getTopLevelDSL, ITopLevelDSL } from "../dsl";

--- a/packages/unmock-core/src/service/util.ts
+++ b/packages/unmock-core/src/service/util.ts
@@ -1,8 +1,8 @@
-import fs from "fs";
-import jsyaml from "js-yaml";
-import pointer from "json-pointer";
-import fspath from "path";
-import XRegExp from "xregexp";
+import * as fs from "fs";
+import * as jsyaml from "js-yaml";
+import * as pointer from "json-pointer";
+import * as fspath from "path";
+import XRegExp = require("xregexp");
 import { OAS_PATH_PARAM_REGEXP, OAS_PATH_PARAMS_KW } from "./constants";
 import { OpenAPIObject, Parameter, Paths } from "./interfaces";
 

--- a/packages/unmock-core/src/utils.ts
+++ b/packages/unmock-core/src/utils.ts
@@ -1,8 +1,8 @@
-import appRootPath from "app-root-path";
+import * as appRootPath from "app-root-path";
 import debug from "debug";
-import fs from "fs";
+import * as fs from "fs";
 import { uniq } from "lodash";
-import path from "path";
+import * as path from "path";
 
 const debugLog = debug("unmock:node:utils");
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "target": "es2015",
     "module": "commonjs",
     "moduleResolution": "node",
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
- Requires using either `import foo = require("foo")` or `import * as foo from "foo"`
- It's not obvious at all which one should use (see [this discussion](https://stackoverflow.com/questions/29596714/new-es6-syntax-for-importing-commonjs-amd-modules-i-e-import-foo-require)) but I tried to follow the guideline of using `import * as blah...` for modules exporting a proper namespace or module
- See [this comment in Jest tsconfig.json](https://github.com/facebook/jest/blob/master/tsconfig.json#L23)