### PR TITLE
Do not default import sinon.

### DIFF
--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -1,5 +1,5 @@
 // Sinon for asserts and matchers
-import sinon from "sinon";
+import * as sinon from "sinon";
 import NodeBackend from "./backend";
 import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
 import WinstonLogger from "./loggers/winston-logger";


### PR DESCRIPTION
- The import `import sinon from "sinon"` relies on `esModuleInterop: true`, because `sinon` has no default export.
- This breaks any usage of `unmock-js` in projects using `esModuleInterop: false` (which is the default)