### PR TITLE
Add @types/sinon to unmock-core.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,8 +2098,7 @@
     "@types/sinon": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
-      "integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==",
-      "dev": true
+      "integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -12211,6 +12210,7 @@
     "unmock-core": {
       "version": "file:packages/unmock-core",
       "requires": {
+        "@types/sinon": "^7.0.13",
         "ajv": "^6.10.0",
         "app-root-path": "^2.2.1",
         "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^8.10.51",
     "@types/shimmer": "^1.0.1",
-    "@types/sinon": "^7.0.13",
     "@types/uuid": "^3.4.5",
     "@types/xregexp": "^3.0.30",
     "axios": "^0.19.0",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
+    "@types/sinon": "^7.0.13",
     "app-root-path": "^2.2.1",
     "ajv": "^6.10.0",
     "axios": "^0.18.0",


### PR DESCRIPTION
- Quick fix while we think if we want to add all types as dependencies (#201).
- Sinon definitely needs to be a dependency because we even export that