### PR TITLE
Adds initial nock-like syntax

### DIFF
--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -1,0 +1,57 @@
+import unmock from "..";
+
+describe("Tests dynamic path tests", () => {
+  beforeEach(() => unmock.on());
+  afterEach(() => unmock.off());
+
+  it("Adds a service", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    unmock
+      .nock("https://foo.com")
+      .get("/foo")
+      .reply(200, { type: "object", properties: { foo: { type: "string" } } });
+    expect(Object.keys(unmock.services).length).toEqual(1);
+  });
+
+  it("Adds a service and changes state", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    const service = unmock
+      .nock("https://foo.com")
+      .get("foo") // slash is prepended automatically
+      .reply(200, { type: "object", properties: { foo: { type: "string" } } });
+    expect(Object.keys(unmock.services).length).toEqual(1);
+    if (service === undefined) {
+      // type-checking mostly...
+      throw new Error("Service was undefined??");
+    }
+    service.state.get("/foo", { foo: "abc" }); // should succeed
+  });
+
+  it("Adds a service and updates it on consecutive calls", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    unmock
+      .nock("https://foo.com")
+      .get("foo") // slash is prepended automatically
+      .reply(200, { type: "object", properties: { foo: { type: "string" } } });
+    const service = unmock
+      .nock("https://foo.com")
+      .post("/foo")
+      .reply(201);
+    expect(Object.keys(unmock.services).length).toEqual(1);
+    if (service === undefined) {
+      // type-checking mostly...
+      throw new Error("Service was undefined??");
+    }
+    service.state("/foo", { $code: 201 }).get("/foo", { $code: 200 }); // should succeed
+  });
+
+  it("Adds a named service", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    unmock
+      .nock("https://abc.com", "foo")
+      .get("abc") // slash is prepended automatically
+      .reply(200, { type: "object", properties: { foo: { type: "string" } } });
+    expect(Object.keys(unmock.services).length).toEqual(1);
+    unmock.services.foo.state.get("/abc", { $code: 200 }); // should succeed
+  });
+});

--- a/packages/unmock-core/src/__tests__/generator.test.ts
+++ b/packages/unmock-core/src/__tests__/generator.test.ts
@@ -15,7 +15,9 @@ const serviceDefLoader = new FsServiceDefLoader({
 
 describe("Tests generator", () => {
   it("loads all paths in __unmock__", () => {
-    const { services } = responseCreatorFactory({
+    const {
+      serviceStore: { services },
+    } = responseCreatorFactory({
       serviceDefLoader,
       options: mockOptions,
     });
@@ -27,7 +29,9 @@ describe("Tests generator", () => {
   });
 
   it("sets a state for swagger api converted to openapi", () => {
-    const { services } = responseCreatorFactory({
+    const {
+      serviceStore: { services },
+    } = responseCreatorFactory({
       serviceDefLoader,
       options: mockOptions,
     });
@@ -86,7 +90,10 @@ describe("Tests generator", () => {
   });
 
   it("Generates correct response from differing status codes", () => {
-    const { services, createResponse } = responseCreatorFactory({
+    const {
+      serviceStore: { services },
+      createResponse,
+    } = responseCreatorFactory({
       serviceDefLoader,
       options: mockOptions,
     });
@@ -121,7 +128,10 @@ describe("Tests generator", () => {
   });
 
   it("Sets a state with a function and generates accordingly", () => {
-    const { services, createResponse } = responseCreatorFactory({
+    const {
+      serviceStore: { services },
+      createResponse,
+    } = responseCreatorFactory({
       serviceDefLoader,
       options: mockOptions,
     });

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -109,8 +109,9 @@ export default class NodeBackend {
 
   public updateServices(newService: IObjectToService) {
     if (this.serviceStore) {
-      this.serviceStore.updateOrAdd(newService);
+      return this.serviceStore.updateOrAdd(newService);
     }
+    return undefined;
   }
 
   /**

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -20,9 +20,10 @@ import {
 } from "../interfaces";
 import FSLogger from "../loggers/filesystem-logger";
 import { serializeRequest } from "../serialize";
-import { IObjectToService, ServiceStore } from "../service/serviceStore";
+import { ServiceStore } from "../service/serviceStore";
 import { resolveUnmockDirectories } from "../utils";
 import ClientRequestTracker from "./client-request-tracker";
+import { IObjectToService } from "../service/interfaces";
 
 const debugLog = debug("unmock:node");
 
@@ -107,6 +108,7 @@ export default class NodeBackend {
     return (this.serviceStore || NodeBackend.dummyStore).services;
   }
 
+  // TODO: Refactor s.t. newService is essentialyl a Service/ServiceCore object
   public updateServices(newService: IObjectToService) {
     if (this.serviceStore) {
       return this.serviceStore.updateOrAdd(newService);

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -20,10 +20,10 @@ import {
 } from "../interfaces";
 import FSLogger from "../loggers/filesystem-logger";
 import { serializeRequest } from "../serialize";
+import { IObjectToService } from "../service/interfaces";
 import { ServiceStore } from "../service/serviceStore";
 import { resolveUnmockDirectories } from "../utils";
 import ClientRequestTracker from "./client-request-tracker";
-import { IObjectToService } from "../service/interfaces";
 
 const debugLog = debug("unmock:node");
 

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -24,7 +24,6 @@ import {
   Response,
   Responses,
   Schema,
-  ServiceStoreType,
 } from "./service/interfaces";
 import { ServiceStore } from "./service/serviceStore";
 
@@ -46,7 +45,7 @@ export function responseCreatorFactory({
   serviceDefLoader: FsServiceDefLoader;
   listeners?: IListener[];
   options: IUnmockOptions;
-}): { services: ServiceStoreType; createResponse: CreateResponse } {
+}): { serviceStore: ServiceStore; createResponse: CreateResponse } {
   const serviceDefs: IServiceDef[] = serviceDefLoader.loadSync();
   const coreServices: IServiceCore[] = serviceDefs.map(serviceDef =>
     ServiceParser.parse(serviceDef),
@@ -57,10 +56,11 @@ export function responseCreatorFactory({
       .map(service => service.match(sreq))
       .filter(res => res !== undefined)
       .shift();
-  const services = ServiceStore(coreServices);
+  // TODO: Maybe move service store instantiation and service parser to backend?
+  const serviceStore = new ServiceStore(coreServices);
 
   return {
-    services,
+    serviceStore,
     createResponse: (req: ISerializedRequest) => {
       // Setup the unmock properties for jsf parsing of x-unmock-*
       setupJSFUnmockProperties(req);

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -61,7 +61,7 @@ export class UnmockPackage implements IUnmockPackage {
     return this.backend.services;
   }
 
-  public nock(baseUrl: string) {
+  public nock(baseUrl: string, name?: string) {
     const dynFn = (method: HTTPMethod, endpoint: string) => ({
       statusCode,
       data,
@@ -75,6 +75,7 @@ export class UnmockPackage implements IUnmockPackage {
         endpoint: endpoint.startsWith("/") ? endpoint : `/${endpoint}`,
         statusCode,
         response: data,
+        name,
       });
 
     return {

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -87,7 +87,7 @@ const dynamicService = (baseUrl: string) => {
     bknd.updateServices({
       baseUrl,
       method,
-      endpoint,
+      endpoint: endpoint.startsWith("/") ? endpoint : `/${endpoint}`,
       statusCode,
       response: data,
     });

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -4,6 +4,7 @@ import NodeBackend from "./backend";
 import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
 import WinstonLogger from "./loggers/winston-logger";
 import { AllowedHosts, BooleanSetting } from "./settings";
+import { Schema } from "./service/interfaces";
 
 export * from "./types";
 export { sinon };
@@ -56,15 +57,133 @@ export class UnmockPackage implements IUnmockPackage {
   }
 }
 
-const unmock: IUnmockPackage = new UnmockPackage(new NodeBackend(), {
+const bknd = new NodeBackend();
+const unmockPackage: IUnmockPackage = new UnmockPackage(bknd, {
   logger: new WinstonLogger(),
 });
 
-// const dynamicService = (foo: any) => {
-//   unmockPackage.services;
-// };
+const dynamicService = (baseUrl: string) => ({
+  get(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+  head(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+  post(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+  put(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+  patch(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+  delete(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+  options(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+  trace(endpoint: string) {
+    return new DynamicServiceSpec(dss =>
+      bknd.updateServices({
+        baseUrl,
+        method: "get",
+        endpoint,
+        statusCode: dss.statusCode,
+        response: dss.data,
+      }),
+    );
+  },
+});
 
-// const unmock = Object.assign(dynamicService, unmockPackage);
+// Placeholder for poet input type, to have
+// e.g. standard object => { type: "object", properties: { ... }}, number => { type: "number", const: ... }
+type InputToPoet = any;
+// tslint:disable-next-line: max-classes-per-file
+class DynamicServiceSpec {
+  public statusCode: number = 200;
+  public data: Schema = {};
+
+  constructor(private updater: (input: DynamicServiceSpec) => void) {}
+
+  public reply(statusCode: number, data?: InputToPoet): void;
+  public reply(data: InputToPoet): void;
+  public reply(maybeStatusCode: number | InputToPoet, maybeData?: InputToPoet) {
+    if (maybeData !== undefined) {
+      this.data = maybeData as Schema; // TODO: use poet to convert to JSON Schema?
+      this.statusCode = maybeStatusCode;
+    } else if (
+      typeof maybeStatusCode === "number" &&
+      maybeStatusCode >= 100 &&
+      maybeStatusCode < 599
+    ) {
+      // we assume it's a status code
+      this.statusCode = maybeStatusCode;
+    } else {
+      this.data = maybeStatusCode as Schema; // TODO: ditto
+    }
+    this.updater(this);
+  }
+}
+
+const unmock = Object.assign(unmockPackage, dynamicService); // Add the function call to the unmock object
 
 export type UnmockNode = typeof unmock;
 

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -60,6 +60,12 @@ const unmock: IUnmockPackage = new UnmockPackage(new NodeBackend(), {
   logger: new WinstonLogger(),
 });
 
+// const dynamicService = (foo: any) => {
+//   unmockPackage.services;
+// };
+
+// const unmock = Object.assign(dynamicService, unmockPackage);
+
 export type UnmockNode = typeof unmock;
 
 export default unmock;

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -64,92 +64,92 @@ const unmockPackage: IUnmockPackage = new UnmockPackage(bknd, {
 
 const dynamicService = (baseUrl: string) => ({
   get(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
         method: "get",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
   head(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
-        method: "get",
+        method: "head",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
   post(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
-        method: "get",
+        method: "post",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
   put(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
-        method: "get",
+        method: "put",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
   patch(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
-        method: "get",
+        method: "patch",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
   delete(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
-        method: "get",
+        method: "delete",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
   options(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
-        method: "get",
+        method: "options",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
   trace(endpoint: string) {
-    return new DynamicServiceSpec(dss =>
-      bknd.updateServices({
+    return new DynamicServiceSpec(dss => {
+      return bknd.updateServices({
         baseUrl,
-        method: "get",
+        method: "trace",
         endpoint,
         statusCode: dss.statusCode,
         response: dss.data,
-      }),
-    );
+      });
+    });
   },
 });
 
@@ -179,7 +179,7 @@ class DynamicServiceSpec {
     } else {
       this.data = maybeStatusCode as Schema; // TODO: ditto
     }
-    this.updater(this);
+    return this.updater(this);
   }
 }
 

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -1,15 +1,9 @@
 // Sinon for asserts and matchers
 import * as sinon from "sinon";
 import NodeBackend from "./backend";
-import {
-  HTTPMethod,
-  ILogger,
-  IUnmockOptions,
-  IUnmockPackage,
-} from "./interfaces";
+import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
 import WinstonLogger from "./loggers/winston-logger";
-import { Service } from "./service";
-import { Schema } from "./service/interfaces";
+import { nockify } from "./nock";
 import { AllowedHosts, BooleanSetting } from "./settings";
 
 export * from "./types";
@@ -62,95 +56,13 @@ export class UnmockPackage implements IUnmockPackage {
   }
 
   public nock(baseUrl: string, name?: string) {
-    const dynFn = (method: HTTPMethod, endpoint: string) => ({
-      statusCode,
-      data,
-    }: {
-      statusCode: number;
-      data: Schema;
-    }) =>
-      this.backend.updateServices({
-        baseUrl,
-        method,
-        endpoint: endpoint.startsWith("/") ? endpoint : `/${endpoint}`,
-        statusCode,
-        response: data,
-        name,
-      });
-
-    return {
-      get(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("get", endpoint));
-      },
-      head(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("head", endpoint));
-      },
-      post(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("post", endpoint));
-      },
-      put(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("put", endpoint));
-      },
-      patch(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("patch", endpoint));
-      },
-      delete(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("delete", endpoint));
-      },
-      options(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("options", endpoint));
-      },
-      trace(endpoint: string) {
-        return new DynamicServiceSpec(dynFn("trace", endpoint));
-      },
-    };
+    return nockify({ backend: this.backend, baseUrl, name });
   }
 }
 
 const unmock = new UnmockPackage(new NodeBackend(), {
   logger: new WinstonLogger(),
 });
-
-type UpdateCallback = ({
-  statusCode,
-  data,
-}: {
-  statusCode: number;
-  data: Schema;
-}) => Service | undefined;
-
-// Placeholder for poet input type, to have
-// e.g. standard object => { type: "object", properties: { ... }}, number => { type: "number", const: ... }
-type InputToPoet = any;
-// tslint:disable-next-line: max-classes-per-file
-class DynamicServiceSpec {
-  private statusCode: number = 200; // TODO default success statuscode per verb?
-  private data: Schema = {};
-
-  constructor(private updater: UpdateCallback) {}
-
-  public reply(statusCode: number, data?: InputToPoet): Service | undefined;
-  public reply(data: InputToPoet): Service | undefined;
-  public reply(
-    maybeStatusCode: number | InputToPoet,
-    maybeData?: InputToPoet,
-  ): Service | undefined {
-    if (maybeData !== undefined) {
-      this.data = maybeData as Schema; // TODO: use poet to convert to JSON Schema?
-      this.statusCode = maybeStatusCode;
-    } else if (
-      typeof maybeStatusCode === "number" &&
-      maybeStatusCode >= 100 &&
-      maybeStatusCode < 599
-    ) {
-      // we assume it's a status code
-      this.statusCode = maybeStatusCode;
-    } else {
-      this.data = maybeStatusCode as Schema; // TODO: ditto
-    }
-    return this.updater({ data: this.data, statusCode: this.statusCode });
-  }
-}
 
 export type UnmockNode = typeof unmock;
 

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -1,0 +1,98 @@
+import NodeBackend from "./backend";
+import { HTTPMethod } from "./interfaces";
+import { Service } from "./service";
+import { Schema } from "./service/interfaces";
+
+type UpdateCallback = ({
+  statusCode,
+  data,
+}: {
+  statusCode: number;
+  data: Schema;
+}) => Service | undefined;
+
+// Placeholder for poet input type, to have
+// e.g. standard object => { type: "object", properties: { ... }}, number => { type: "number", const: ... }
+type InputToPoet = any;
+
+export class DynamicServiceSpec {
+  private statusCode: number = 200; // TODO default success statuscode per verb?
+  private data: Schema = {};
+
+  constructor(private updater: UpdateCallback) {}
+
+  // TODO: Should this allow fluency for consecutive .get, .post, etc on the same service?
+  public reply(statusCode: number, data?: InputToPoet): Service | undefined;
+  public reply(data: InputToPoet): Service | undefined;
+  public reply(
+    maybeStatusCode: number | InputToPoet,
+    maybeData?: InputToPoet,
+  ): Service | undefined {
+    if (maybeData !== undefined) {
+      this.data = maybeData as Schema; // TODO: use poet to convert to JSON Schema?
+      this.statusCode = maybeStatusCode;
+    } else if (
+      typeof maybeStatusCode === "number" &&
+      maybeStatusCode >= 100 &&
+      maybeStatusCode < 599
+    ) {
+      // we assume it's a status code
+      this.statusCode = maybeStatusCode;
+    } else {
+      this.data = maybeStatusCode as Schema; // TODO: ditto
+    }
+    return this.updater({ data: this.data, statusCode: this.statusCode });
+  }
+}
+
+export const nockify = ({
+  backend,
+  baseUrl,
+  name,
+}: {
+  backend: NodeBackend;
+  baseUrl: string;
+  name?: string;
+}) => {
+  const dynFn = (method: HTTPMethod, endpoint: string) => ({
+    statusCode,
+    data,
+  }: {
+    statusCode: number;
+    data: Schema;
+  }) =>
+    backend.updateServices({
+      baseUrl,
+      method,
+      endpoint: endpoint.startsWith("/") ? endpoint : `/${endpoint}`,
+      statusCode,
+      response: data,
+      name,
+    });
+  return {
+    get(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("get", endpoint));
+    },
+    head(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("head", endpoint));
+    },
+    post(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("post", endpoint));
+    },
+    put(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("put", endpoint));
+    },
+    patch(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("patch", endpoint));
+    },
+    delete(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("delete", endpoint));
+    },
+    options(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("options", endpoint));
+    },
+    trace(endpoint: string) {
+      return new DynamicServiceSpec(dynFn("trace", endpoint));
+    },
+  };
+};

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -89,6 +89,16 @@ export interface IService {
 
 export type ServiceStoreType = Record<string, IService>;
 
+// Used to programmatically define/update a service
+export interface IObjectToService {
+  baseUrl: string;
+  method: HTTPMethod;
+  endpoint: string;
+  statusCode: number;
+  response: string | Schema;
+  name?: string;
+}
+
 export interface IServiceCore {
   /**
    * Name for the service.

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -1,11 +1,14 @@
+import { defaultsDeep } from "lodash";
 import { HTTPMethod, ISerializedRequest } from "../interfaces";
 import { DEFAULT_STATE_ENDPOINT } from "./constants";
 import {
   Dereferencer,
+  IObjectToService,
   IServiceCore,
   IStateInput,
   MatcherResponse,
   OpenAPIObject,
+  PathItem,
 } from "./interfaces";
 import { OASMatcher } from "./matcher";
 import {
@@ -18,6 +21,46 @@ import { State } from "./state/state";
 import { derefIfNeeded } from "./util";
 
 export class ServiceCore implements IServiceCore {
+  public static from(
+    baseSchema: OpenAPIObject,
+    {
+      baseUrl,
+      method,
+      endpoint,
+      statusCode,
+      response,
+      name,
+    }: IObjectToService & { name: string },
+  ): IServiceCore {
+    // TODO: Very basic guessing for mediaType; extend this as needed (maybe @mime-types or similar?)
+    const mediaType =
+      typeof response === "string" ? "text/*" : "application/json";
+    // TODO: Decouple from ServiceCore :( - this is nasty
+    const newPath: PathItem = {
+      [endpoint]: {
+        [method]: {
+          responses: {
+            [statusCode]: {
+              description: "Automatically added",
+              content: {
+                [mediaType]: { schema: response },
+              },
+            },
+          },
+        },
+      },
+    };
+    const newUrls = [{ url: baseUrl }];
+
+    const newPaths = defaultsDeep(newPath, baseSchema.paths);
+    const newServers = defaultsDeep(newUrls, baseSchema.servers);
+    const finalSchema = { ...baseSchema, paths: newPaths, servers: newServers };
+    return new ServiceCore({
+      schema: finalSchema,
+      name,
+    });
+  }
+
   public readonly name: string;
   public readonly absPath: string;
   public readonly dereferencer: Dereferencer;

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -73,5 +73,7 @@ export class ServiceStore {
     });
     this.cores[serviceName] = newServiceCore;
     this.services[serviceName] = new Service(newServiceCore);
+
+    return this.services[serviceName];
   }
 }

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -51,12 +51,17 @@ export class ServiceStore {
     // TODO: Very basic guessing for mediaType; extend this as needed (maybe @mime-types or similar?)
     const mediaType =
       typeof response === "string" ? "text/*" : "application/json";
+    // TODO: Decouple from ServiceCore :( - this is nasty
     const newPath: PathItem = {
       [endpoint]: {
         [method]: {
-          [statusCode]: {
-            description: "Automatically added",
-            [mediaType]: { schema: response },
+          responses: {
+            [statusCode]: {
+              description: "Automatically added",
+              content: {
+                [mediaType]: { schema: response },
+              },
+            },
           },
         },
       },
@@ -66,7 +71,6 @@ export class ServiceStore {
     const newPaths = defaultsDeep(newPath, baseSchema.paths);
     const newServers = defaultsDeep(newUrls, baseSchema.servers);
     const finalSchema = { ...baseSchema, paths: newPaths, servers: newServers };
-    // TODO: Decouple from ServiceCore :(
     const newServiceCore = new ServiceCore({
       schema: finalSchema,
       name: serviceName,

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -1,8 +1,77 @@
-import { IServiceCore, ServiceStoreType } from "./interfaces";
+import { defaultsDeep } from "lodash";
+import * as url from "url";
+import { HTTPMethod } from "../interfaces";
+import { IServiceCore, OpenAPIObject, PathItem, Schema } from "./interfaces";
 import { Service } from "./service";
+import { ServiceCore } from "./serviceCore";
 
-export const ServiceStore = (coreServices: IServiceCore[]): ServiceStoreType =>
-  coreServices.reduce(
-    (o, core) => ({ ...o, [core.name]: new Service(core) }),
-    {},
-  );
+export interface IObjectToService {
+  baseUrl: string;
+  method: HTTPMethod;
+  endpoint: string;
+  statusCode: number;
+  response: string | Schema;
+  name?: string;
+}
+
+export class ServiceStore {
+  public readonly services: Record<string, Service>;
+  private readonly cores: Record<string, IServiceCore>;
+  constructor(coreServices: IServiceCore[]) {
+    this.cores = coreServices.reduce(
+      (o, core) => ({ ...o, [core.name]: core }),
+      {},
+    );
+    this.services = coreServices.reduce(
+      (o, core) => ({ ...o, [core.name]: new Service(core) }),
+      {},
+    );
+  }
+
+  public updateOrAdd({
+    baseUrl,
+    method,
+    endpoint,
+    statusCode,
+    response,
+    name,
+  }: IObjectToService) {
+    // TODO: Tighly coupled with OpenAPI at the moment... resolve this at a later time
+    const serviceName = name || url.parse(baseUrl).hostname || baseUrl;
+    const baseSchema: OpenAPIObject =
+      serviceName !== undefined && this.cores[serviceName] !== undefined
+        ? // service exists
+          this.cores[serviceName].schema
+        : // Build new schema object
+          {
+            openapi: "3.0.0",
+            info: { title: "Internally built by unmock", version: "0.0.0" },
+            paths: {},
+          };
+    // TODO: Very basic guessing for mediaType; extend this as needed (maybe @mime-types or similar?)
+    const mediaType =
+      typeof response === "string" ? "text/*" : "application/json";
+    const newPath: PathItem = {
+      [endpoint]: {
+        [method]: {
+          [statusCode]: {
+            description: "Automatically added",
+            [mediaType]: { schema: response },
+          },
+        },
+      },
+    };
+    const newUrls = [{ url: baseUrl }];
+
+    const newPaths = defaultsDeep(newPath, baseSchema.paths);
+    const newServers = defaultsDeep(newUrls, baseSchema.servers);
+    const finalSchema = { ...baseSchema, paths: newPaths, servers: newServers };
+    // TODO: Decouple from ServiceCore :(
+    const newServiceCore = new ServiceCore({
+      schema: finalSchema,
+      name: serviceName,
+    });
+    this.cores[serviceName] = newServiceCore;
+    this.services[serviceName] = new Service(newServiceCore);
+  }
+}


### PR DESCRIPTION
This is done mostly as a building block for future PRs.
- Adds `unmock.nock(baseUrl, [name]).[HTTP METHOD](endpoint).reply([statusCode], [object/string])` allowing to dynamically add/update services.
- Many many `TODO` notes on where to improve, next steps, etc