### PR TITLE
Add reset method

### DIFF
--- a/packages/unmock-core/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/index.test.ts
@@ -124,6 +124,12 @@ describe("Unmock node package", () => {
         expect.objectContaining({ statusCode: 201 }),
       );
     });
+    test("should reset spies with unmock.reset()", async () => {
+      await axios.post("http://petstore.swagger.io/v1/pets", {});
+      sinon.assert.calledOnce(petstore.spy);
+      unmock.reset();
+      sinon.assert.notCalled(petstore.spy);
+    });
     test("should not have tracked calls after reset", async () => {
       await axios.post("http://petstore.swagger.io/v1/pets", {});
       petstore.reset();

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -68,6 +68,10 @@ export class UnmockPackage implements IUnmockPackage {
   public reloadServices() {
     this.backend.loadServices();
   }
+
+  public reset() {
+    Object.values(this.backend.services).forEach(service => service.reset());
+  }
 }
 
 const unmock = new UnmockPackage(new NodeBackend(), {

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -76,6 +76,11 @@ export interface IUnmockPackage {
    * Any dynamically-defined services will be deleted.
    */
   reloadServices(): void;
+
+  /**
+   * Resets all services' state, including spies.
+   */
+  reset(): void;
 }
 
 /**


### PR DESCRIPTION
- Replaces https://github.com/unmock/unmock-js/pull/191 (thanks @dangquangdon)
- Adds some technical debt: `unmock.reset()` and `backend.reset()` have very different behaviours now so it might be better to rename `backend.reset()` -> `backend.off()`

