### PR TITLE
- Add support for multiple $code

### DIFF
--- a/packages/unmock-core/src/__tests__/backend/states.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/states.test.ts
@@ -161,5 +161,16 @@ describe("Node.js interceptor", () => {
       resp = await axios("http://petstore.swagger.io/v1/pets/3");
       expect(resp.data.properties.isCat).toBeFalsy();
     });
+
+    test("Works with multiple codes", async () => {
+      petstore.state(dsl.functionResponse(() => "baz", { $code: [404, 500] }));
+      try {
+        await axios("http://petstore.swagger.io/v1/pets");
+        throw new Error("Expected a 404 response");
+      } catch (err) {
+        expect([404, 500]).toContain(err.response.status);
+        expect(err.response.data).toBe("baz");
+      }
+    });
   });
 });

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -146,9 +146,8 @@ const getStateForOperation = (
       return undefined;
     }
     operationStatusCode = "default";
-    stateStatusCode = genOptions.isFlaky
-      ? firstOrRandomOrUndefined(stateCodes)
-      : chooseResponseCode(stateCodes);
+    // If we have multiple state codes to choose from for this operation, choose one at random
+    stateStatusCode = firstOrRandomOrUndefined(stateCodes);
   } else {
     stateStatusCode = operationStatusCode = genOptions.isFlaky
       ? firstOrRandomOrUndefined(possibleResponseCodes)

--- a/packages/unmock-core/src/service/dsl/interfaces.ts
+++ b/packages/unmock-core/src/service/dsl/interfaces.ts
@@ -4,9 +4,12 @@ import { Schema } from "../interfaces";
  * DSL related parameters that can only be found at the top level
  */
 // Defines a mapping for top level DSL keys, to be used with different providers
-export const TopLevelDSLKeys: { [DSLKey: string]: string } = {
-  $code: "number",
-  $times: "number",
+// The values (functions) help determine if the the given `u` is of a valid type
+export const TopLevelDSLKeys: { [DSLKey: string]: (u: unknown) => boolean } = {
+  $code: (u: unknown) =>
+    typeof u === "number" ||
+    (Array.isArray(u) && u.every(n => typeof n === "number")),
+  $times: (u: unknown) => typeof u === "number",
 } as const;
 
 export interface ITopLevelDSL {
@@ -14,7 +17,7 @@ export interface ITopLevelDSL {
    * Defines the response based on the requested response code.
    * If the requested response code is not found, returns 'default'
    */
-  $code?: number;
+  $code?: number | number[];
   $times?: number;
   [DSLKey: string]: any;
 }

--- a/packages/unmock-core/src/service/dsl/utils.ts
+++ b/packages/unmock-core/src/service/dsl/utils.ts
@@ -16,8 +16,7 @@ export const getTopLevelDSL = (state: UnmockServiceState) =>
   Object.keys(state)
     .filter(
       (key: string) =>
-        TopLevelDSLKeys[key] !== undefined &&
-        TopLevelDSLKeys[key] === typeof state[key],
+        TopLevelDSLKeys[key] !== undefined && TopLevelDSLKeys[key](state[key]),
     )
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
 
@@ -25,8 +24,7 @@ export const filterTopLevelDSL = (state: UnmockServiceState) =>
   Object.keys(state)
     .filter(
       (key: string) =>
-        TopLevelDSLKeys[key] === undefined ||
-        TopLevelDSLKeys[key] !== typeof state[key],
+        TopLevelDSLKeys[key] === undefined || !TopLevelDSLKeys[key](state[key]),
     )
     .reduce((a, b) => ({ ...a, [b]: state[b] }), {});
 


### PR DESCRIPTION
`$code` to now accept also an array of codes.
In the edge case where none of the codes exist explicitly in the service schema (but a default response exists), the response code will be chosen at random.