### PR TITLE
Add peer dependency to unmock in unmock-jest

### DIFF
--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -2,6 +2,7 @@
 import * as sinon from "sinon";
 import NodeBackend from "./backend";
 import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
+import FsSnapshotter from "./loggers/snapshotter";
 import WinstonLogger from "./loggers/winston-logger";
 import { nockify } from "./nock";
 import { AllowedHosts, BooleanSetting } from "./settings";
@@ -10,6 +11,9 @@ export * from "./types";
 export { sinon };
 export { default as dsl } from "./service/state/transformers";
 export { u } from "./nock";
+
+const utils = { snapshotter: FsSnapshotter };
+export { utils };
 
 export class UnmockPackage implements IUnmockPackage {
   public allowedHosts: AllowedHosts;

--- a/packages/unmock-jest/package.json
+++ b/packages/unmock-jest/package.json
@@ -14,6 +14,10 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "jest": ">= 22.0.0"
+    "jest": ">= 22.0.0",
+    "unmock": ">= 0.2.2"
+  },
+  "devDependencies": {
+    "unmock": "file:../unmock"
   }
 }

--- a/packages/unmock-jest/src/reporter/index.ts
+++ b/packages/unmock-jest/src/reporter/index.ts
@@ -1,4 +1,5 @@
 // tslint:disable:no-console
+import { utils } from "unmock";
 import { IUnmockJestReporterOptions, resolveOptions } from "./options";
 
 // https://jestjs.io/docs/en/configuration#reporters-array-modulename-modulename-options
@@ -30,6 +31,10 @@ export default class UnmockJestReporter implements jest.Reporter {
     console.log("onRunComplete");
     console.log("Contexts", contexts);
     console.log("Results", results);
+    const snapshots = utils.snapshotter
+      .getOrUpdateSnapshotter()
+      .readSnapshots();
+    console.log(`Snapshots: ${JSON.stringify(snapshots)}`);
   }
 
   public onTestResult(

--- a/packages/unmock-jest/src/reporter/index.ts
+++ b/packages/unmock-jest/src/reporter/index.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-console
-import { utils } from "unmock";
+import { utils as unmockUtils } from "unmock";
 import { IUnmockJestReporterOptions, resolveOptions } from "./options";
 
 // https://jestjs.io/docs/en/configuration#reporters-array-modulename-modulename-options
@@ -31,7 +31,7 @@ export default class UnmockJestReporter implements jest.Reporter {
     console.log("onRunComplete");
     console.log("Contexts", contexts);
     console.log("Results", results);
-    const snapshots = utils.snapshotter
+    const snapshots = unmockUtils.snapshotter
       .getOrUpdateSnapshotter()
       .readSnapshots();
     console.log(`Snapshots: ${JSON.stringify(snapshots)}`);


### PR DESCRIPTION
- Quick PR on how I thought unmock-jest would depend on unmock, adding unmock as peer dependency
- Possibly could also only peer-depend on "unmock-core"? Not sure if npm would then complain about missing peer dependency if `unmock-core` is not explicitly added in package.json
- Exports `utils` from unmock package