### PR TITLE
Add snapshot timestamp, export ISnapshot, fix folder missing bug

### DIFF
--- a/packages/unmock-core/src/__tests__/snapshotter.test.ts
+++ b/packages/unmock-core/src/__tests__/snapshotter.test.ts
@@ -72,17 +72,17 @@ describe("Snapshot writer/reader", () => {
     });
   });
 
-  const snapshotWriterReader = new FsSnapshotWriterReader(outputFolder);
-
-  beforeEach(() => {
-    snapshotWriterReader.deleteSnapshots();
-  });
-
-  afterEach(() => {
-    snapshotWriterReader.deleteSnapshots();
-  });
-
   describe("writing and reading", () => {
+    const snapshotWriterReader = new FsSnapshotWriterReader(outputFolder);
+
+    beforeAll(() => {
+      snapshotWriterReader.deleteSnapshots();
+    });
+
+    afterEach(() => {
+      snapshotWriterReader.deleteSnapshots();
+    });
+
     it("should write to expected folder", () => {
       expect(snapshotWriterReader.read()).toHaveLength(0);
 

--- a/packages/unmock-core/src/__tests__/snapshotter.test.ts
+++ b/packages/unmock-core/src/__tests__/snapshotter.test.ts
@@ -64,7 +64,7 @@ describe("Snapshot writer/reader", () => {
       const formatted = format(exampleSnapshotInput);
       expect(formatted).toContain(timestamp.toISOString());
     });
-    it("should have format and parse be identity", () => {
+    it("should parse the same object from formatted object", () => {
       const formatted = format(exampleSnapshotInput);
       const parsed = parseSnapshot(formatted);
       expect(parsed).toEqual(exampleSnapshotInput);

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -2,7 +2,7 @@
 import * as sinon from "sinon";
 import NodeBackend from "./backend";
 import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
-import FsSnapshotter from "./loggers/snapshotter";
+import FsSnapshotter, { ISnapshot } from "./loggers/snapshotter";
 import WinstonLogger from "./loggers/winston-logger";
 import { nockify } from "./nock";
 import { AllowedHosts, BooleanSetting } from "./settings";
@@ -12,6 +12,7 @@ export { sinon };
 export { default as dsl } from "./service/state/transformers";
 export { u } from "./nock";
 
+export { ISnapshot };
 const utils = { snapshotter: FsSnapshotter };
 export { utils };
 

--- a/packages/unmock-core/src/loggers/snapshotter/expect-extend.ts
+++ b/packages/unmock-core/src/loggers/snapshotter/expect-extend.ts
@@ -18,6 +18,7 @@ export const unmockSnapshot = (writer: ISnapshotWriterReader) => {
       testPath: this.testPath || "",
       currentTestName: this.currentTestName || "",
       data: obj,
+      timestamp: new Date(),
     };
     debugLog(`Snapshotting: ${JSON.stringify(snapshotInput)}`);
     writer.write(snapshotInput);

--- a/packages/unmock-core/src/loggers/snapshotter/index.ts
+++ b/packages/unmock-core/src/loggers/snapshotter/index.ts
@@ -27,6 +27,8 @@ const DEFAULT_OPTIONS: IFsSnapshotterOptions = {
   outputFolder: DEFAULT_SNAPSHOT_DIRECTORY,
 };
 
+export { ISnapshot };
+
 export const resolveOptions = (
   userOptions: Partial<IFsSnapshotterOptions>,
 ): IFsSnapshotterOptions => {

--- a/packages/unmock-core/src/loggers/snapshotter/snapshot-writer-reader.ts
+++ b/packages/unmock-core/src/loggers/snapshotter/snapshot-writer-reader.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import * as fs from "fs";
-import { flatten } from "lodash";
+import { flatten, sortBy } from "lodash";
 import * as os from "os";
 import * as path from "path";
 import { IListenerInput } from "../../interfaces";
@@ -89,7 +89,9 @@ export class FsSnapshotWriterReader implements ISnapshotWriterReader {
     const snapshots: ISnapshot[][] = snapshotFiles.map(filename =>
       FsSnapshotWriterReader.readFileContents(filename),
     );
-    return flatten(snapshots);
+    return sortBy(flatten(snapshots), (snapshot: ISnapshot) =>
+      snapshot.timestamp.getTime(),
+    );
   }
 
   public deleteSnapshots(): void {

--- a/packages/unmock-jest/src/reporter/index.ts
+++ b/packages/unmock-jest/src/reporter/index.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-console
-import { utils as unmockUtils } from "unmock";
+import { ISnapshot, utils as unmockUtils } from "unmock";
 import { IUnmockJestReporterOptions, resolveOptions } from "./options";
 
 // https://jestjs.io/docs/en/configuration#reporters-array-modulename-modulename-options
@@ -14,7 +14,7 @@ export default class UnmockJestReporter implements jest.Reporter {
     this.rootDir = globalConfig.rootDir;
   }
 
-  public onRunStart(
+  /* public onRunStart(
     results: jest.AggregatedResult,
     options: jest.ReporterOnStartOptions,
   ) {
@@ -22,7 +22,7 @@ export default class UnmockJestReporter implements jest.Reporter {
     console.log("results", results);
     console.log("reporterOnStartOptions", options);
     console.log("Options", this.options);
-  }
+  } */
 
   public onRunComplete(
     contexts: Set<jest.Context>,
@@ -31,21 +31,22 @@ export default class UnmockJestReporter implements jest.Reporter {
     console.log("onRunComplete");
     console.log("Contexts", contexts);
     console.log("Results", results);
-    const snapshots = unmockUtils.snapshotter
+    const snapshots: ISnapshot[] = unmockUtils.snapshotter
       .getOrUpdateSnapshotter()
       .readSnapshots();
+
     console.log(`Snapshots: ${JSON.stringify(snapshots)}`);
   }
 
-  public onTestResult(
+  /* public onTestResult(
     test: jest.Test,
     testResult: jest.TestResult,
     aggregatedResult: jest.AggregatedResult,
   ): void {
     console.log("onTestResult", test, testResult, aggregatedResult);
-  }
+  } */
 
-  public onTestStart(test: jest.Test): void {
+  /* public onTestStart(test: jest.Test): void {
     console.log("onTestStart", test);
-  }
+  } */
 }


### PR DESCRIPTION
- Exports `ISnapshot` at top-level from `unmock` so it's usable in reporter. Would be nice to have it inside namespace such as `unmock.utils.snapshots.ISnapshot` but we don't organize our code like that atm so would be a bit more work.
- Adds timestamp to snapshots so they're easier to handle
- Adds check on write if the output folder (such as `${snapshotFolder}/435aAx/`) exists, as it may have been deleted by `deleteSnapshots()` method.
