### PR TITLE
More fluent nock syntax

### DIFF
--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -53,4 +53,18 @@ describe("Tests dynamic path tests", () => {
     expect(Object.keys(unmock.services).length).toEqual(1);
     unmock.services.foo.state.get("/abc", { $code: 200 }); // should succeed
   });
+
+  it("Chains multiple endpoints", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    unmock
+      .nock("https://abc.com", "foo")
+      .get("abc") // slash is prepended automatically
+      .reply(200, { foo: u.str() })
+      .post("bar")
+      .reply(404);
+    expect(Object.keys(unmock.services).length).toEqual(1);
+    expect(() =>
+      unmock.services.foo.state.post("/bar", { $code: 404 }),
+    ).not.toThrow();
+  });
 });

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -23,7 +23,7 @@ describe("Tests dynamic path tests", () => {
       // type-checking mostly...
       throw new Error("Service was undefined??");
     }
-    expect(() => service.state.get("/foo", { foo: "abc" })).not.toThrow(); // should succeed
+    expect(() => service.state.get("/foo", { foo: "abc" })).not.toThrow();
   });
 
   it("Adds a service and updates it on consecutive calls", () => {
@@ -41,7 +41,7 @@ describe("Tests dynamic path tests", () => {
       // type-checking mostly...
       throw new Error("Service was undefined??");
     }
-    service.state("/foo", { $code: 201 }).get("/foo", { $code: 200 }); // should succeed
+    expect(() => service.state("/foo", { $code: 201 }).get("/foo", { $code: 200 }).not.toThrow();
   });
 
   it("Adds a named service", () => {
@@ -51,7 +51,7 @@ describe("Tests dynamic path tests", () => {
       .get("abc") // slash is prepended automatically
       .reply(200, { foo: u.str() });
     expect(Object.keys(unmock.services).length).toEqual(1);
-    unmock.services.foo.state.get("/abc", { $code: 200 }); // should succeed
+    expect(() => unmock.services.foo.state.get("/abc", { $code: 200 })).not.toThrow();
   });
 
   it("Chains multiple endpoints", () => {

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -14,11 +14,12 @@ describe("Tests dynamic path tests", () => {
 
   it("Adds a service and changes state", () => {
     expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
-    const service = unmock
+    unmock
       .nock("https://foo.com")
       .get("foo") // slash is prepended automatically
       .reply(200, { foo: u.str() });
     expect(Object.keys(unmock.services).length).toEqual(1);
+    const service = unmock.services["foo.com"];
     if (service === undefined) {
       // type-checking mostly...
       throw new Error("Service was undefined??");
@@ -32,11 +33,12 @@ describe("Tests dynamic path tests", () => {
       .nock("https://foo.com")
       .get("foo") // slash is prepended automatically
       .reply(200, { foo: u.city() });
-    const service = unmock
+    unmock
       .nock("https://foo.com")
       .post("/foo")
       .reply(201);
     expect(Object.keys(unmock.services).length).toEqual(1);
+    const service = unmock.services["foo.com"];
     if (service === undefined) {
       // type-checking mostly...
       throw new Error("Service was undefined??");

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -73,4 +73,33 @@ describe("Tests dynamic path tests", () => {
       unmock.services.foo.state.post("/bar", { $code: 404 }),
     ).not.toThrow();
   });
+
+  it("Chains multiple endpoints in multiple calls", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    const dynamicSpec = unmock
+      .nock("https://abc.com", "foo")
+      .get("foo")
+      .reply(200, { city: u.city() });
+    dynamicSpec.get("foo").reply(404, { msg: u.str() });
+    const service = unmock.services.foo;
+    expect(() => service.state.get("/foo", { $code: 404 })).not.toThrow();
+  });
+
+  it("Allows using same name with multiple servers", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    unmock
+      .nock("https://abc.com", "foo")
+      .get("foo")
+      .reply(200, { city: u.city() });
+    unmock
+      .nock("https://def.com", "foo")
+      .get("foo")
+      .reply(404, { msg: u.str() });
+    unmock
+      .nock("https://abc.com", "foo")
+      .get("foo")
+      .reply(500);
+    const service = unmock.services.foo;
+    expect(() => service.state.get("/foo", { $code: 500 })).not.toThrow();
+  });
 });

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -41,7 +41,9 @@ describe("Tests dynamic path tests", () => {
       // type-checking mostly...
       throw new Error("Service was undefined??");
     }
-    expect(() => service.state("/foo", { $code: 201 }).get("/foo", { $code: 200 }).not.toThrow();
+    expect(() =>
+      service.state("/foo", { $code: 201 }).get("/foo", { $code: 200 }),
+    ).not.toThrow();
   });
 
   it("Adds a named service", () => {
@@ -51,7 +53,9 @@ describe("Tests dynamic path tests", () => {
       .get("abc") // slash is prepended automatically
       .reply(200, { foo: u.str() });
     expect(Object.keys(unmock.services).length).toEqual(1);
-    expect(() => unmock.services.foo.state.get("/abc", { $code: 200 })).not.toThrow();
+    expect(() =>
+      unmock.services.foo.state.get("/abc", { $code: 200 }),
+    ).not.toThrow();
   });
 
   it("Chains multiple endpoints", () => {

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -151,12 +151,12 @@ export class DynamicServiceSpec {
   public reply(
     statusCode: number,
     data?: InputToPoet | InputToPoet[],
-  ): FluentDyamicService;
-  public reply(data: InputToPoet | InputToPoet[]): FluentDyamicService;
+  ): FluentDynamicService;
+  public reply(data: InputToPoet | InputToPoet[]): FluentDynamicService;
   public reply(
     maybeStatusCode: number | InputToPoet | InputToPoet[],
     maybeData?: InputToPoet | InputToPoet[],
-  ): FluentDyamicService {
+  ): FluentDynamicService {
     if (maybeData !== undefined) {
       this.data = JSONSchemify(maybeData) as Schema;
       this.statusCode = maybeStatusCode as number;
@@ -179,7 +179,7 @@ export class DynamicServiceSpec {
   }
 }
 
-type FluentDyamicService = {
+type FluentDynamicService = {
   [k in HTTPMethod]: (endpoint: string) => DynamicServiceSpec;
 } & { state: StateType; spy: ServiceSpy };
 
@@ -188,7 +188,7 @@ const buildFluentNock = (
   baseUrl: string,
   name?: string,
   service?: Service,
-): FluentDyamicService => {
+): FluentDynamicService => {
   const dynFn = (method: HTTPMethod, endpoint: string) => ({
     statusCode,
     data,
@@ -225,7 +225,7 @@ const buildFluentNock = (
         ),
     }),
     {},
-  ) as FluentDyamicService;
+  ) as FluentDynamicService;
   if (service !== undefined) {
     fluent.state = service.state;
     fluent.spy = service.spy;

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -11,7 +11,9 @@ import {
 import NodeBackend from "./backend";
 import { HTTPMethod } from "./interfaces";
 import { Service } from "./service";
-import { Schema } from "./service/interfaces";
+import { Schema, StateType } from "./service/interfaces";
+import { ServiceStore } from "./service/serviceStore";
+import { ServiceSpy } from "./service/spy";
 
 // Used to differentiate between e.g. `{ foo: { type: "string" } }` as a literal value
 // (i.e. key `foo` having the value of `{type: "string"}`) and a dynamic JSON schema
@@ -127,7 +129,7 @@ type UpdateCallback = ({
 }: {
   statusCode: number;
   data: Schema;
-}) => Service | undefined;
+}) => { store: ServiceStore; service: Service };
 
 // Placeholder for poet input type, to have
 // e.g. standard object => { type: "object", properties: { ... }}, number => { type: "number", const: ... }
@@ -141,18 +143,20 @@ export class DynamicServiceSpec {
   constructor(
     private updater: UpdateCallback,
     private statusCode: number = 200,
+    private baseUrl: string,
+    private name?: string,
   ) {}
 
   // TODO: Should this allow fluency for consecutive .get, .post, etc on the same service?
   public reply(
     statusCode: number,
     data?: InputToPoet | InputToPoet[],
-  ): Service | undefined;
-  public reply(data: InputToPoet | InputToPoet[]): Service | undefined;
+  ): FluentDyamicService;
+  public reply(data: InputToPoet | InputToPoet[]): FluentDyamicService;
   public reply(
     maybeStatusCode: number | InputToPoet | InputToPoet[],
     maybeData?: InputToPoet | InputToPoet[],
-  ): Service | undefined {
+  ): FluentDyamicService {
     if (maybeData !== undefined) {
       this.data = JSONSchemify(maybeData) as Schema;
       this.statusCode = maybeStatusCode as number;
@@ -166,9 +170,68 @@ export class DynamicServiceSpec {
     } else {
       this.data = JSONSchemify(maybeStatusCode) as Schema;
     }
-    return this.updater({ data: this.data, statusCode: this.statusCode });
+    const { store, service } = this.updater({
+      data: this.data,
+      statusCode: this.statusCode,
+    });
+
+    return buildFluentNock(store, this.baseUrl, this.name, service);
   }
 }
+
+type FluentDyamicService = {
+  [k in HTTPMethod]: (endpoint: string) => DynamicServiceSpec;
+} & { state: StateType; spy: ServiceSpy };
+
+const buildFluentNock = (
+  store: ServiceStore,
+  baseUrl: string,
+  name?: string,
+  service?: Service,
+): FluentDyamicService => {
+  const dynFn = (method: HTTPMethod, endpoint: string) => ({
+    statusCode,
+    data,
+  }: {
+    statusCode: number;
+    data: Schema;
+  }) =>
+    store.updateOrAdd({
+      baseUrl,
+      method,
+      endpoint: endpoint.startsWith("/") ? endpoint : `/${endpoint}`,
+      statusCode,
+      response: data,
+      name,
+    });
+  const fluent = Object.entries({
+    get: 200,
+    head: 200,
+    post: 201,
+    put: 204,
+    patch: 204,
+    delete: 200,
+    options: 200,
+    trace: 200,
+  }).reduce(
+    (o, [method, code]) => ({
+      ...o,
+      [method]: (endpoint: string) =>
+        new DynamicServiceSpec(
+          dynFn(method as HTTPMethod, endpoint),
+          code,
+          baseUrl,
+          name,
+        ),
+    }),
+    {},
+  ) as FluentDyamicService;
+  if (service !== undefined) {
+    fluent.state = service.state;
+    fluent.spy = service.spy;
+  }
+  return fluent;
+};
 
 export const nockify = ({
   backend,
@@ -178,46 +241,4 @@ export const nockify = ({
   backend: NodeBackend;
   baseUrl: string;
   name?: string;
-}) => {
-  const dynFn = (method: HTTPMethod, endpoint: string) => ({
-    statusCode,
-    data,
-  }: {
-    statusCode: number;
-    data: Schema;
-  }) =>
-    backend.serviceStore.updateOrAdd({
-      baseUrl,
-      method,
-      endpoint: endpoint.startsWith("/") ? endpoint : `/${endpoint}`,
-      statusCode,
-      response: data,
-      name,
-    });
-  return {
-    get(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("get", endpoint), 200);
-    },
-    head(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("head", endpoint), 200);
-    },
-    post(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("post", endpoint), 201);
-    },
-    put(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("put", endpoint), 204);
-    },
-    patch(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("patch", endpoint), 204);
-    },
-    delete(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("delete", endpoint), 200);
-    },
-    options(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("options", endpoint), 200);
-    },
-    trace(endpoint: string) {
-      return new DynamicServiceSpec(dynFn("trace", endpoint), 200);
-    },
-  };
-};
+}) => buildFluentNock(backend.serviceStore, baseUrl, name);

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -1,4 +1,4 @@
-import { defaultsDeep } from "lodash";
+import { defaultsDeep, unionBy } from "lodash";
 import { HTTPMethod, ISerializedRequest } from "../interfaces";
 import { DEFAULT_STATE_ENDPOINT } from "./constants";
 import {
@@ -53,7 +53,10 @@ export class ServiceCore implements IServiceCore {
     const newUrls = [{ url: baseUrl }];
 
     const newPaths = defaultsDeep(newPath, baseSchema.paths);
-    const newServers = defaultsDeep(newUrls, baseSchema.servers);
+    const newServers = unionBy(
+      newUrls.concat(baseSchema.servers || []),
+      e => e.url,
+    );
     const finalSchema = { ...baseSchema, paths: newPaths, servers: newServers };
     return new ServiceCore({
       schema: finalSchema,

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -24,9 +24,7 @@ export class ServiceStore {
     );
   }
 
-  public updateOrAdd(
-    input: IObjectToService,
-  ): { store: ServiceStore; service: Service } {
+  public updateOrAdd(input: IObjectToService): ServiceStore {
     // TODO: Tighly coupled with OpenAPI at the moment... resolve this at a later time
     const serviceName =
       input.name || url.parse(input.baseUrl).hostname || input.baseUrl;
@@ -47,6 +45,6 @@ export class ServiceStore {
     this.cores[serviceName] = newServiceCore;
     this.services[serviceName] = new Service(newServiceCore);
 
-    return { store: this, service: this.services[serviceName] };
+    return this;
   }
 }

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -24,7 +24,9 @@ export class ServiceStore {
     );
   }
 
-  public updateOrAdd(input: IObjectToService) {
+  public updateOrAdd(
+    input: IObjectToService,
+  ): { store: ServiceStore; service: Service } {
     // TODO: Tighly coupled with OpenAPI at the moment... resolve this at a later time
     const serviceName =
       input.name || url.parse(input.baseUrl).hostname || input.baseUrl;
@@ -45,6 +47,6 @@ export class ServiceStore {
     this.cores[serviceName] = newServiceCore;
     this.services[serviceName] = new Service(newServiceCore);
 
-    return this.services[serviceName];
+    return { store: this, service: this.services[serviceName] };
   }
 }


### PR DESCRIPTION
- Adds the option to chain different endpoints when defining a service, much like nock does (i.e. `unmock.nock(...).get(...).reply(...).post(...).reply(...)` etc.
**New info**
- The dynamic service creation will now return a "dynamic service specifcation", which one can build continuously on top of (see tests).
- Acccess to the service should *always* be done via `unmock.services.X`
- Updated so that multiple URLs are concatenated and not overwritten.

**Old info**
- **I'm not sure this is the best way to approach the idea.** There are two downsides:
    - We no longer return a `Service` object, but instead return an object that gives access to the `state` and `spy` properties of the newly created / modified `Service`.
    - Such calls can get confusing, as this becomes possible:
        ```typescript
        unmock.nock("https://foo.com/")
          .get("/bar")
          .reply(200, { content: u.str() })
          .post("/baz")
          .reply(404, { msg: u.str() })
          .state
            .get("/bar", { content: "bar!"})
            .post("/baz", { msg: "no reason given" });
        ```