### PR TITLE
Adds default mapping

### DIFF
--- a/packages/openapi-refinements/src/__tests__/index.test.ts
+++ b/packages/openapi-refinements/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import {
 removeCodes,
 includeCodes,
+mapDefaultToCodes,
 changeMinItems,
 Arr,
 changeMaxItems,
@@ -113,6 +114,7 @@ const responses =
 expect(Object.keys(responses)).toEqual(["200", "default"]);
 });
 
+
 test("everything is composeable", () => {
 const refined = [
     includeCodes("/pets", "get", ["200"]),
@@ -142,6 +144,16 @@ expect(Object.keys(refinedResponsesGet)).toEqual(["200"]);
 expect(refinedResponsesGet["200"]).toEqual(responsesGet["200"]);
 expect(Object.keys(refinedResponsesPost)).toEqual(["default"]);
 expect(refinedResponsesPost.default).toEqual(responsesPost.default);
+});
+
+test("map default to codes correctly maps default to 200", () => {
+  const refined = [
+      mapDefaultToCodes("/pets", "get", ["200"]),
+      includeCodes("/pets", "get", ["200"]),
+  ].reduce((a, b) => b(a), petstore);
+  expect((<any>refined).paths["/pets"].get.responses["200"].content[
+    "application/json"
+    ].schema.$ref).toBe("#/components/schemas/Error");
 });
 
 test("changeMinItems changes min items", () => {

--- a/packages/openapi-refinements/src/index.ts
+++ b/packages/openapi-refinements/src/index.ts
@@ -745,3 +745,28 @@ operations: MethodNames | MethodNames[] | boolean = true,
 r: Array<keyof Responses> | boolean = true
 ) => (o: OpenAPIObject): OpenAPIObject =>
 removeCodesInternal(o, coaxPath(path), coaxMethods(operations), r);
+
+const mapDefaultToCodesFunction = (b: Array<keyof Responses>) => (r: Responses): Responses =>
+  Object.entries(r)
+    .concat(r.default ? b.map(i => [i, r.default]) : [])
+    .reduce((a, z) => ({ ...a, [z[0]]: z[1]}), {});
+
+const mapDefaultToCodesInternal = (
+o: OpenAPIObject,
+path: RegExp | boolean,
+operations: MethodNames[] | boolean,
+r: Array<keyof Responses>
+) =>
+  codesInternal(
+    o,
+    path,
+    operations,
+    mapDefaultToCodesFunction(r),
+  );
+
+export const mapDefaultToCodes = (
+path: string | RegExp | boolean = true,
+operations: MethodNames | MethodNames[] | boolean = true,
+r: Array<keyof Responses> = []
+) => (o: OpenAPIObject): OpenAPIObject =>
+mapDefaultToCodesInternal(o, coaxPath(path), coaxMethods(operations), r);

--- a/packages/unmock-core/src/__tests__/backend/state.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/state.test.ts
@@ -7,7 +7,7 @@ import { OpenAPIObject } from "loas3/dist/generated/full";
 import { transform } from "../../generator-utils";
 import { ISerializedRequest } from "../../interfaces";
 
-const { withCodes, responseBody, noopThrows, compose, times } = transform;
+const { withCodes, mapDefaultTo, responseBody, noopThrows, compose, times } = transform;
 
 const servicesDirectory = path.join(__dirname, "..", "__unmock__");
 
@@ -53,6 +53,17 @@ describe("Node.js interceptor", () => {
             typeof pet.id === "number" && typeof pet.name === "string",
         ),
       ).toBeTruthy();
+    });
+
+    test("maps default correctly", async () => {
+      petstore.state(
+        mapDefaultTo(200),
+        withCodes(200),
+      );
+      const response = await axios("http://petstore.swagger.io/v1/pets");
+      expect(response.status).toBe(200);
+      expect(typeof response.data.message).toBe("string");
+      expect(typeof response.data.code).toBe("number");
     });
 
     test("gets correct state after setting state with status code", async () => {

--- a/packages/unmock-core/src/generator-utils.ts
+++ b/packages/unmock-core/src/generator-utils.ts
@@ -20,6 +20,7 @@ import {
   removeCodes,
   requestBody,
   responseBody,
+  mapDefaultToCodes,
 } from "openapi-refinements";
 export {
   Arr,
@@ -45,6 +46,16 @@ const withOrWithoutCodes = (withOrWithout: boolean) => (
 
 const withCodes = withOrWithoutCodes(true);
 const withoutCodes = withOrWithoutCodes(false);
+const mapDefaultTo = (
+  codes: keyof Responses | CodeAsInt | Array<keyof Responses | CodeAsInt>,
+  path?: string | RegExp | boolean,
+  method?: MethodNames | MethodNames[] | boolean,
+) => (_: ISerializedRequest, o: OpenAPIObject) =>
+    mapDefaultToCodes(
+      path !== undefined ? path : true,
+      method !== undefined ? method : true,
+      (codes instanceof Array ? codes : [codes]).map(codeConvert))(o);
+
 
 interface ISchemaAddress {
   lens?: Array<string | number | typeof Arr | typeof Addl>;
@@ -226,6 +237,7 @@ export const transform = {
   },
   withCodes,
   withoutCodes,
+  mapDefaultTo,
   responseBody: makeSchemaTraversalStructure<Partial<IResponseBodyOptions>>(
     (options?: Partial<IResponseBodyOptions>) =>
       responseBody(...responseBodySignatureFromOptions(options))),

--- a/packages/unmock-core/src/generator-utils.ts
+++ b/packages/unmock-core/src/generator-utils.ts
@@ -12,6 +12,7 @@ import {
   changeToConst,
   header,
   includeCodes,
+  mapDefaultToCodes,
   MethodNames,
   methodParameter,
   oneOfKeep,
@@ -20,7 +21,6 @@ import {
   removeCodes,
   requestBody,
   responseBody,
-  mapDefaultToCodes,
 } from "openapi-refinements";
 export {
   Arr,


### PR DESCRIPTION
This is needed so that unmock examples works with the new syntax. Otherwise, it is impossible to map the Slack default response to 200.