### PR TITLE
Corrects nock type.

### DIFF
--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -7,6 +7,13 @@ import {
   JSONSchemaObject,
   JSSTAnything,
   JSSTEmpty,
+  JSSTAllOf,
+  JSSTAnyOf,
+  JSSTOneOf,
+  JSSTList,
+  JSSTNot,
+  JSSTTuple,
+  JSSTObject,
 } from "json-schema-strictly-typed";
 import NodeBackend from "./backend";
 import { HTTPMethod } from "./interfaces";
@@ -32,10 +39,22 @@ const DynamicJSONValue: io.Type<
   io.identity,
 );
 
-const JSO = JSONSchemaObject(JSSTEmpty(DynamicJSONValue), DynamicJSONValue);
+const RecursiveUnion: io.Type<
+RecursiveUnionType,
+RecursiveUnionType
+> = io.recursion("JSO", () => io.union([
+  JSONPrimitive, JSONObject, JSONArray, ExtendedArray, ExtendedObject
+]));
+const JSO: io.Type<
+ExtendedJSONSchema,
+ExtendedJSONSchema
+> = io.recursion("JSO", () => JSONSchemaObject(RecursiveUnion, DynamicJSONValue));
+
+type RecursiveUnionType = JSONPrimitive | JSONObject | JSONArray | IExtendedArrayType | IExtendedObjectType;
+
 // Define json schema types extended with the dynamic json value property
 type ExtendedJSONSchema = JSONSchemaObject<
-  JSSTEmpty<IDynamicJSONValue>,
+  RecursiveUnionType,
   IDynamicJSONValue
 >;
 type ExtendedPrimitiveType = JSONPrimitive | ExtendedJSONSchema;
@@ -45,9 +64,7 @@ type ExtendedValueType =
   | IExtendedObjectType
   | JSONArray
   | JSONObject;
-interface IExtendedObjectType {
-  [k: string]: ExtendedValueType;
-}
+interface IExtendedObjectType extends Record<string, ExtendedValueType> {} // Defined as interface due to circular reasons
 interface IExtendedArrayType extends Array<ExtendedValueType> {} // Defined as interface due to circular reference
 
 // Define matching codecs for the above types
@@ -90,11 +107,34 @@ const removeDynamicSymbol = (
 };
 
 const JSONSchemify = (e: ExtendedValueType): JSSTAnything<JSSTEmpty<{}>, {}> =>
-  JSO.is(e)
-    ? removeDynamicSymbol(e)
+  isDynamic(e)
+    ? removeDynamicSymbol(
+        // we cover all of the nested cases,
+        // followed by un-nested cases
+        JSSTAllOf(RecursiveUnion, DynamicJSONValue).is(e)
+          ? { ...e, allOf: e.allOf.map(JSONSchemify) }
+          : JSSTAnyOf(RecursiveUnion, DynamicJSONValue).is(e)
+          ? { ...e, anyOf: e.anyOf.map(JSONSchemify) }
+          : JSSTOneOf(RecursiveUnion, DynamicJSONValue).is(e)
+          ? { ...e, oneOf: e.oneOf.map(JSONSchemify) }
+          : JSSTNot(RecursiveUnion, DynamicJSONValue).is(e)
+          ? { ...e, not: JSONSchemify(e.not) }
+          : JSSTList(RecursiveUnion, DynamicJSONValue).is(e)
+          ? { ...e, items: JSONSchemify(e.items) }
+          : JSSTTuple(RecursiveUnion, DynamicJSONValue).is(e)
+          ? { ...e, oneOf: e.items.map(JSONSchemify) }
+          : JSSTObject(RecursiveUnion, DynamicJSONValue).is(e)
+          ? {
+              ...e,
+              ...(e.additionalProperties ? {additionalProperties: JSONSchemify(e.additionalProperties)} : {}),
+              ...(e.patternProperties ? {patternProperties: Object.entries(e.patternProperties).reduce((a,b) => ({ ...a, [b[0]]: JSONSchemify(b[1])}), {})} : {}),
+              ...(e.properties ? {properties: Object.entries(e.properties).reduce((a,b) => ({ ...a, [b[0]]: JSONSchemify(b[1])}), {})} : {})
+            }
+          : e
+      )
     : ExtendedArray.is(e) || JSONArray.is(e)
     ? tuple_<JSSTEmpty<{}>, {}>({})(
-        e.map((i: ExtendedValueType) => JSONSchemify(i)),
+        e.map(JSONSchemify),
       )
     : ExtendedObject.is(e) || JSONObject.is(e)
     ? type_<JSSTEmpty<{}>, {}>({})(
@@ -107,7 +147,7 @@ const JSONSchemify = (e: ExtendedValueType): JSSTAnything<JSSTEmpty<{}>, {}> =>
     : cnst_<{}>({})(e);
 
 // Define poet to recognize the new "dynamic type"
-const jspt = extendT<JSSTEmpty<IDynamicJSONValue>, IDynamicJSONValue>({
+const jspt = extendT<ExtendedJSONSchema, IDynamicJSONValue>({
   dynamic: DynamicJSONSymbol,
 });
 

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -5,15 +5,15 @@ import {
   JSONObject,
   JSONPrimitive,
   JSONSchemaObject,
-  JSSTAnything,
-  JSSTEmpty,
   JSSTAllOf,
   JSSTAnyOf,
-  JSSTOneOf,
+  JSSTAnything,
+  JSSTEmpty,
   JSSTList,
   JSSTNot,
-  JSSTTuple,
   JSSTObject,
+  JSSTOneOf,
+  JSSTTuple,
 } from "json-schema-strictly-typed";
 import NodeBackend from "./backend";
 import { HTTPMethod } from "./interfaces";

--- a/packages/unmock/src/__tests__/end-to-end/simple-service.test.ts
+++ b/packages/unmock/src/__tests__/end-to-end/simple-service.test.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import unmock, { transform, u } from "../../";
+import unmock, { transform, u, Arr } from "../../";
 const { responseBody } = transform;
 
 unmock
@@ -7,13 +7,13 @@ unmock
   .get("/users")
   .reply(200, u.array(
     u.type({
-      id: u.number(),
-      name: u.number(),
-    }, {
-      address: u.type({
+      address: {
         city: u.string(),
         state: u.string(),
-      }, {}),
+      },
+    }, {
+      id: u.number(),
+      name: u.number(),
     }),
   ));
 
@@ -26,12 +26,14 @@ describe("Simple service test", () => {
     const response0 = await axios("https://api.foo.com/v1/users");
     expect(response0.data.length).toBeGreaterThanOrEqual(56);
     foo.state(
+      responseBody({ lens: [Arr] }).required("id"),
       responseBody().listToTuple(5),
       responseBody({ lens: [2, "id"]}).const(55),
       responseBody({ lens: [3, "id"]}).const(56),
     );
     const response1 = await axios("https://api.foo.com/v1/users");
     expect(response1.data.length).toBe(5);
+    expect(typeof response1.data[1].address.city).toBe("string");
     expect(response1.data[2].id).toBe(55);
     expect(response1.data[3].id).toBe(56);
   });


### PR DESCRIPTION
Previously, the nock type admitted JSON that contained JSONSchema but not vice versa. This fixes that.