### PR TITLE
Sort test suites by the number of failures.

### DIFF
--- a/packages/unmock-jest/src/__tests__/utils.test.ts
+++ b/packages/unmock-jest/src/__tests__/utils.test.ts
@@ -1,0 +1,52 @@
+import { ISnapshot } from "unmock";
+import { ITestSuite } from "../reporter/types";
+import { sortTestSuites } from "../reporter/utils";
+
+const testSuite1: ITestSuite = {
+  testFilePath: "blah",
+  suiteResults: {
+    numFailingTests: 3,
+  } as jest.TestResult,
+  snapshots: [],
+};
+
+const testSuite2: ITestSuite = {
+  testFilePath: "blah2",
+  suiteResults: {
+    numFailingTests: 2,
+  } as jest.TestResult,
+  snapshots: [],
+};
+
+const testSuite3: ITestSuite = {
+  testFilePath: "blah3",
+  suiteResults: {
+    numFailingTests: 2,
+  } as jest.TestResult,
+  snapshots: [{} as ISnapshot],
+};
+
+describe("Reporter utils", () => {
+  describe("sorting test suites", () => {
+    it("should sort test suites by number of failing tests", () => {
+      expect(sortTestSuites([testSuite1, testSuite2])).toEqual([
+        testSuite1,
+        testSuite2,
+      ]);
+      expect(sortTestSuites([testSuite2, testSuite1])).toEqual([
+        testSuite1,
+        testSuite2,
+      ]);
+    });
+    it("should sort test suites by number of snapshots when matching number of failing tests", () => {
+      expect(sortTestSuites([testSuite2, testSuite3])).toEqual([
+        testSuite3,
+        testSuite2,
+      ]);
+      expect(sortTestSuites([testSuite2, testSuite3])).toEqual([
+        testSuite3,
+        testSuite2,
+      ]);
+    });
+  });
+});

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -193,8 +193,6 @@ const buildTestResultsDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
     (testSuite) => buildTestSuiteDiv(testSuite)
   );
 
-  // Sort test suites by failure count and/or HTTP request count
-
   forEach(testSuiteElements, node => {
     const block = root.ele("div");
     block.importDocument(node);

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -1,4 +1,4 @@
-import { Dictionary, forEach, map } from "lodash";
+import { Dictionary, forEach, map, toPairs } from "lodash";
 import * as React from "react";
 import * as ReactDomServer from "react-dom/server";
 import stripAnsi from "strip-ansi";
@@ -7,7 +7,7 @@ import xmlBuilder = require("xmlbuilder");
 import Calls from "./components/calls";
 import stylesheet from "./stylesheet";
 import { IReportInput, ITestSuite } from "./types";
-import { groupTestsByFilePath } from "./utils";
+import { toTestSuites, sortTestSuites } from "./utils";
 
 const createHtmlBase = (): xmlBuilder.XMLDocument => {
   const htmlBase = {
@@ -110,7 +110,6 @@ const buildTestSuiteTitleDiv = (
  * @param testSuite Test suite results
  */
 const buildTestSuiteDiv = (
-  filename: string,
   testSuite: ITestSuite,
 ): xmlBuilder.XMLDocument => {
   const suiteResult = testSuite.suiteResults;
@@ -124,7 +123,7 @@ const buildTestSuiteDiv = (
     .begin()
     .ele("div", { class: `test-suite ${suiteSuccessClass}` });
 
-  const testSuiteTitleDiv = buildTestSuiteTitleDiv(filename, testSuite);
+  const testSuiteTitleDiv = buildTestSuiteTitleDiv(testSuite.testFilePath, testSuite);
 
   element.importDocument(testSuiteTitleDiv);
 
@@ -178,18 +177,23 @@ const buildHeaderDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
   return headerDiv;
 };
 
+
 /**
  * Build div containing results for all test files (excluding header etc.)
  */
 const buildTestResultsDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
   const root = xmlBuilder.begin().ele("div", { class: "test-results" });
 
-  const grouped: Dictionary<ITestSuite> = groupTestsByFilePath(input);
+  const testSuites: ITestSuite[] = toTestSuites(input);
+
+  const sortedSuites = sortTestSuites(testSuites);
 
   const testSuiteElements: xmlBuilder.XMLDocument[] = map(
-    grouped,
-    (testResults, filename) => buildTestSuiteDiv(filename, testResults),
+    sortedSuites,
+    (testSuite) => buildTestSuiteDiv(testSuite)
   );
+
+  // Sort test suites by failure count and/or HTTP request count
 
   forEach(testSuiteElements, node => {
     const block = root.ele("div");

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -1,4 +1,4 @@
-import { Dictionary, forEach, map, toPairs } from "lodash";
+import { forEach, map } from "lodash";
 import * as React from "react";
 import * as ReactDomServer from "react-dom/server";
 import stripAnsi from "strip-ansi";
@@ -7,7 +7,7 @@ import xmlBuilder = require("xmlbuilder");
 import Calls from "./components/calls";
 import stylesheet from "./stylesheet";
 import { IReportInput, ITestSuite } from "./types";
-import { toTestSuites, sortTestSuites } from "./utils";
+import { sortTestSuites, toTestSuites } from "./utils";
 
 const createHtmlBase = (): xmlBuilder.XMLDocument => {
   const htmlBase = {

--- a/packages/unmock-jest/src/reporter/types.ts
+++ b/packages/unmock-jest/src/reporter/types.ts
@@ -13,6 +13,7 @@ export interface IReportInput {
  * Represents the results for a given **test file**
  */
 export interface ITestSuite {
+  testFilePath: string;
   suiteResults: jest.TestResult;
   snapshots: ISnapshot[];
 }

--- a/packages/unmock-jest/src/reporter/utils.ts
+++ b/packages/unmock-jest/src/reporter/utils.ts
@@ -1,9 +1,11 @@
-import { Dictionary, groupBy, mapValues } from "lodash";
+import { groupBy, map, mapValues } from "lodash";
 import { IReportInput, ITestSuite } from "./types";
 
-export const groupTestsByFilePath = (
-  input: IReportInput,
-): Dictionary<ITestSuite> => {
+export const sortTestSuites = (testSuites: ITestSuite[]): ITestSuite[] => {
+  return testSuites;
+};
+
+export const toTestSuites = (input: IReportInput): ITestSuite[] => {
   const groupedResultsByFilePath = groupBy(
     input.jestData.aggregatedResult.testResults,
     testResult => testResult.testFilePath,
@@ -25,7 +27,8 @@ export const groupTestsByFilePath = (
     snapshot => snapshot.testPath,
   );
 
-  const combined = mapValues(testResultByFilePath, (value, filepath) => ({
+  const combined = map(testResultByFilePath, (value, filepath) => ({
+    testFilePath: value.testFilePath,
     suiteResults: value,
     snapshots: snapshotsByFilePath[filepath] || [],
   }));

--- a/packages/unmock-jest/src/reporter/utils.ts
+++ b/packages/unmock-jest/src/reporter/utils.ts
@@ -1,8 +1,13 @@
-import { groupBy, map, mapValues } from "lodash";
+import { groupBy, map, mapValues, reverse, sortBy } from "lodash";
 import { IReportInput, ITestSuite } from "./types";
 
 export const sortTestSuites = (testSuites: ITestSuite[]): ITestSuite[] => {
-  return testSuites;
+  return reverse(
+    sortBy(testSuites, [
+      testSuite => testSuite.suiteResults.numFailingTests,
+      testSuite => testSuite.snapshots.length,
+    ]),
+  );
 };
 
 export const toTestSuites = (input: IReportInput): ITestSuite[] => {


### PR DESCRIPTION
- Sort test suites by the number of failures and then by the number of HTTP calls (the order is meaningless anyway)
- Should tests be sorted as well? It's kinda logical they appear in the same order as in the file