### PR TITLE
Export nock as named, remove UnmockNode type export.

### DIFF
--- a/packages/unmock-core/src/__tests__/corePackage.test.ts
+++ b/packages/unmock-core/src/__tests__/corePackage.test.ts
@@ -1,4 +1,4 @@
-import { UnmockNode, UnmockPackage } from "..";
+import { UnmockPackage } from "..";
 import NodeBackend from "../backend/index";
 
 class TestBackend extends NodeBackend {
@@ -16,7 +16,7 @@ const backend = new TestBackend();
 
 describe("Tests core package", () => {
   describe("tests allowedHosts", () => {
-    let pkg: UnmockNode;
+    let pkg: UnmockPackage;
     beforeEach(() => {
       pkg = new UnmockPackage(backend);
     });

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -13,7 +13,7 @@ describe("Tests dynamic path tests", () => {
   });
 
   it("should add a service when used with named export", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expect(Object.keys(unmock.services).length).toEqual(0);
     nock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -1,4 +1,4 @@
-import unmock, { u } from "..";
+import unmock, { nock, u } from "..";
 
 describe("Tests dynamic path tests", () => {
   beforeEach(() => unmock.reloadServices());
@@ -7,6 +7,14 @@ describe("Tests dynamic path tests", () => {
     expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
     unmock
       .nock("https://foo.com")
+      .get("/foo")
+      .reply(200, { foo: u.string() });
+    expect(Object.keys(unmock.services).length).toEqual(1);
+  });
+
+  it("should add a service when used with named export", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    nock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });
     expect(Object.keys(unmock.services).length).toEqual(1);

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -76,10 +76,10 @@ export class UnmockPackage implements IUnmockPackage {
   }
 }
 
-const unmock = new UnmockPackage(new NodeBackend(), {
+export const unmock = new UnmockPackage(new NodeBackend(), {
   logger: new WinstonLogger(),
 });
 
-export type UnmockNode = typeof unmock;
+export const nock = unmock.nock.bind(unmock);
 
 export default unmock;


### PR DESCRIPTION
- `UnmockNode` can be deleted as `UnmockPackage` is exported (`typeof unmock`)