### PR TITLE
Support consecutive calls to `reply` in nock syntax

### DIFF
--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -88,5 +88,25 @@ describe("Tests dynamic path tests", () => {
       .nock("https://abc.com", "foo")
       .get("foo")
       .reply(500);
+    // @ts-ignore // "private fields" heh...
+    expect(unmock.services.foo.core.oasSchema.servers).toEqual([
+      { url: "https://abc.com" },
+      { url: "https://def.com" },
+    ]);
+  });
+
+  it("Defines different responses on same endpoint and method", () => {
+    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    unmock
+      .nock("https://foo.com", "foo")
+      .get("bar")
+      .reply(200, { msg: u.string() })
+      .reply(404, { msg: "Page not found!" });
+    expect(
+      Object.keys(
+        // @ts-ignore // "private fields" heh...
+        unmock.services.foo.core.oasSchema.paths["/bar"].get.responses,
+      ),
+    ).toEqual(["200", "404"]);
   });
 });

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -1,15 +1,10 @@
+import { OpenAPIObject, Schema } from "loas3/dist/generated/full";
 import {
-  OpenAPIObject,
-  Operation,
-  PathItem,
-  Schema,
-} from "loas3/dist/generated/full";
-import {
+  CodeAsInt,
   HTTPMethod,
   ISerializedRequest,
   IStateTransformer,
 } from "../interfaces";
-import { DEFAULT_STATE_HTTP_METHOD } from "./constants";
 import { IRequestResponsePair, ServiceSpy } from "./spy";
 
 export {
@@ -29,28 +24,6 @@ export {
   Responses,
 } from "loas3/dist/generated/full";
 
-const DEF_REST_METHOD = [DEFAULT_STATE_HTTP_METHOD] as const;
-
-type DEFAULT_HTTP_METHOD_AS_TYPE = typeof DEF_REST_METHOD[number];
-export type ExtendedHTTPMethod = HTTPMethod | DEFAULT_HTTP_METHOD_AS_TYPE;
-
-export type OASMethodKey = keyof PathItem & HTTPMethod;
-
-export type Dereferencer = <T>(obj: any) => T;
-
-// maps from media types (e.g. "application/json") to schema
-export type mediaTypeToSchema = Record<string, Schema>;
-// maps from status to mediaTypeToSchema
-export type codeToMedia = Record<string, mediaTypeToSchema>;
-
-export type MatcherResponse =
-  | {
-      operation: Operation;
-      state: codeToMedia | undefined;
-      service: IServiceCore;
-    }
-  | undefined;
-
 export interface IService {
   readonly spy: ServiceSpy;
   reset(): void;
@@ -64,7 +37,7 @@ export interface IObjectToService {
   baseUrl: string;
   method: HTTPMethod;
   endpoint: string;
-  statusCode: number;
+  statusCode: CodeAsInt | "default";
   response: string | Schema;
   name?: string;
 }


### PR DESCRIPTION
- Adds support for consecutive calls to `reply` in nock syntax
- Requires us to update interfaces etc once we add e.g. `replyWithFile`, or headers, etc
- Simplifies some logic
- Adds test and fixes some old ones
- Adds comments
- Has a very verbose branch name