### PR TITLE
Use CSS for switching between test suites, rewrite components with React.

### DIFF
--- a/packages/unmock-jest/src/reporter/components/test-suite.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suite.tsx
@@ -1,5 +1,7 @@
+import { map } from "lodash";
 import * as React from "react";
 import { ITestSuite } from "../types";
+import Test from "./test";
 
 const Summary = ({ testSuite }: { testSuite: ITestSuite }) => {
     const numPassingTests = testSuite.suiteResults.numPassingTests;
@@ -16,8 +18,20 @@ const Summary = ({ testSuite }: { testSuite: ITestSuite }) => {
 };
 
 const TestSuite = ({ testSuite }: { testSuite: ITestSuite }) => {
+
+    const testElements = map(
+        testSuite.suiteResults.testResults,
+        (assertionResult: jest.AssertionResult) => {
+            const snapshotsForTest = testSuite.snapshots.filter(
+                snapshot => snapshot.currentTestName === assertionResult.fullName,
+            );
+            return <Test assertionResult={assertionResult} snapshots={snapshotsForTest} key={assertionResult.fullName}/>
+        },
+  );
+
     return (<div className="">
             <Summary testSuite={testSuite}/>
+            {...testElements}
     </div>)
 }
 

--- a/packages/unmock-jest/src/reporter/components/test-suite.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suite.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { ITestSuite } from "../types";
+
+const TestSuite = ({ testSuite }: { testSuite: ITestSuite }) => {
+    return (<div className="">
+        <h1>
+            {"Results for: " + testSuite.testFilePath}
+        </h1>
+    </div>)
+}
+
+export default TestSuite;

--- a/packages/unmock-jest/src/reporter/components/test-suite.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suite.tsx
@@ -1,4 +1,3 @@
-import { map } from "lodash";
 import * as React from "react";
 import { ITestSuite } from "../types";
 import Test from "./test";
@@ -19,8 +18,7 @@ const Summary = ({ testSuite }: { testSuite: ITestSuite }) => {
 
 const TestSuite = ({ testSuite }: { testSuite: ITestSuite }) => {
 
-    const testElements = map(
-        testSuite.suiteResults.testResults,
+    const testElements = testSuite.suiteResults.testResults.map(
         (assertionResult: jest.AssertionResult) => {
             const snapshotsForTest = testSuite.snapshots.filter(
                 snapshot => snapshot.currentTestName === assertionResult.fullName,

--- a/packages/unmock-jest/src/reporter/components/test-suite.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suite.tsx
@@ -1,11 +1,23 @@
 import * as React from "react";
 import { ITestSuite } from "../types";
 
+const Summary = ({ testSuite }: { testSuite: ITestSuite }) => {
+    const numPassingTests = testSuite.suiteResults.numPassingTests;
+    const numFailingTests = testSuite.suiteResults.numFailingTests;
+    const nSnapshots = testSuite.snapshots.length;
+    return (<div className="test-suite__title">
+        <div className="test-suite__title-filename">
+            {testSuite.testFilePath}
+        </div>
+        <div className="test-suite__title-summary">
+            {`Passing: ${numPassingTests}, failing: ${numFailingTests}, HTTP calls: ${nSnapshots}`}
+        </div>
+    </div>)
+};
+
 const TestSuite = ({ testSuite }: { testSuite: ITestSuite }) => {
     return (<div className="">
-        <h1>
-            {"Results for: " + testSuite.testFilePath}
-        </h1>
+            <Summary testSuite={testSuite}/>
     </div>)
 }
 

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { ITestSuite } from "../types";
+
+const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): React.ReactElement => {
+  return (<fieldset><div className="container">
+    <input type="radio" id="box-1" className="box-button" name="content" defaultChecked={true} value="box-1" />
+    <label htmlFor="box-1" className="test-suite-label test-suite-label-1" id="feature-label">Test suite 1</label>
+    <input type="radio" id="box-2" className="box-button" name="content" value="box-2" />
+    <label htmlFor="box-2" className="test-suite-label test-suite-label-2" id="feature-label">Test suite 2</label>
+    <div className="test-suite test-suite-1"><h1>Results for test suite 1</h1></div>
+    <div className="test-suite test-suite-2"><h1>Results for test suite 2</h1></div>
+  </div>
+</fieldset>);
+}
+
+export default TestResults;

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -12,19 +12,21 @@ const testFileToId = (file: string) => file.replace(/[\/|\\|\.]/g, "-");  // TOD
  */
 const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
 
-    const elementsAndCss = map(testSuites, (testSuite) => {
+    const elementsAndCss = map(testSuites, (testSuite, index) => {
         const id = testFileToId(testSuite.testFilePath);
         const elementCss = `#box-${id}:checked~.test-suite-label-${id} {
-    background-color: #FF1493;
+    filter: brightness(85%);
     }
 
+    /* Display test suite when corresponding box is checked */
     #box-${id}:checked~.test-suite-${id} {
     display: block;
     }
 `;
+        const testSuiteLabelColor = testSuite.suiteResults.numFailingTests > 0 ? `test-suite-label--failure` : `test-suite-label--success`;
         return [
-            <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={true} value={`box-${id}`} key={`input-${id}`} />,
-            <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id}`} id="feature-label" key={`label-${id}`}>{testSuite.testFilePath}</label>,
+            <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={index === 0} value={`box-${id}`} key={`input-${id}`} />,
+            <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id} ${testSuiteLabelColor}`} id="feature-label" key={`label-${id}`}>{testSuite.testFilePath}</label>,
             <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} /></div>,
             elementCss,
         ];

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -1,16 +1,39 @@
 import * as React from "react";
 import { ITestSuite } from "../types";
 
-const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): React.ReactElement => {
-  return (<fieldset><div className="container">
-    <input type="radio" id="box-1" className="box-button" name="content" defaultChecked={true} value="box-1" />
-    <label htmlFor="box-1" className="test-suite-label test-suite-label-1" id="feature-label">Test suite 1</label>
-    <input type="radio" id="box-2" className="box-button" name="content" value="box-2" />
-    <label htmlFor="box-2" className="test-suite-label test-suite-label-2" id="feature-label">Test suite 2</label>
-    <div className="test-suite test-suite-1"><h1>Results for test suite 1</h1></div>
-    <div className="test-suite test-suite-2"><h1>Results for test suite 2</h1></div>
-  </div>
-</fieldset>);
+const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
+
+  const css = `
+  #box-1:checked~.test-suite-label-1 {
+  background-color: #FF1493;
+}
+
+#box-2:checked~.test-suite-label-2 {
+  background-color: #FF1493;
+}
+
+
+#box-1:checked~.test-suite-1 {
+  display: block;
+}
+
+#box-2:checked~.test-suite-2 {
+  display: block;
+}
+`;
+
+  const renderResult = () => (<fieldset>
+      <div className="container">
+        <input type="radio" id="box-1" className="test-suite-input" name="content" defaultChecked={true} value="box-1" />
+        <label htmlFor="box-1" className="test-suite-label test-suite-label-1" id="feature-label">Test suite 1</label>
+        <input type="radio" id="box-2" className="test-suite-input" name="content" value="box-2" />
+        <label htmlFor="box-2" className="test-suite-label test-suite-label-2" id="feature-label">Test suite 2</label>
+        <div className="test-suite test-suite-1"><h1>Results for test suite 1</h1></div>
+        <div className="test-suite test-suite-2"><h1>Results for test suite 2</h1></div>
+    </div>
+    </fieldset>);
+
+  return [css, renderResult];
 }
 
 export default TestResults;

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -6,6 +6,10 @@ import TestSuite from "./test-suite";
 
 const testFileToId = (file: string) => file.replace(/[\/|\\|\.]/g, "-");  // TODO Use path.sep?
 
+/**
+ * Not actually a React component but something that returns dynamically generated CSS and a React component
+ * @returns Tuple where the first element is CSS string, second is a React component for rendering the test results.
+ */
 const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
 
     const elementsAndCss = map(testSuites, (testSuite) => {

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -15,7 +15,7 @@ const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () 
     const elementsAndCss = map(testSuites, (testSuite, index) => {
         const id = testFileToId(testSuite.testFilePath);
         const elementCss = `#box-${id}:checked~.test-suite-label-${id} {
-    filter: brightness(85%);
+    opacity: 1;
     }
 
     /* Display test suite when corresponding box is checked */
@@ -23,10 +23,18 @@ const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () 
     display: block;
     }
 `;
+
+        const numPassingTests = testSuite.suiteResults.numPassingTests;
+        const numFailingTests = testSuite.suiteResults.numFailingTests;
+        const nSnapshots = testSuite.snapshots.length;
+
         const testSuiteLabelColor = testSuite.suiteResults.numFailingTests > 0 ? `test-suite-label--failure` : `test-suite-label--success`;
         return [
             <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={index === 0} value={`box-${id}`} key={`input-${id}`} />,
-            <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id} ${testSuiteLabelColor}`} id="feature-label" key={`label-${id}`}>{testSuite.testFilePath}</label>,
+            <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id} ${testSuiteLabelColor}`} id="feature-label" key={`label-${id}`}>
+                <span className="test-suite-label__filename">{testSuite.testFilePath}</span>
+                <span className="test-suite-label__summary">{`Passing: ${numPassingTests}, failing: ${numFailingTests}, HTTP calls: ${nSnapshots}`}</span>
+            </label>,
             <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} /></div>,
             elementCss,
         ];

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -1,39 +1,51 @@
+import { map } from "lodash";
+import * as os from "os";
+import * as path from "path";
 import * as React from "react";
 import { ITestSuite } from "../types";
 
 const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
 
-  const css = `
-  #box-1:checked~.test-suite-label-1 {
-  background-color: #FF1493;
-}
+    const testFileToId = (file: string) => file.replace(/[\/|\.]/g, "-");  // TODO Use path.sep
 
-#box-2:checked~.test-suite-label-2 {
-  background-color: #FF1493;
-}
+    const elementsAndCss = map(testSuites, (testSuite) => {
+        const id = testFileToId(testSuite.testFilePath);
+        const elementCss = `#box-${id}:checked~.test-suite-label-${id} {
+    background-color: #FF1493;
+    }
 
-
-#box-1:checked~.test-suite-1 {
-  display: block;
-}
-
-#box-2:checked~.test-suite-2 {
-  display: block;
-}
+    #box-${id}:checked~.test-suite-${id} {
+    display: block;
+    }
 `;
+        return [
+            <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={true} value={`box-${id}`} key={`input-${id}`} />,
+            <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id}`} id="feature-label" key={`label-${id}`}>{testSuite.testFilePath}</label>,
+            <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><h1>{testSuite.testFilePath}</h1></div>,
+            elementCss,
+        ];
+    });
+
+    const inputs = map(elementsAndCss, (element) => element[0]);
+    const labels = map(elementsAndCss, (element) => element[1]);
+    const divs = map(elementsAndCss, (element) => element[2]);
+    const css = map(elementsAndCss, (element) => element[3]);
 
   const renderResult = () => (<fieldset>
       <div className="container">
-        <input type="radio" id="box-1" className="test-suite-input" name="content" defaultChecked={true} value="box-1" />
-        <label htmlFor="box-1" className="test-suite-label test-suite-label-1" id="feature-label">Test suite 1</label>
+        {/*<input type="radio" id="box-1" className="test-suite-input" name="content" defaultChecked={true} value="box-1" />
         <input type="radio" id="box-2" className="test-suite-input" name="content" value="box-2" />
+        <label htmlFor="box-1" className="test-suite-label test-suite-label-1" id="feature-label">Test suite 1</label>
         <label htmlFor="box-2" className="test-suite-label test-suite-label-2" id="feature-label">Test suite 2</label>
         <div className="test-suite test-suite-1"><h1>Results for test suite 1</h1></div>
-        <div className="test-suite test-suite-2"><h1>Results for test suite 2</h1></div>
+  <div className="test-suite test-suite-2"><h1>Results for test suite 2</h1></div>*/}
+        {...inputs}
+        {...labels}
+        {...divs}
     </div>
     </fieldset>);
 
-  return [css, renderResult];
+  return [css.join(os.EOL), renderResult];
 }
 
 export default TestResults;

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -1,12 +1,12 @@
 import { map } from "lodash";
 import * as os from "os";
-import * as path from "path";
 import * as React from "react";
 import { ITestSuite } from "../types";
+import TestSuite from "./test-suite";
+
+const testFileToId = (file: string) => file.replace(/[\/|\\|\.]/g, "-");  // TODO Use path.sep?
 
 const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
-
-    const testFileToId = (file: string) => file.replace(/[\/|\.]/g, "-");  // TODO Use path.sep
 
     const elementsAndCss = map(testSuites, (testSuite) => {
         const id = testFileToId(testSuite.testFilePath);
@@ -21,7 +21,7 @@ const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () 
         return [
             <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={true} value={`box-${id}`} key={`input-${id}`} />,
             <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id}`} id="feature-label" key={`label-${id}`}>{testSuite.testFilePath}</label>,
-            <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><h1>{testSuite.testFilePath}</h1></div>,
+            <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} /></div>,
             elementCss,
         ];
     });
@@ -32,13 +32,7 @@ const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () 
     const css = map(elementsAndCss, (element) => element[3]);
 
   const renderResult = () => (<fieldset>
-      <div className="container">
-        {/*<input type="radio" id="box-1" className="test-suite-input" name="content" defaultChecked={true} value="box-1" />
-        <input type="radio" id="box-2" className="test-suite-input" name="content" value="box-2" />
-        <label htmlFor="box-1" className="test-suite-label test-suite-label-1" id="feature-label">Test suite 1</label>
-        <label htmlFor="box-2" className="test-suite-label test-suite-label-2" id="feature-label">Test suite 2</label>
-        <div className="test-suite test-suite-1"><h1>Results for test suite 1</h1></div>
-  <div className="test-suite test-suite-2"><h1>Results for test suite 2</h1></div>*/}
+      <div className="test-results-container">
         {...inputs}
         {...labels}
         {...divs}

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -1,4 +1,3 @@
-import { map } from "lodash";
 import * as os from "os";
 import * as React from "react";
 import { ITestSuite } from "../types";
@@ -12,7 +11,7 @@ const testFileToId = (file: string) => file.replace(/[\/|\\|\.]/g, "-");  // TOD
  */
 const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
 
-    const elementsAndCss = map(testSuites, (testSuite, index) => {
+    const elementsAndCss = testSuites.map((testSuite, index) => {
         const id = testFileToId(testSuite.testFilePath);
         const elementCss = `#box-${id}:checked~.test-suite-label-${id} {
     opacity: 1;
@@ -29,27 +28,27 @@ const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () 
         const nSnapshots = testSuite.snapshots.length;
 
         const testSuiteLabelColor = testSuite.suiteResults.numFailingTests > 0 ? `test-suite-label--failure` : `test-suite-label--success`;
-        return [
-            <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={index === 0} value={`box-${id}`} key={`input-${id}`} />,
-            <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id} ${testSuiteLabelColor}`} id="feature-label" key={`label-${id}`}>
+        return {
+            input: <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={index === 0} value={`box-${id}`} key={`input-${id}`} />,
+            label: <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id} ${testSuiteLabelColor}`} id="feature-label" key={`label-${id}`}>
                 <span className="test-suite-label__filename">{testSuite.testFilePath}</span>
                 <span className="test-suite-label__summary">{`Passing: ${numPassingTests}, failing: ${numFailingTests}, HTTP calls: ${nSnapshots}`}</span>
             </label>,
-            <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} /></div>,
-            elementCss,
-        ];
+            testSuite: <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} /></div>,
+            css: elementCss
+        };
     });
 
-    const inputs = map(elementsAndCss, (element) => element[0]);
-    const labels = map(elementsAndCss, (element) => element[1]);
-    const divs = map(elementsAndCss, (element) => element[2]);
-    const css = map(elementsAndCss, (element) => element[3]);
+    const inputs = elementsAndCss.map(val => val.input);
+    const labels = elementsAndCss.map(val => val.label);
+    const testSuiteComponents = elementsAndCss.map(val => val.testSuite);
+    const css = elementsAndCss.map(val => val.css);
 
   const renderResult = () => (<fieldset>
       <div className="test-results-container">
         {...inputs}
         {...labels}
-        {...divs}
+        {...testSuiteComponents}
     </div>
     </fieldset>);
 

--- a/packages/unmock-jest/src/reporter/components/test.tsx
+++ b/packages/unmock-jest/src/reporter/components/test.tsx
@@ -9,7 +9,10 @@ const buildTestTitle = (assertionResult: jest.AssertionResult) =>
 
 const Test = ({ assertionResult, snapshots }: { assertionResult: jest.AssertionResult, snapshots: ISnapshot[]}) => {
     return (<div className="test">
-        {buildTestTitle(assertionResult)}
+        <div className="test__title">
+            {buildTestTitle(assertionResult)}
+        </div>
+        
     </div>);
 };
 

--- a/packages/unmock-jest/src/reporter/components/test.tsx
+++ b/packages/unmock-jest/src/reporter/components/test.tsx
@@ -1,12 +1,18 @@
-import { map } from "lodash";
 import * as React from "react";
 import stripAnsi from "strip-ansi";
 import { ISnapshot } from "unmock";
+import Calls from "./calls";
 
 const buildTestTitle = (assertionResult: jest.AssertionResult) =>
   assertionResult.ancestorTitles
     .map(ancestorTitle => `${ancestorTitle} > `)
     .join(" ") + assertionResult.title;
+
+const TestTitle = ({ assertionResult }: { assertionResult: jest.AssertionResult}) => {
+    return (<div className="test__title">
+            {buildTestTitle(assertionResult)}
+    </div>);
+}
 
 const FailureMessage = ({ messages }: { messages: string[] }) => {
     return (<div className={`test__failure-messages`}>
@@ -23,14 +29,14 @@ const Test = ({ assertionResult, snapshots }: { assertionResult: jest.AssertionR
         ? "test--failure"
         : "test--success";
 
-    return (<div className={`test ${statusClass}`}>
-        <div className="test__title">
-            {buildTestTitle(assertionResult)}
-        </div>
-        { failureMessages.length > 0 ? 
-            <FailureMessage messages={failureMessages} />
-            : null }
-    </div>);
+    return (
+        <div className={`test ${statusClass}`}>
+            <TestTitle assertionResult={assertionResult} />
+            { failureMessages.length > 0 ?
+                <FailureMessage messages={failureMessages} />
+                : null }
+            <Calls assertionResult={assertionResult}  snapshots={snapshots}/>
+        </div>);
 };
 
 export default Test;

--- a/packages/unmock-jest/src/reporter/components/test.tsx
+++ b/packages/unmock-jest/src/reporter/components/test.tsx
@@ -1,5 +1,6 @@
 import { map } from "lodash";
 import * as React from "react";
+import stripAnsi from "strip-ansi";
 import { ISnapshot } from "unmock";
 
 const buildTestTitle = (assertionResult: jest.AssertionResult) =>
@@ -7,12 +8,28 @@ const buildTestTitle = (assertionResult: jest.AssertionResult) =>
     .map(ancestorTitle => `${ancestorTitle} > `)
     .join(" ") + assertionResult.title;
 
+const FailureMessage = ({ messages }: { messages: string[] }) => {
+    return (<div className={`test__failure-messages`}>
+                {`Failure message: ${messages.map((message) => stripAnsi(message)).join(", ")}`}
+            </div>) 
+}
+
 const Test = ({ assertionResult, snapshots }: { assertionResult: jest.AssertionResult, snapshots: ISnapshot[]}) => {
-    return (<div className="test">
+
+    const failureMessages = assertionResult.failureMessages;
+
+    const statusClass =
+        failureMessages.length > 0
+        ? "test--failure"
+        : "test--success";
+
+    return (<div className={`test ${statusClass}`}>
         <div className="test__title">
             {buildTestTitle(assertionResult)}
         </div>
-        
+        { failureMessages.length > 0 ? 
+            <FailureMessage messages={failureMessages} />
+            : null }
     </div>);
 };
 

--- a/packages/unmock-jest/src/reporter/components/test.tsx
+++ b/packages/unmock-jest/src/reporter/components/test.tsx
@@ -20,6 +20,11 @@ const FailureMessage = ({ messages }: { messages: string[] }) => {
             </div>) 
 }
 
+/**
+ * Build Test component
+ * @param assertionResult Jest results for the test
+ * @param snapshots All unmock snapshots for **this test**
+ */
 const Test = ({ assertionResult, snapshots }: { assertionResult: jest.AssertionResult, snapshots: ISnapshot[]}) => {
 
     const failureMessages = assertionResult.failureMessages;

--- a/packages/unmock-jest/src/reporter/components/test.tsx
+++ b/packages/unmock-jest/src/reporter/components/test.tsx
@@ -1,0 +1,16 @@
+import { map } from "lodash";
+import * as React from "react";
+import { ISnapshot } from "unmock";
+
+const buildTestTitle = (assertionResult: jest.AssertionResult) =>
+  assertionResult.ancestorTitles
+    .map(ancestorTitle => `${ancestorTitle} > `)
+    .join(" ") + assertionResult.title;
+
+const Test = ({ assertionResult, snapshots }: { assertionResult: jest.AssertionResult, snapshots: ISnapshot[]}) => {
+    return (<div className="test">
+        {buildTestTitle(assertionResult)}
+    </div>);
+};
+
+export default Test;

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -1,10 +1,6 @@
-import { forEach, map } from "lodash";
 import * as React from "react";
 import * as ReactDomServer from "react-dom/server";
-import stripAnsi from "strip-ansi";
-import { ISnapshot } from "unmock";
 import xmlBuilder = require("xmlbuilder");
-import Calls from "./components/calls";
 import TestSuites from "./components/test-suites";
 import stylesheet from "./stylesheet";
 import { IReportInput, ITestSuite } from "./types";
@@ -27,123 +23,8 @@ const createHtml = ({ css, body } : { css: string, body: string }) => {
 
 export const PAGE_TITLE = "Unmock Jest report";
 
-const buildTestTitle = (assertionResult: jest.AssertionResult) =>
-  assertionResult.ancestorTitles
-    .map(ancestorTitle => `${ancestorTitle} > `)
-    .join(" ") + assertionResult.title;
-
 const renderReact = (element: React.ReactElement): string =>
   ReactDomServer.renderToStaticMarkup(element);
-
-/**
- * Build a div containing the results for a single test ("assertion")
- * @param assertionResult Jest results for the test
- * @param snapshots All unmock snapshots for **this test**
- */
-const buildTestDiv = (
-  assertionResult: jest.AssertionResult,
-  snapshots: ISnapshot[],
-): xmlBuilder.XMLDocument => {
-  const statusClass =
-    assertionResult.failureMessages.length > 0
-      ? "test--failure"
-      : "test--success";
-
-  const testDiv = xmlBuilder
-    .begin()
-    .ele("div", { class: `test ${statusClass}` });
-
-  // Title
-  const testTitle = buildTestTitle(assertionResult);
-  testDiv.ele("div", { class: "test-title" }, testTitle);
-
-  // Failure messages
-  if (assertionResult.failureMessages.length > 0) {
-    const failureDiv = testDiv.ele("div", {
-      class: "test__failure-messages",
-    });
-    failureDiv.raw(
-      `Failure message: ${stripAnsi(
-        assertionResult.failureMessages.join(", "),
-      )}`,
-    );
-  }
-
-  const callsElement = <Calls assertionResult={assertionResult}  snapshots={snapshots}/>;
-
-  testDiv.raw(renderReact(callsElement));
-
-  return testDiv;
-};
-
-/**
- * Build title div for test suite
- */
-const buildTestSuiteTitleDiv = (
-  filename: string,
-  testSuite: ITestSuite,
-): xmlBuilder.XMLDocument => {
-  const suiteResult = testSuite.suiteResults;
-  const numFailingTests = suiteResult.numFailingTests;
-  const snapshots = testSuite.snapshots;
-  const numPassingTests = suiteResult.numPassingTests;
-  const div = xmlBuilder.begin().ele("div", {
-    class: "test-suite__title",
-  });
-
-  div.ele("div", { class: "test-suite__title-filename" }, filename);
-
-  div.ele(
-    "div",
-    { class: "test-suite__title-summary" },
-    `Passing: ${numPassingTests}, failing: ${numFailingTests}, HTTP calls: ${snapshots.length}`,
-  );
-  return div;
-};
-
-/**
- * Build a div for showing the results for a single test suite (a single test file).
- * @param filename Test file path
- * @param testSuite Test suite results
- */
-const buildTestSuiteDiv = (
-  testSuite: ITestSuite,
-): xmlBuilder.XMLDocument => {
-  const suiteResult = testSuite.suiteResults;
-  const numFailingTests = suiteResult.numFailingTests;
-  const snapshots = testSuite.snapshots;
-
-  const suiteSuccessClass =
-    numFailingTests === 0 ? " test-suite--success" : " test-suite--failure";
-
-  const element = xmlBuilder
-    .begin()
-    .ele("div", { class: `test-suite ${suiteSuccessClass}` });
-
-  const testSuiteTitleDiv = buildTestSuiteTitleDiv(testSuite.testFilePath, testSuite);
-
-  element.importDocument(testSuiteTitleDiv);
-
-  const testResults = element.ele("div", {
-    class: "test-suite__results" + suiteSuccessClass,
-  });
-
-  const testElements: xmlBuilder.XMLDocument[] = map(
-    suiteResult.testResults,
-    assertionResult => {
-      const snapshotsForTest = snapshots.filter(
-        snapshot => snapshot.currentTestName === assertionResult.fullName,
-      );
-      return buildTestDiv(assertionResult, snapshotsForTest);
-    },
-  );
-
-  forEach(testElements, testBlock => {
-    testResults.importDocument(testBlock);
-  });
-
-  return element;
-};
 
 /**
  * Build the header div containing title, timestamp, summary, etc.
@@ -175,38 +56,11 @@ const buildHeaderDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
 };
 
 
-/**
- * Build div containing results for all test files (excluding header etc.)
- */
-const buildTestResultsDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
-  const root = xmlBuilder.begin().ele("div", { class: "test-results" });
-
-  const testSuites: ITestSuite[] = toTestSuites(input);
-
-  const sortedSuites = sortTestSuites(testSuites);
-
-  const testSuiteElements: xmlBuilder.XMLDocument[] = map(
-    sortedSuites,
-    (testSuite) => buildTestSuiteDiv(testSuite)
-  );
-
-  forEach(testSuiteElements, node => {
-    const block = root.ele("div");
-    block.importDocument(node);
-  });
-  return root;
-};
-
-
-
 const buildBodyDiv = (input: IReportInput): [xmlBuilder.XMLDocument, string] => {
   const reportBody = xmlBuilder.begin().element("div", { class: "report" });
 
   // Header
   reportBody.importDocument(buildHeaderDiv(input));
-
-  // Test results
-  reportBody.importDocument(buildTestResultsDiv(input));
 
   const testSuites: ITestSuite[] = sortTestSuites(toTestSuites(input));
 

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -26,8 +26,24 @@ const createHtmlBase = (): xmlBuilder.XMLDocument => {
     },
   };
 
-  return xmlBuilder.create(htmlBase);
+  const doc = xmlBuilder.create(htmlBase);
+  return doc;
 };
+
+const createHtml = ({ css, body } : { css: string, body: string }) => {
+  return `<html>
+  <head>
+  <meta charset="utf-8">
+  <title>Unmock Report</title>
+  <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
+  <style type="text/css">${stylesheet}</style>
+  <style type="text/css">${css}</style>
+  </head>
+  <body>
+  ${body}
+  </body>
+  </html>`;
+}
 
 export const PAGE_TITLE = "Unmock Jest report";
 
@@ -203,7 +219,7 @@ const buildTestResultsDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
 
 
 
-const buildBodyDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
+const buildBodyDiv = (input: IReportInput): [xmlBuilder.XMLDocument, string] => {
   const reportBody = xmlBuilder.begin().element("div", { class: "report" });
 
   // Header
@@ -214,16 +230,17 @@ const buildBodyDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
 
   const testSuites: ITestSuite[] = sortTestSuites(toTestSuites(input));
 
-  reportBody.raw(renderReact(<TestSuites testSuites={testSuites} />));
+  const [css, TestSuitesComponent ] = TestSuites({testSuites });
 
-  return reportBody;
+  reportBody.raw(renderReact(<TestSuitesComponent />));
+
+  return [reportBody, css];
 };
 
 export const createReport = (input: IReportInput) => {
-  const htmlOutput: xmlBuilder.XMLDocument = createHtmlBase();
-  const body: xmlBuilder.XMLDocument = buildBodyDiv(input);
-  htmlOutput.ele("body").importDocument(body);
-  return htmlOutput.end({ pretty: true });
+  const [body, css] = buildBodyDiv(input);
+  const htmlOutput = createHtml({ css, body: body.end() });
+  return htmlOutput;
 };
 
 export default createReport;

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -5,6 +5,7 @@ import stripAnsi from "strip-ansi";
 import { ISnapshot } from "unmock";
 import xmlBuilder = require("xmlbuilder");
 import Calls from "./components/calls";
+import TestSuites from "./components/test-suites";
 import stylesheet from "./stylesheet";
 import { IReportInput, ITestSuite } from "./types";
 import { sortTestSuites, toTestSuites } from "./utils";
@@ -200,6 +201,8 @@ const buildTestResultsDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
   return root;
 };
 
+
+
 const buildBodyDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
   const reportBody = xmlBuilder.begin().element("div", { class: "report" });
 
@@ -208,6 +211,10 @@ const buildBodyDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
 
   // Test results
   reportBody.importDocument(buildTestResultsDiv(input));
+
+  const testSuites: ITestSuite[] = sortTestSuites(toTestSuites(input));
+
+  reportBody.raw(renderReact(<TestSuites testSuites={testSuites} />));
 
   return reportBody;
 };

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -60,7 +60,7 @@ const buildTestDiv = (
   // Failure messages
   if (assertionResult.failureMessages.length > 0) {
     const failureDiv = testDiv.ele("div", {
-      class: "test-failure-messages",
+      class: "test__failure-messages",
     });
     failureDiv.raw(
       `Failure message: ${stripAnsi(

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -10,39 +10,19 @@ import stylesheet from "./stylesheet";
 import { IReportInput, ITestSuite } from "./types";
 import { sortTestSuites, toTestSuites } from "./utils";
 
-const createHtmlBase = (): xmlBuilder.XMLDocument => {
-  const htmlBase = {
-    html: {
-      head: {
-        meta: { "@charset": "utf-8" },
-        title: { "#text": "Unmock report" },
-        link: {
-          "@href":
-            "https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900",
-          "@rel": "stylesheet",
-        },
-        style: { "@type": "text/css", "#text": stylesheet },
-      },
-    },
-  };
-
-  const doc = xmlBuilder.create(htmlBase);
-  return doc;
-};
-
 const createHtml = ({ css, body } : { css: string, body: string }) => {
   return `<html>
   <head>
-  <meta charset="utf-8">
-  <title>Unmock Report</title>
-  <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
-  <style type="text/css">${stylesheet}</style>
-  <style type="text/css">${css}</style>
+    <meta charset="utf-8">
+    <title>Unmock Report</title>
+    <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900" rel="stylesheet" />
+    <style type="text/css">${stylesheet}</style>
+    <style type="text/css">${css}</style>
   </head>
   <body>
-  ${body}
+    ${body}
   </body>
-  </html>`;
+</html>`;
 }
 
 export const PAGE_TITLE = "Unmock Jest report";

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -163,7 +163,6 @@ body {
 .test-suite {
   display: none;
   padding: 2rem;
-  text-align: center;
 }
 
 .test-suite-label {

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -167,10 +167,17 @@ body {
 
 .test-suite-label {
   display: inline-block;
-  background-color: red;
   border-radius: 2rem;
   padding: 1rem;
   margin-bottom: 1rem;
+}
+
+.test-suite-label--success {
+  background-color: ${successGreen};
+}
+
+.test-suite-label--failure {
+  background-color: ${failureRed};
 }
 
 .test-results-container {

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -56,6 +56,7 @@ body {
 }
 
 .test-suite__title-summary {
+  font-size: 2rem;
 }
 
 .test-suite__results {

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -168,9 +168,19 @@ body {
 .test-suite-label {
   display: inline-block;
   background-color: red;
-  border-style: dashed;
   border-radius: 2rem;
   padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.test-results-container {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+}
+
+fieldset {
+  border-style: none;
 }
 
 `;

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -86,7 +86,7 @@ body {
   border-radius: 2rem;
 }
 
-.test-title {
+.test__title {
   font-size: 2rem;
   font-weight: 700;
 }

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -155,6 +155,24 @@ body {
   width: 100%;
 }
 
+.test-suite-input {
+  display: none;
+}
+
+.test-suite {
+  display: none;
+  padding: 2rem;
+  text-align: center;
+}
+
+.test-suite-label {
+  display: inline-block;
+  background-color: red;
+  border-style: dashed;
+  border-radius: 2rem;
+  padding: 1rem;
+}
+
 `;
 
 export default stylesheet;

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -46,6 +46,7 @@ body {
 .test-suite__title {
   background-color: #eee;
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   padding: 1rem 2rem;
   border-radius: 2rem;
@@ -53,10 +54,13 @@ body {
 
 .test-suite__title-filename {
   font-size: 2rem;
+  font-weight: bold;
+  margin: auto;
 }
 
 .test-suite__title-summary {
   font-size: 2rem;
+  margin: auto;
 }
 
 .test-suite__results {
@@ -168,8 +172,18 @@ body {
 .test-suite-label {
   display: inline-block;
   border-radius: 2rem;
-  padding: 1rem;
+  padding: 1rem 2rem;
   margin-bottom: 1rem;
+  font-size: 2rem;
+  opacity: 0.7;
+}
+
+.test-suite-label__filename {
+  float: left;
+}
+
+.test-suite-label__summary {
+  float: right;
 }
 
 .test-suite-label--success {


### PR DESCRIPTION
- One can now switch between test suites by clicking on the labels, implemented with CSS radio-buttons and sibling selectors
- Rewrote the test suite components with React, xmlbuilder can soon be removed
- [ ]  Would be nice to add checkbox CSS hacks also to individual tests so one can enlarge and collapse them
- [ ]  Needs tests
- [ ]  Full paths to test files are a bit annoying, could drop longest common directory

Looks like this:
<img width="1409" alt="Screenshot 2019-09-20 at 11 05 03" src="https://user-images.githubusercontent.com/11660974/65310263-9ef5d880-db96-11e9-9960-017ea8961fb1.png">
