### PR TITLE
Adds an associate method

### DIFF
--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -184,5 +184,28 @@ describe("Tests dynamic path tests", () => {
         { url: "https://www.bar.com" },
       ]);
     });
+
+    it("A URL can be associated with multiple services and won't delete other services if they share name and URL", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get("")
+        .reply(200);
+      unmock
+        .nock("https://www.bar.com")
+        .get("")
+        .reply(200);
+      expect(unmock.services.foo).toBeDefined();
+      expect(unmock.services["www.bar.com"]).toBeDefined();
+      expectNServices(2);
+      unmock.associate("https://www.bar.com", "foo"); // add a server to foo
+      expect(getPrivateSchema("foo").servers).toEqual([
+        { url: "https://www.bar.com" },
+        { url: "https://www.foo.com" },
+      ]);
+      expect(getPrivateSchema("www.bar.com").servers).toEqual([
+        { url: "https://www.bar.com" },
+      ]);
+    });
   });
 });

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -1,32 +1,38 @@
 import unmock, { nock, u } from "..";
 
+const expectNServices = (expectedLength: number) =>
+  expect(Object.keys(unmock.services).length).toEqual(expectedLength);
+
+// @ts-ignore // we access private fields in this test for simplicity; it would probably be cleaner to have some of these as E2E tests
+const getPrivateSchema = (name: string) => unmock.services[name].core.oasSchema;
+
 describe("Tests dynamic path tests", () => {
   beforeEach(() => unmock.reloadServices());
 
   it("Adds a service", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     unmock
       .nock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });
-    expect(Object.keys(unmock.services).length).toEqual(1);
+    expectNServices(1);
   });
 
   it("should add a service when used with named export", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0);
+    expectNServices(0);
     nock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });
-    expect(Object.keys(unmock.services).length).toEqual(1);
+    expectNServices(1);
   });
 
   it("Adds a service and changes state", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     unmock
       .nock("https://foo.com")
       .get("foo") // slash is prepended automatically
       .reply(200, { foo: u.string() });
-    expect(Object.keys(unmock.services).length).toEqual(1);
+    expectNServices(1);
     const service = unmock.services["foo.com"];
     if (service === undefined) {
       // type-checking mostly...
@@ -35,7 +41,7 @@ describe("Tests dynamic path tests", () => {
   });
 
   it("Adds a service and updates it on consecutive calls", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     unmock
       .nock("https://foo.com")
       .get("foo") // slash is prepended automatically
@@ -44,7 +50,7 @@ describe("Tests dynamic path tests", () => {
       .nock("https://foo.com")
       .post("/foo")
       .reply(201);
-    expect(Object.keys(unmock.services).length).toEqual(1);
+    expectNServices(1);
     const service = unmock.services["foo.com"];
     if (service === undefined) {
       // type-checking mostly...
@@ -53,37 +59,37 @@ describe("Tests dynamic path tests", () => {
   });
 
   it("Adds a named service", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     unmock
       .nock("https://abc.com", "foo")
       .get("abc") // slash is prepended automatically
       .reply(200, { foo: u.string() });
-    expect(Object.keys(unmock.services).length).toEqual(1);
+    expectNServices(1);
   });
 
   it("Chains multiple endpoints", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     unmock
       .nock("https://abc.com", "foo")
       .get("abc") // slash is prepended automatically
       .reply(200, { foo: u.string() })
       .post("bar")
       .reply(404);
-    expect(Object.keys(unmock.services).length).toEqual(1);
+    expectNServices(1);
   });
 
   it("Chains multiple endpoints in multiple calls", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     const dynamicSpec = unmock
       .nock("https://abc.com", "foo")
       .get("foo")
       .reply(200, { city: u.string("address.city") });
     dynamicSpec.get("foo").reply(404, { msg: u.string("address.city") });
-    expect(Object.keys(unmock.services).length).toEqual(1);
+    expectNServices(1);
   });
 
   it("Allows using same name with multiple servers", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     unmock
       .nock("https://abc.com", "foo")
       .get("foo")
@@ -96,25 +102,87 @@ describe("Tests dynamic path tests", () => {
       .nock("https://abc.com", "foo")
       .get("foo")
       .reply(500);
-    // @ts-ignore // "private fields" heh...
-    expect(unmock.services.foo.core.oasSchema.servers).toEqual([
+    expect(getPrivateSchema("foo").servers).toEqual([
       { url: "https://abc.com" },
       { url: "https://def.com" },
     ]);
   });
 
   it("Defines different responses on same endpoint and method", () => {
-    expect(Object.keys(unmock.services).length).toEqual(0); // Uses the default location and not the test folder
+    expectNServices(0);
     unmock
       .nock("https://foo.com", "foo")
       .get("bar")
       .reply(200, { msg: u.string() })
       .reply(404, { msg: "Page not found!" });
     expect(
-      Object.keys(
-        // @ts-ignore // "private fields" heh...
-        unmock.services.foo.core.oasSchema.paths["/bar"].get.responses,
-      ),
+      Object.keys(getPrivateSchema("foo").paths["/bar"].get.responses),
     ).toEqual(["200", "404"]);
+  });
+
+  describe("Association works as expected", () => {
+    it("Defines an empty service when nothing exists", () => {
+      expectNServices(0);
+      unmock.associate("https://foo.com", "foo");
+      expectNServices(1);
+      const schema = getPrivateSchema("foo");
+      expect(Object.keys(schema.paths).length).toEqual(0);
+      expect(schema.servers.length).toEqual(1);
+    });
+
+    it("Associates a service by url", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com")
+        .get("")
+        .reply(200);
+      expect(unmock.services["www.foo.com"]).toBeDefined();
+      expectNServices(1);
+      unmock.associate("https://www.foo.com", "foo"); // rename the service
+      expectNServices(1);
+      expect(unmock.services.foo).toBeDefined();
+      expect(unmock.services["www.foo.com"]).toBeUndefined();
+    });
+
+    it("Associates a url by name", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get("")
+        .reply(200);
+      expect(unmock.services.foo).toBeDefined();
+      expectNServices(1);
+      unmock.associate("https://www.bar.com", "foo"); // add a server
+      expectNServices(1);
+      expect(unmock.services["www.foo.com"]).toBeUndefined();
+      expect(unmock.services["www.bar.com"]).toBeUndefined();
+      expect(getPrivateSchema("foo").servers).toEqual([
+        { url: "https://www.bar.com" },
+        { url: "https://www.foo.com" },
+      ]);
+    });
+
+    it("A URL can be associated with multiple services", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get("")
+        .reply(200);
+      unmock
+        .nock("https://www.bar.com", "bar")
+        .get("")
+        .reply(200);
+      expect(unmock.services.foo).toBeDefined();
+      expect(unmock.services.bar).toBeDefined();
+      expectNServices(2);
+      unmock.associate("https://www.bar.com", "foo"); // add a server
+      expect(getPrivateSchema("foo").servers).toEqual([
+        { url: "https://www.bar.com" },
+        { url: "https://www.foo.com" },
+      ]);
+      expect(getPrivateSchema("bar").servers).toEqual([
+        { url: "https://www.bar.com" },
+      ]);
+    });
   });
 });

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -207,5 +207,25 @@ describe("Tests dynamic path tests", () => {
         { url: "https://www.bar.com" },
       ]);
     });
+
+    it("Can add to an existing service after call to associate", () => {
+      expectNServices(0);
+      unmock.associate("https://www.foo.com", "foo"); // empty service
+      expectNServices(1);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get("")
+        .reply(200);
+      expectNServices(1);
+      expect(Object.keys(getPrivateSchema("foo").paths).length).toEqual(1);
+      unmock.associate("https://www.bar.com", "bar"); // empty service
+      expectNServices(2);
+      // since a name is not given, it cannot be associated with previously declared www.bar.com.
+      unmock
+        .nock("https://www.bar.com")
+        .get("")
+        .reply(200);
+      expectNServices(3);
+    });
   });
 });

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -67,6 +67,10 @@ export class UnmockPackage implements IUnmockPackage {
     return nockify({ backend: this.backend, baseUrl, name });
   }
 
+  public associate(url: string, name: string) {
+    this.backend.serviceStore.updateOrAdd({ baseUrl: url, name });
+  }
+
   public reloadServices() {
     this.backend.loadServices();
   }

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -575,6 +575,17 @@ export interface IUnmockPackage {
   off(): void;
 
   /**
+   * Associates a service with a base URL (server, host, etc.).
+   * If the service with `url` exists, it will be accessible via the new `name`.
+   * If the service with `name` exists and `url` is missing as a server, it will be added.
+   * If the service with `name` exists and `url` is listed in a different service - it will be added to the named service as well.
+   * If there is no service matching `name`, and no service matching `url`, it will create an empty service with that server and name.
+   * @param url
+   * @param name
+   */
+  associate(url: string, name: string): void;
+
+  /**
    * Reloads all services for unmock.
    * Any dynamically-defined services will be deleted.
    */

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -35,10 +35,10 @@ export type ServiceStoreType = Record<string, IService>;
 // Used to programmatically define/update a service
 export interface IObjectToService {
   baseUrl: string;
-  method: HTTPMethod;
-  endpoint: string;
-  statusCode: CodeAsInt | "default";
-  response: string | Schema;
+  method?: HTTPMethod;
+  endpoint?: string;
+  statusCode?: CodeAsInt | "default";
+  response?: string | Schema;
   name?: string;
 }
 

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -29,20 +29,23 @@ export class ServiceCore implements IServiceCore {
     const mediaType =
       typeof response === "string" ? "text/*" : "application/json";
     // TODO: Decouple from ServiceCore :( - this is nasty
-    const newPath: PathItem = {
-      [endpoint]: {
-        [method]: {
-          responses: {
-            [statusCode]: {
-              description: "Automatically added",
-              content: {
-                [mediaType]: { schema: response },
+    const newPath: PathItem =
+      endpoint !== undefined && method !== undefined && statusCode !== undefined
+        ? {
+            [endpoint]: {
+              [method]: {
+                responses: {
+                  [statusCode]: {
+                    description: "Automatically added",
+                    content: {
+                      [mediaType]: { schema: response },
+                    },
+                  },
+                },
               },
             },
-          },
-        },
-      },
-    };
+          }
+        : {};
     const newUrls = [{ url: baseUrl }];
 
     const newPaths = defaultsDeep(newPath, baseSchema.paths);

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -43,9 +43,11 @@ export class ServiceStore {
       ...input,
       name: serviceName,
     });
-    if (this.cores[hostName] !== undefined) {
+    if (
+      this.cores[hostName] !== undefined &&
+      this.cores[serviceName] === undefined
+    ) {
       // remove old service core and wrapper if a service is just renamed
-      // when hostname == servicename, this is essentially a no-op
       delete this.cores[hostName];
       delete this.services[hostName];
     }

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -26,14 +26,15 @@ export class ServiceStore {
 
   public updateOrAdd(input: IObjectToService): ServiceStore {
     // TODO: Tighly coupled with OpenAPI at the moment... resolve this at a later time
-    const serviceName =
-      input.name || url.parse(input.baseUrl).hostname || input.baseUrl;
+    const hostName = url.parse(input.baseUrl).hostname || input.baseUrl;
+    const serviceName = input.name || hostName || input.baseUrl;
     const baseSchema: OpenAPIObject =
       serviceName !== undefined && this.cores[serviceName] !== undefined
-        ? // service exists
-          this.cores[serviceName].schema
-        : // Build new schema object
-          {
+        ? this.cores[serviceName].schema /* service exists by name */
+        : this.cores[hostName] !== undefined
+        ? this.cores[hostName].schema /* service exists by base url */
+        : {
+            /* new service - some template schema */
             openapi: "3.0.0",
             info: { title: "Internally built by unmock", version: "0.0.0" },
             paths: {},
@@ -42,6 +43,12 @@ export class ServiceStore {
       ...input,
       name: serviceName,
     });
+    if (this.cores[hostName] !== undefined) {
+      // remove old service core and wrapper if a service is just renamed
+      // when hostname == servicename, this is essentially a no-op
+      delete this.cores[hostName];
+      delete this.services[hostName];
+    }
     this.cores[serviceName] = newServiceCore;
     this.services[serviceName] = new Service(newServiceCore);
 


### PR DESCRIPTION
Resolves #251.
The behavior is defined in the method itself, but essentially:
- If `url` exists as a service name, and there is no service named `name`, then the service will renamed from `url` to `name`.
- If `url` exists as a service name and there's already a service named `name`, then the `url` will be added as a server for that service.
- If `url` does not exist as a service name and there's a service named `name`, then the `url` will be added as a server for that service.
- If `url` does not exist as a service name and there's no service named `name`, then a new service will be created with no endpoints or operation, just a simple server.