### PR TITLE
Pretty-print test file paths in reporter.

### DIFF
--- a/packages/unmock-jest/src/__tests__/utils.test.ts
+++ b/packages/unmock-jest/src/__tests__/utils.test.ts
@@ -49,20 +49,27 @@ describe("Reporter utils", () => {
       ]);
     });
   });
-  describe("Finding longest common path", () => {
-    it("should match everything when only single array given", () => {
+  describe("Finding longest array in common", () => {
+    it("should return the whole array when only single array given", () => {
       const result = largestCommonArray([["dir", "stuff"]]);
       expect(result).toEqual(["dir", "stuff"]);
     });
-    it("should match everything when the paths match", () => {
+    it("should return the whole array when all items match", () => {
       const result = largestCommonArray([["dir", "stuff"], ["dir", "stuff"]]);
       expect(result).toEqual(["dir", "stuff"]);
     });
-    it("should only match the matching parts in the beginning", () => {
+    it("should return the two first items when they match", () => {
+      const result = largestCommonArray([
+        ["dir", "stuff", "baz"],
+        ["dir", "stuff"],
+      ]);
+      expect(result).toEqual(["dir", "stuff"]);
+    });
+    it("should only return the first when the first matches", () => {
       const result = largestCommonArray([["dir", "stuff"], ["dir", "baz"]]);
       expect(result).toEqual(["dir"]);
     });
-    it("should not match anything when first is different", () => {
+    it("should return an empty array when first item is different", () => {
       const result = largestCommonArray([["dir", "stuff"], ["dir2", "stuff"]]);
       expect(result).toEqual([]);
     });

--- a/packages/unmock-jest/src/__tests__/utils.test.ts
+++ b/packages/unmock-jest/src/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { ITestSuite } from "../reporter/types";
 import { largestCommonArray, sortTestSuites } from "../reporter/utils";
 
 const testSuite1: ITestSuite = {
+  shortFilePath: "blah",
   testFilePath: "blah",
   suiteResults: {
     numFailingTests: 3,
@@ -11,6 +12,7 @@ const testSuite1: ITestSuite = {
 };
 
 const testSuite2: ITestSuite = {
+  shortFilePath: "blah2",
   testFilePath: "blah2",
   suiteResults: {
     numFailingTests: 2,
@@ -19,6 +21,7 @@ const testSuite2: ITestSuite = {
 };
 
 const testSuite3: ITestSuite = {
+  shortFilePath: "blah3",
   testFilePath: "blah3",
   suiteResults: {
     numFailingTests: 2,

--- a/packages/unmock-jest/src/__tests__/utils.test.ts
+++ b/packages/unmock-jest/src/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { ISnapshot } from "unmock";
 import { ITestSuite } from "../reporter/types";
-import { sortTestSuites } from "../reporter/utils";
+import { longestCommonPath, sortTestSuites } from "../reporter/utils";
 
 const testSuite1: ITestSuite = {
   testFilePath: "blah",
@@ -47,6 +47,24 @@ describe("Reporter utils", () => {
         testSuite3,
         testSuite2,
       ]);
+    });
+  });
+  describe("Finding longest common path", () => {
+    it("should match everything when only single array given", () => {
+      const result = longestCommonPath([["dir", "stuff"]]);
+      expect(result).toEqual(["dir", "stuff"]);
+    });
+    it("should match everything when the paths match", () => {
+      const result = longestCommonPath([["dir", "stuff"], ["dir", "stuff"]]);
+      expect(result).toEqual(["dir", "stuff"]);
+    });
+    it("should only match the matching parts in the beginning", () => {
+      const result = longestCommonPath([["dir", "stuff"], ["dir", "baz"]]);
+      expect(result).toEqual(["dir"]);
+    });
+    it("should not match anything when first is different", () => {
+      const result = longestCommonPath([["dir", "stuff"], ["dir2", "stuff"]]);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/unmock-jest/src/__tests__/utils.test.ts
+++ b/packages/unmock-jest/src/__tests__/utils.test.ts
@@ -61,6 +61,10 @@ describe("Reporter utils", () => {
       const result = largestCommonArray([["dir", "stuff"], ["dir", "stuff"]]);
       expect(result).toEqual(["dir", "stuff"]);
     });
+    it("should return empty array when one of the arrays is empty", () => {
+      const result = largestCommonArray([[], ["dir", "stuff"]]);
+      expect(result).toEqual([]);
+    });
     it("should return the two first items when they match", () => {
       const result = largestCommonArray([
         ["dir", "stuff", "baz"],

--- a/packages/unmock-jest/src/__tests__/utils.test.ts
+++ b/packages/unmock-jest/src/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { ISnapshot } from "unmock";
 import { ITestSuite } from "../reporter/types";
-import { longestCommonPath, sortTestSuites } from "../reporter/utils";
+import { largestCommonArray, sortTestSuites } from "../reporter/utils";
 
 const testSuite1: ITestSuite = {
   testFilePath: "blah",
@@ -51,19 +51,19 @@ describe("Reporter utils", () => {
   });
   describe("Finding longest common path", () => {
     it("should match everything when only single array given", () => {
-      const result = longestCommonPath([["dir", "stuff"]]);
+      const result = largestCommonArray([["dir", "stuff"]]);
       expect(result).toEqual(["dir", "stuff"]);
     });
     it("should match everything when the paths match", () => {
-      const result = longestCommonPath([["dir", "stuff"], ["dir", "stuff"]]);
+      const result = largestCommonArray([["dir", "stuff"], ["dir", "stuff"]]);
       expect(result).toEqual(["dir", "stuff"]);
     });
     it("should only match the matching parts in the beginning", () => {
-      const result = longestCommonPath([["dir", "stuff"], ["dir", "baz"]]);
+      const result = largestCommonArray([["dir", "stuff"], ["dir", "baz"]]);
       expect(result).toEqual(["dir"]);
     });
     it("should not match anything when first is different", () => {
-      const result = longestCommonPath([["dir", "stuff"], ["dir2", "stuff"]]);
+      const result = largestCommonArray([["dir", "stuff"], ["dir2", "stuff"]]);
       expect(result).toEqual([]);
     });
   });

--- a/packages/unmock-jest/src/reporter/components/test-suite.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suite.tsx
@@ -8,7 +8,7 @@ const Summary = ({ testSuite }: { testSuite: ITestSuite }) => {
     const nSnapshots = testSuite.snapshots.length;
     return (<div className="test-suite__title">
         <div className="test-suite__title-filename">
-            {testSuite.testFilePath}
+            {testSuite.shortFilePath}
         </div>
         <div className="test-suite__title-summary">
             {`Passing: ${numPassingTests}, failing: ${numFailingTests}, HTTP calls: ${nSnapshots}`}

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -31,7 +31,7 @@ const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () 
         return {
             input: <input type="radio" id={`box-${id}`} className="test-suite-input" name="content" defaultChecked={index === 0} value={`box-${id}`} key={`input-${id}`} />,
             label: <label htmlFor={`box-${id}`} className={`test-suite-label test-suite-label-${id} ${testSuiteLabelColor}`} id="feature-label" key={`label-${id}`}>
-                <span className="test-suite-label__filename">{testSuite.testFilePath}</span>
+                <span className="test-suite-label__filename">{testSuite.shortFilePath}</span>
                 <span className="test-suite-label__summary">{`Passing: ${numPassingTests}, failing: ${numFailingTests}, HTTP calls: ${nSnapshots}`}</span>
             </label>,
             testSuite: <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} /></div>,

--- a/packages/unmock-jest/src/reporter/types.ts
+++ b/packages/unmock-jest/src/reporter/types.ts
@@ -13,6 +13,7 @@ export interface IReportInput {
  * Represents the results for a given **test file**
  */
 export interface ITestSuite {
+  shortFilePath: string;
   testFilePath: string;
   suiteResults: jest.TestResult;
   snapshots: ISnapshot[];

--- a/packages/unmock-jest/src/reporter/utils.ts
+++ b/packages/unmock-jest/src/reporter/utils.ts
@@ -1,4 +1,5 @@
 import { groupBy, map, mapValues, reverse, sortBy } from "lodash";
+import * as path from "path";
 import { IReportInput, ITestSuite } from "./types";
 
 export const sortTestSuites = (testSuites: ITestSuite[]): ITestSuite[] => {
@@ -8,6 +9,36 @@ export const sortTestSuites = (testSuites: ITestSuite[]): ITestSuite[] => {
       testSuite => testSuite.snapshots.length,
     ]),
   );
+};
+
+export const longestCommonString = (strings: string[]): string => {
+  return strings.reduce((acc, val) => {
+    let longest = "";
+    for (let i = 0; i < acc.length; i++) {
+      const tried = acc.substring(0, i);
+      if (val.startsWith(tried)) {
+        longest = tried;
+        continue;
+      } else {
+        break;
+      }
+    }
+    return longest;
+  });
+};
+
+export const longestCommonPath = (paths: string[][]): string[] => {
+  return paths.reduce((acc, val) => {
+    let commonItems = 0;
+    for (let i = 0; i < acc.length; i++) {
+      if (acc[i] === val[i]) {
+        commonItems = i + 1;
+      } else {
+        break;
+      }
+    }
+    return acc.slice(0, commonItems);
+  });
 };
 
 export const toTestSuites = (input: IReportInput): ITestSuite[] => {
@@ -32,8 +63,14 @@ export const toTestSuites = (input: IReportInput): ITestSuite[] => {
     snapshot => snapshot.testPath,
   );
 
+  const paths = input.jestData.aggregatedResult.testResults.map(testResult =>
+    path.dirname(testResult.testFilePath).split(path.sep),
+  );
+
+  const longestPath = longestCommonPath(paths).join(path.sep);
+
   const combined = map(testResultByFilePath, (value, filepath) => ({
-    testFilePath: value.testFilePath,
+    testFilePath: value.testFilePath.replace(longestPath, ""),
     suiteResults: value,
     snapshots: snapshotsByFilePath[filepath] || [],
   }));

--- a/packages/unmock-jest/src/reporter/utils.ts
+++ b/packages/unmock-jest/src/reporter/utils.ts
@@ -70,7 +70,8 @@ export const toTestSuites = (input: IReportInput): ITestSuite[] => {
   const longestPath = largestCommonArray(paths).join(path.sep) + path.sep;
 
   const combined = map(testResultByFilePath, (value, filepath) => ({
-    testFilePath: value.testFilePath.replace(longestPath, ""),
+    shortFilePath: value.testFilePath.replace(longestPath, ""),
+    testFilePath: value.testFilePath,
     suiteResults: value,
     snapshots: snapshotsByFilePath[filepath] || [],
   }));

--- a/packages/unmock-jest/src/reporter/utils.ts
+++ b/packages/unmock-jest/src/reporter/utils.ts
@@ -34,9 +34,7 @@ const largestCommonArray2 = <T>(arr1: T[], arr2: T[]): T[] => {
  * @return Longest array that all arrays start with
  */
 export const largestCommonArray = <T>(arrays: T[][]): T[] => {
-  return arrays.reduce((acc, val) => {
-    return largestCommonArray2(acc, val);
-  });
+  return arrays.reduce((acc, val) => largestCommonArray2(acc, val));
 };
 
 export const toTestSuites = (input: IReportInput): ITestSuite[] => {

--- a/packages/unmock-jest/src/reporter/utils.ts
+++ b/packages/unmock-jest/src/reporter/utils.ts
@@ -11,24 +11,17 @@ export const sortTestSuites = (testSuites: ITestSuite[]): ITestSuite[] => {
   );
 };
 
-export const longestCommonString = (strings: string[]): string => {
-  return strings.reduce((acc, val) => {
-    let longest = "";
-    for (let i = 0; i < acc.length; i++) {
-      const tried = acc.substring(0, i);
-      if (val.startsWith(tried)) {
-        longest = tried;
-        continue;
-      } else {
-        break;
-      }
-    }
-    return longest;
-  });
-};
-
-export const longestCommonPath = (paths: string[][]): string[] => {
-  return paths.reduce((acc, val) => {
+/**
+ * Find the longest common items for a list of arrays
+ * Examples:
+ * [["a", "b"], ["a", "c"]] => ["a"]
+ * [["a", "b"], ["a", "b"]] => ["a", "b"]
+ * [["a", "c"], ["b", "c"]] => []
+ * @param arrays List of arrays
+ * @return Longest array that all arrays start with
+ */
+export const largestCommonArray = <T>(arrays: T[][]): T[] => {
+  return arrays.reduce((acc, val) => {
     let commonItems = 0;
     for (let i = 0; i < acc.length; i++) {
       if (acc[i] === val[i]) {
@@ -67,7 +60,7 @@ export const toTestSuites = (input: IReportInput): ITestSuite[] => {
     path.dirname(testResult.testFilePath).split(path.sep),
   );
 
-  const longestPath = longestCommonPath(paths).join(path.sep);
+  const longestPath = largestCommonArray(paths).join(path.sep);
 
   const combined = map(testResultByFilePath, (value, filepath) => ({
     testFilePath: value.testFilePath.replace(longestPath, ""),


### PR DESCRIPTION
Add `shortFilePath` to `ITestSuite` interface, created by looking for the longest common directory common to all tests and stripping that from the file path.

Looks like this
<img width="1410" alt="Screenshot 2019-09-20 at 16 02 14" src="https://user-images.githubusercontent.com/11660974/65328893-0a07d500-dbc0-11e9-8ae0-f028ecc3da03.png">
