### PR TITLE
Accept an array as path for nock-syntax, support regex (named and unnamed).

### DIFF
--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -228,4 +228,77 @@ describe("Tests dynamic path tests", () => {
       expectNServices(3);
     });
   });
+
+  describe("Paths can be defined using arrays and regexs", () => {
+    it("An empty array of strings is equal to root path", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get([])
+        .reply(200);
+      expectNServices(1);
+      expect(Object.keys(getPrivateSchema("foo").paths)).toEqual(["/"]);
+    });
+
+    it("An array of strings is equal to the string of its parts", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get(["foo", "foo", "foo"])
+        .reply(200);
+      expectNServices(1);
+      expect(Object.keys(getPrivateSchema("foo").paths)).toEqual([
+        "/foo/foo/foo",
+      ]);
+    });
+
+    it("A simple regex is added as a parameter with randomly generated name", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get(["foo", /\W+/, "bar"])
+        .reply(200);
+      expectNServices(1);
+      const schema = getPrivateSchema("foo");
+      expect(Object.keys(schema.paths).length).toEqual(1);
+      const path = Object.keys(schema.paths)[0];
+      expect(path).toMatch(/^\/foo\/\{[^}]+\}\/bar/);
+      expect(schema.paths[path].parameters.length).toEqual(1);
+      expect(path).toContain(schema.paths[path].parameters[0].name);
+      expect(schema.paths[path].parameters[0].schema.pattern).toEqual("/\\W+/");
+    });
+
+    it("A regex is added as a parameter given name", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get(["foo", ["baz", /\W+/], "bar"])
+        .reply(200);
+      expectNServices(1);
+      const schema = getPrivateSchema("foo");
+      expect(Object.keys(schema.paths).length).toEqual(1);
+      const path = Object.keys(schema.paths)[0];
+      expect(path).toEqual("/foo/{baz}/bar");
+      expect(schema.paths[path].parameters.length).toEqual(1);
+      expect(schema.paths[path].parameters[0].schema.pattern).toEqual("/\\W+/");
+    });
+
+    it("Also handles multiple parameters", () => {
+      expectNServices(0);
+      unmock
+        .nock("https://www.foo.com", "foo")
+        .get(["foo", ["baz", /\W+/], "bar", /\d+/, ["spam", /eggs/]])
+        .reply(200);
+      expectNServices(1);
+      const schema = getPrivateSchema("foo");
+      expect(Object.keys(schema.paths).length).toEqual(1);
+      const path = Object.keys(schema.paths)[0];
+      expect(path).toMatch(/\/foo\/{baz}\/bar\/{\w+}\/{spam}/);
+      const params = schema.paths[path].parameters;
+      expect(params.length).toEqual(3);
+      expect(params[0].schema.pattern).toEqual("/\\W+/");
+      expect(params[1].schema.pattern).toEqual("/\\d+/");
+      expect(params[2].schema.pattern).toEqual("/eggs/");
+    });
+  });
 });

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -109,7 +109,7 @@ const maybeAddStringSchema = (
 ): Array<Reference | Schema> => (s.length === 0 ? [{ type: "string" }] : s);
 
 const discernName = (o: Option<Parameter>, n: string): Option<Parameter> =>
-  isNone(o) ? o : o.value.name === n && o.value.in === "path" ? o : none;
+  isNone(o) || (o.value.name === n && o.value.in === "path") ? o : none;
 
 const internalGetParameter = (
   t: Traversal<PathItem, Reference | Parameter>,
@@ -190,18 +190,15 @@ const pathParameterMatch = (
     i =>
       jsonschema.validate(part, {
         ...i,
-        definitions:
-          oas.components && oas.components.schemas
-            ? Object.entries(oas.components.schemas).reduce(
-                (a, b) => ({
-                  ...a,
-                  [b[0]]: isReference(b[1])
-                    ? changeRef(b[1])
-                    : changeRefs(b[1]),
-                }),
-                {},
-              )
-            : {},
+        definitions: Object.entries(
+          (oas.components && oas.components.schemas) || {},
+        ).reduce(
+          (a, b) => ({
+            ...a,
+            [b[0]]: isReference(b[1]) ? changeRef(b[1]) : changeRefs(b[1]),
+          }),
+          {},
+        ),
       }).valid,
   ).length > 0;
 
@@ -387,9 +384,9 @@ export const truncatePath = (
 /**
  * A matcher that takes a request and a dictionary of
  * openAPI schema and returns a dictionary containing
- * *only* the schmea with *only* the path item and *only*
+ * *only* the schema with *only* the path item and *only*
  * the method corresponding to the request. This will be
- * and empty dictionary if the schema does not exist,
+ * an empty dictionary if the schema does not exist,
  * empty PathItems if the path does not exist, and
  * empty operations if the method does not exist.
  * @param req The request

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -202,6 +202,8 @@ const pathParameterMatch = (
       }).valid,
   ).length > 0;
 
+const pathParamRegex = new RegExp(/^\{[^}]+\}/gi);
+
 export const matchesInternal = (
   path: string[],
   pathItemKey: string[],
@@ -213,9 +215,8 @@ export const matchesInternal = (
   path.length === pathItemKey.length &&
   (path.length === 0 || // terminal condition
     ((path[0] === pathItemKey[0] || // either they are equal, or...
-      /* is wild card, ie {} */ (pathItemKey[0].length > 2 &&
-        pathItemKey[0][0] === "{" &&
-        pathItemKey[0].slice(-1) === "}" &&
+      /* is wild card, ie {} */
+      (pathItemKey[0].match(pathParamRegex) !== null &&
         pathParameterMatch(
           path[0],
           pathItemKey[0].slice(1, -1),
@@ -612,7 +613,7 @@ export function responseCreatorFactory({
       // first transformer is the matcher
       matcher,
       // subsequent developer-defined transformers
-      ...Object.entries(store.cores).map(([_, core]) =>
+      ...Object.values(store.cores).map(core =>
         hoistTransformer(core.transformer),
       ),
     ];

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -17,7 +17,7 @@ import {
 } from "json-schema-strictly-typed";
 import NodeBackend from "./backend";
 import { CodeAsInt, HTTPMethod } from "./interfaces";
-import { Schema } from "./service/interfaces";
+import { Schema, ValidEndpointType } from "./service/interfaces";
 import { ServiceStore } from "./service/serviceStore";
 
 /*************************************************
@@ -190,7 +190,7 @@ type InputToPoet = { [k: string]: any } | Primitives | Primitives[];
 
 // How the fluent dynamic service API looks like (e.g. specifies `get(endpoint: string) => DynamicServiceSpec`)
 type FluentDynamicService = {
-  [k in HTTPMethod]: (endpoint: string) => DynamicServiceSpec;
+  [k in HTTPMethod]: (endpoint: ValidEndpointType) => DynamicServiceSpec;
 };
 
 // How the actual dynamic service spec looks like (e.g. `reply(statusCode: number, data: InputToPoet): ...`)
@@ -209,8 +209,6 @@ interface IDynamicServiceSpec {
     data: InputToPoet | InputToPoet[],
   ): FluentDynamicService & IDynamicServiceSpec;
 }
-
-type ValidEndpointType = string | Array<string | RegExp>;
 
 export class DynamicServiceSpec implements IDynamicServiceSpec {
   private data: Schema = {};
@@ -272,16 +270,14 @@ const updateStore = (
   statusCode: CodeAsInt | "default";
   data: Schema;
 }) =>
-  Array.isArray(endpoint)
-    ? store
-    : store.updateOrAdd({
-        baseUrl,
-        method,
-        endpoint: endpoint.startsWith("/") ? endpoint : `/${endpoint}`,
-        statusCode,
-        response: data,
-        name,
-      });
+  store.updateOrAdd({
+    baseUrl,
+    method,
+    endpoint,
+    statusCode,
+    response: data,
+    name,
+  });
 
 const buildFluentNock = (
   store: ServiceStore,

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -33,10 +33,13 @@ export interface IService {
 export type ServiceStoreType = Record<string, IService>;
 
 // Used to programmatically define/update a service
+export type ValidEndpointType =
+  | string
+  | Array<string | RegExp | [string, RegExp]>;
 export interface IObjectToService {
   baseUrl: string;
   method?: HTTPMethod;
-  endpoint?: string;
+  endpoint?: ValidEndpointType;
   statusCode?: CodeAsInt | "default";
   response?: string | Schema;
   name?: string;

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -32,25 +32,25 @@ export class ServiceCore implements IServiceCore {
     // Create a new endpoint from array if needed
     const endpointParameters = {
       parameters: Array.isArray(endpoint)
-        ? endpoint
-            .filter(e => typeof e !== "string")
-            .map(e => ({
-              in: "path",
-              required: true,
-              ...(e instanceof RegExp
-                ? {
-                    name: Math.random()
-                      .toString(36)
-                      .substring(2),
-                    schema: { pattern: e.toString() },
-                  }
-                : {
-                    name: e[0],
-                    schema: {
-                      pattern: e[1].toString(),
-                    },
-                  }),
-            }))
+        ? (endpoint.filter(e => typeof e !== "string") as Array<
+            RegExp | [string, RegExp]
+          >).map(e => ({
+            in: "path",
+            required: true,
+            ...(e instanceof RegExp
+              ? {
+                  name: Math.random()
+                    .toString(36)
+                    .substring(2),
+                  schema: { pattern: e },
+                }
+              : {
+                  name: e[0],
+                  schema: {
+                    pattern: e[1],
+                  },
+                }),
+          }))
         : [],
     };
     const newEndpoint = Array.isArray(endpoint)
@@ -62,9 +62,8 @@ export class ServiceCore implements IServiceCore {
                 : `{${endpointParameters.parameters
                     .filter(a =>
                       Array.isArray(e)
-                        ? a.name === e[0] &&
-                          a.schema.pattern === e[1].toString()
-                        : a.schema.pattern === e.toString(),
+                        ? a.name === e[0] && a.schema.pattern === e[1]
+                        : a.schema.pattern === e,
                     )
                     .map(a => a.name)
                     .shift()}}`, // otherwise get the next element from endpointParameters

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -29,10 +29,60 @@ export class ServiceCore implements IServiceCore {
     const mediaType =
       typeof response === "string" ? "text/*" : "application/json";
     // TODO: Decouple from ServiceCore :( - this is nasty
+    // Create a new endpoint from array if needed
+    const endpointParameters = {
+      parameters: Array.isArray(endpoint)
+        ? endpoint
+            .filter(e => typeof e !== "string")
+            .map(e => ({
+              in: "path",
+              required: true,
+              ...(e instanceof RegExp
+                ? {
+                    name: Math.random()
+                      .toString(36)
+                      .substring(2),
+                    schema: { pattern: e.toString() },
+                  }
+                : {
+                    name: e[0],
+                    schema: {
+                      pattern: e[1].toString(),
+                    },
+                  }),
+            }))
+        : [],
+    };
+    const newEndpoint = Array.isArray(endpoint)
+      ? endpoint
+          .map(
+            e =>
+              typeof e === "string"
+                ? e /* string - literal part of the path */
+                : `{${endpointParameters.parameters
+                    .filter(a =>
+                      Array.isArray(e)
+                        ? a.name === e[0] &&
+                          a.schema.pattern === e[1].toString()
+                        : a.schema.pattern === e.toString(),
+                    )
+                    .map(a => a.name)
+                    .shift()}}`, // otherwise get the next element from endpointParameters
+          )
+          .join("/")
+      : endpoint;
+    const finalEndpoint =
+      newEndpoint === undefined || newEndpoint.startsWith("/")
+        ? newEndpoint
+        : `/${newEndpoint}`; /* Prepend leading / if needed */
+
     const newPath: PathItem =
-      endpoint !== undefined && method !== undefined && statusCode !== undefined
+      finalEndpoint !== undefined &&
+      method !== undefined &&
+      statusCode !== undefined
         ? {
-            [endpoint]: {
+            [finalEndpoint]: {
+              ...endpointParameters,
               [method]: {
                 responses: {
                   [statusCode]: {


### PR DESCRIPTION
Resolves #252.
Was also going over `generator.ts` and to get hands-on experience I changed small stuff there.

Todo for future:
- [ ] Support wildcards?
- [ ] Update state to include specialization for paths with parameters, where the parameter is noted. Similarly, support for wildcards (`?`, `*`, `**`).