### PR TITLE
Write snapshots to user home directory.

### DIFF
--- a/packages/unmock-core/src/loggers/snapshotter/index.ts
+++ b/packages/unmock-core/src/loggers/snapshotter/index.ts
@@ -2,7 +2,8 @@ import debug from "debug";
 import * as expect from "expect";
 import * as fs from "fs";
 import { merge } from "lodash";
-import { tmpdir as osTmpdir } from "os";
+import * as mkdirp from "mkdirp";
+import { homedir } from "os";
 import { resolve as pathResolve } from "path";
 import { IListener, IListenerInput } from "../../interfaces";
 import { unmockSnapshot } from "./expect-extend";
@@ -19,8 +20,9 @@ export interface IFsSnapshotterOptions {
 }
 
 export const DEFAULT_SNAPSHOT_DIRECTORY = pathResolve(
-  osTmpdir(), // TODO Resolve if symlink?
+  homedir(),
   ".unmock",
+  "snapshots",
 );
 
 const DEFAULT_OPTIONS: IFsSnapshotterOptions = {
@@ -38,7 +40,7 @@ export const resolveOptions = (
 const ensureDirExists = (directory: string) => {
   if (!fs.existsSync(directory)) {
     debugLog(`Creating snapshot directory: ${directory}`);
-    return fs.mkdirSync(directory); // TODO Catch
+    return mkdirp.sync(directory);
   }
 
   if (!fs.lstatSync(directory).isDirectory()) {


### PR DESCRIPTION
- Writing to `os.tmpdir()` is not safe in shared machines: the test files could contain sensitive information and anyone using the machine could access them. There's also a risk that the files are accidentally shared between multiple users.
- ▶️  Write to `os.homedir()/.unmock/snapshots` instead. In that folder, a folder with random name is created for every new instance of `SnapshotWriterReader` to avoid sync issues with multiple processes. Alternative would be to use [lockfile](https://www.npmjs.com/package/lockfile).
- Instead of home directory, we could also write to e.g. `__unmock__/snapshots` in the application directory. That would require that users add the snapshot folder to `.gitignore`.
- Also see [this question](https://softwareengineering.stackexchange.com/questions/398812/is-it-safe-to-store-application-files-to-users-temp-directory)