### PR TITLE
Fix bug in Jest reporter.

### DIFF
--- a/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
+++ b/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
@@ -6,7 +6,7 @@ describe("Test suites component", () => {
             expect(testFileToId(`C:\\\\Windows\\Users\\Meeshkan`)).toBe("C--Windows-Users-Meeshkan");
         });
         it("should change unix path to proper id", () => {
-            expect(testFileToId("/unix/path/dir")).toBe("-unix-path-dir");
+            expect(testFileToId("/unix/path/dir/file.txt")).toBe("-unix-path-dir-file-txt");
         });
     });
 });

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -4,7 +4,7 @@ import { ITestSuite } from "../types";
 import TestSuite from "./test-suite";
 
 // Replace file path separator chars with a dash
-export const testFileToId = (file: string) => file.replace(/(\/|\\(\\)?|:)/g, "-");
+export const testFileToId = (file: string) => file.replace(/(\/|\\(\\)?|:|\.)/g, "-");
 
 /**
  * Not actually a React component but something that returns dynamically generated CSS and a React component


### PR DESCRIPTION
- Dot in filename causes trouble when a CSS class is generated from the filename (dot is a selector in CSS)