### PR TITLE
Use short file path in generating test suite element IDs.

### DIFF
--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -13,7 +13,7 @@ export const testFileToId = (file: string) => file.replace(/(\/|\\(\\)?|:|\.)/g,
 const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
 
     const elementsAndCss = testSuites.map((testSuite, index) => {
-        const id = testFileToId(testSuite.testFilePath);
+        const id = testFileToId(testSuite.shortFilePath);
         const elementCss = `#box-${id}:checked~.test-suite-label-${id} {
     opacity: 1;
     }


### PR DESCRIPTION
Do not use full paths (`/root/git/user/app/test/basic.test.ts`) for generating IDs for test suites but the short file paths (`app/test/basic.test.ts`). In this way, the generated HTML should not depend on the machine where the report is generated.

(Element IDs are used to target specific elements to, for example, switch between them using CSS `checked` selector).