### PR TITLE
Reorganize reporter view, add more tests to reporter

### DIFF
--- a/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
+++ b/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
@@ -33,21 +33,29 @@ describe("Test suites component", () => {
             const fieldset = dom.window.document.querySelector("fieldset");
             expect(fieldset).toBeInTheDocument();
         });
+        it("should have two inputs", () => {
+            const inputs = dom.window.document.querySelectorAll("input");
+            expect(inputs).toHaveLength(2);
+        });
+        it("should have input with expected id", () => {
+            const inputElement = dom.window.document.querySelector("input#box-dsl-test-ts");
+            expect(inputElement).toBeDefined();
+        });
         it("should have two labels", () => {
             const labels = dom.window.document.querySelectorAll("label");
             expect(labels).toHaveLength(2);
         });
         it("rendered component should have label with expected class", () => {
-            const label = dom.window.document.querySelector("label .test-suite-label-dsl-test-ts");
-            expect(label).toBeDefined();
+            const label = dom.window.document.querySelector("label.test-suite-label-dsl-test-ts");
+            expect(label).not.toBeNull();
         });
         it("should have two divs for test suite results", () => {
             const divs = dom.window.document.querySelectorAll("div .test-suite");
             expect(divs).toHaveLength(2);
         });
         it("should have div with expected class", () => {
-            const div = dom.window.document.querySelector("div .test-suite-dsl-test-ts");
-            expect(div).toBeDefined();
+            const div = dom.window.document.querySelector("div.test-suite-dsl-test-ts");
+            expect(div).not.toBeNull();
         });
     });
 });

--- a/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
+++ b/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
@@ -3,15 +3,27 @@ import { JSDOM } from "jsdom";
 import * as React from "react";
 import * as ReactDomServer from "react-dom/server";
 import TestSuites, { testFileToId } from "../../reporter/components/test-suites";
+import stylesheet from "../../reporter/stylesheet";
 import { ITestSuite } from "../../reporter/types";
 import { toTestSuites } from "../../reporter/utils";
 import { readJson } from "../utils";
+
 const jestResults = readJson("resources/jest-results.json");
 const unmockSnapshots = readJson("resources/unmock-snapshots.json");
 
 const input = {
     jestData: { aggregatedResult: jestResults },
     snapshots: unmockSnapshots,
+};
+
+const renderTestSuites = () => {
+    const testSuites: ITestSuite[] = toTestSuites(input);
+    const [css, TestSuitesComponent] = TestSuites({testSuites });
+    const element = ReactDomServer.renderToStaticMarkup(<TestSuitesComponent />);
+    // Small hack to include stylesheets in the DOM
+    const html = `<!DOCTYPE html><html><head><style>${stylesheet}</style><style>${css}</style></head><body>${element}</body></html>`;
+    const dom = new JSDOM(html);
+    return dom;
 };
 
 describe("Test suites component", () => {
@@ -25,10 +37,7 @@ describe("Test suites component", () => {
     });
 
     describe("rendered component", () => {
-        const testSuites: ITestSuite[] = toTestSuites(input);
-        const [, TestSuitesComponent] = TestSuites({testSuites });
-        const element = ReactDomServer.renderToStaticMarkup(<TestSuitesComponent />);
-        const dom = new JSDOM(element);
+        const dom = renderTestSuites();
         it("should have fieldset", () => {
             const fieldset = dom.window.document.querySelector("fieldset");
             expect(fieldset).toBeInTheDocument();
@@ -45,9 +54,20 @@ describe("Test suites component", () => {
             const labels = dom.window.document.querySelectorAll("label");
             expect(labels).toHaveLength(2);
         });
-        it("rendered component should have label with expected class", () => {
+        it("should have label with expected class", () => {
             const label = dom.window.document.querySelector("label.test-suite-label-dsl-test-ts");
             expect(label).not.toBeNull();
+        });
+        it("should have label with expected opacities", () => {
+            /**
+             * These tests break easily but they're there to check that the radio checker works!
+             */
+            const label = dom.window.document.querySelector("label.test-suite-label-dsl-test-ts");
+            expect(label).not.toBeNull();
+            expect(label).toHaveStyle("opacity: 1");
+            const label2 = dom.window.document.querySelector("label.test-suite-label-basic-test-ts");
+            expect(label2).not.toBeNull();
+            expect(label2).toHaveStyle("opacity: 0.7");
         });
         it("should have two divs for test suite results", () => {
             const divs = dom.window.document.querySelectorAll("div .test-suite");

--- a/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
+++ b/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
@@ -1,4 +1,15 @@
-import { testFileToId } from "../../reporter/components/test-suites";
+import TestSuites, { testFileToId } from "../../reporter/components/test-suites";
+import { ITestSuite } from "../../reporter/types";
+import { toTestSuites } from "../../reporter/utils";
+import { readJson } from "../utils";
+
+const jestResults = readJson("resources/jest-results.json");
+const unmockSnapshots = readJson("resources/unmock-snapshots.json");
+
+const input = {
+    jestData: { aggregatedResult: jestResults },
+    snapshots: unmockSnapshots,
+};
 
 describe("Test suites component", () => {
     describe("turning file path into id", () => {
@@ -7,6 +18,14 @@ describe("Test suites component", () => {
         });
         it("should change unix path to proper id", () => {
             expect(testFileToId("/unix/path/dir/file.txt")).toBe("-unix-path-dir-file-txt");
+        });
+    });
+
+    describe("rendering", () => {
+        const testSuites: ITestSuite[] = toTestSuites(input);
+        it("example test", () => {
+            const [css, TestSuitesComponent] = TestSuites({testSuites });
+            expect(testSuites).toHaveLength(2);
         });
     });
 });

--- a/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
+++ b/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
@@ -1,8 +1,11 @@
+import "@testing-library/jest-dom/extend-expect";
+import { JSDOM } from "jsdom";
+import * as React from "react";
+import * as ReactDomServer from "react-dom/server";
 import TestSuites, { testFileToId } from "../../reporter/components/test-suites";
 import { ITestSuite } from "../../reporter/types";
 import { toTestSuites } from "../../reporter/utils";
 import { readJson } from "../utils";
-
 const jestResults = readJson("resources/jest-results.json");
 const unmockSnapshots = readJson("resources/unmock-snapshots.json");
 
@@ -21,11 +24,30 @@ describe("Test suites component", () => {
         });
     });
 
-    describe("rendering", () => {
+    describe("rendered component", () => {
         const testSuites: ITestSuite[] = toTestSuites(input);
-        it("example test", () => {
-            const [css, TestSuitesComponent] = TestSuites({testSuites });
-            expect(testSuites).toHaveLength(2);
+        const [, TestSuitesComponent] = TestSuites({testSuites });
+        const element = ReactDomServer.renderToStaticMarkup(<TestSuitesComponent />);
+        const dom = new JSDOM(element);
+        it("should have fieldset", () => {
+            const fieldset = dom.window.document.querySelector("fieldset");
+            expect(fieldset).toBeInTheDocument();
+        });
+        it("should have two labels", () => {
+            const labels = dom.window.document.querySelectorAll("label");
+            expect(labels).toHaveLength(2);
+        });
+        it("rendered component should have label with expected class", () => {
+            const label = dom.window.document.querySelector("label .test-suite-label-dsl-test-ts");
+            expect(label).toBeDefined();
+        });
+        it("should have two divs for test suite results", () => {
+            const divs = dom.window.document.querySelectorAll("div .test-suite");
+            expect(divs).toHaveLength(2);
+        });
+        it("should have div with expected class", () => {
+            const div = dom.window.document.querySelector("div .test-suite-dsl-test-ts");
+            expect(div).toBeDefined();
         });
     });
 });

--- a/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
+++ b/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
@@ -73,9 +73,14 @@ describe("Test suites component", () => {
             const divs = dom.window.document.querySelectorAll("div .test-suite");
             expect(divs).toHaveLength(2);
         });
-        it("should have div with expected class", () => {
+        it("should have first div with expected class and it be visible", () => {
             const div = dom.window.document.querySelector("div.test-suite-dsl-test-ts");
             expect(div).not.toBeNull();
+            expect(div).toHaveStyle("display: block");
+        });
+        it("should have as second div a hidden block", () => {
+            const div = dom.window.document.querySelector("div.test-suite-basic-test-ts");
+            expect(div).toHaveStyle("display: none");
         });
     });
 });

--- a/packages/unmock-jest/src/__tests__/create-report.test.ts
+++ b/packages/unmock-jest/src/__tests__/create-report.test.ts
@@ -1,19 +1,10 @@
-// Matchers from jest-dom
 import "@testing-library/jest-dom/extend-expect";
-import * as fs from "fs";
 import { JSDOM } from "jsdom";
 import * as path from "path";
 import createReport from "../reporter/create-report";
 import { writeToDirectory } from "../reporter/write-report";
 import { exampleInput } from "./fake-data";
-
-const readJson = (pathToJson: string): any => {
-  const fullpath = path.isAbsolute(pathToJson)
-    ? pathToJson
-    : path.resolve(__dirname, pathToJson);
-  const fileContents = fs.readFileSync(fullpath, { encoding: "utf-8" });
-  return JSON.parse(fileContents);
-};
+import { readJson } from "./utils";
 
 const jestResults = readJson("resources/jest-results.json");
 const unmockSnapshots = readJson("resources/unmock-snapshots.json");

--- a/packages/unmock-jest/src/__tests__/utils.ts
+++ b/packages/unmock-jest/src/__tests__/utils.ts
@@ -1,0 +1,10 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export const readJson = (pathToJson: string): any => {
+  const fullpath = path.isAbsolute(pathToJson)
+    ? pathToJson
+    : path.resolve(__dirname, pathToJson);
+  const fileContents = fs.readFileSync(fullpath, { encoding: "utf-8" });
+  return JSON.parse(fileContents);
+};

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -165,7 +165,7 @@ body {
 .test-suite-label {
   display: inline-block;
   border-radius: 2rem;
-  padding: 1rem 2rem;
+  padding: 0.5rem 2rem;
   margin: 1rem;
   font-size: 2rem;
   opacity: 0.7;
@@ -177,7 +177,10 @@ body {
 }
 
 .test-suite-label__summary {
+  font-size: 0.75em;
   float: right;
+  /* Translate down as much as the smaller font-size requires */
+  transform: translateY(25%);
 }
 
 .test-suite-label--success {

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -37,11 +37,6 @@ body {
   text-align: center;
 }
 
-.test-suite {
-  padding: 1rem;
-  margin-top: 3rem;
-}
-
 .test-suite__title {
   background-color: #eee;
   display: flex;
@@ -162,15 +157,19 @@ body {
 .test-suite {
   display: none;
   padding: 2rem;
+  flex: 1 0 100%;
+  padding: 1rem;
+  margin-top: 1rem;
 }
 
 .test-suite-label {
   display: inline-block;
   border-radius: 2rem;
   padding: 1rem 2rem;
-  margin-bottom: 1rem;
+  margin: 1rem;
   font-size: 2rem;
   opacity: 0.7;
+  flex: 1 1 auto;
 }
 
 .test-suite-label__filename {
@@ -191,7 +190,8 @@ body {
 
 .test-results-container {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   padding: 1rem;
 }
 

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -172,14 +172,13 @@ body {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .test-suite-label__filename {}
 
 .test-suite-label__summary {
   font-size: 0.75em;
-  /* Translate down as much as the smaller font-size requires */
-  transform: translateY(12.5%);
 }
 
 .test-suite-label--success {

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -163,24 +163,23 @@ body {
 }
 
 .test-suite-label {
-  display: inline-block;
   border-radius: 2rem;
   padding: 0.5rem 2rem;
   margin: 1rem;
   font-size: 2rem;
   opacity: 0.7;
   flex: 1 1 auto;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
-.test-suite-label__filename {
-  float: left;
-}
+.test-suite-label__filename {}
 
 .test-suite-label__summary {
   font-size: 0.75em;
-  float: right;
   /* Translate down as much as the smaller font-size requires */
-  transform: translateY(25%);
+  transform: translateY(12.5%);
 }
 
 .test-suite-label--success {


### PR DESCRIPTION
- Add flexbox in row direction to position buttons and the content (see below)
- Add tests to `test-suites.tsx`: uses `renderToString` and `jsdom` for simple tests on the built HTML (it did not seem reasonable to use `react-test-renderer`, `enzyme` or stuff as there's no JS at all involved)

<img width="1279" alt="Screenshot 2019-09-27 at 15 43 03" src="https://user-images.githubusercontent.com/11660974/65769964-a80a1b00-e13d-11e9-8a2a-aa6a87584860.png">
