### PR TITLE
Adds scaffolding for redactor

### DIFF
--- a/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
+++ b/packages/unmock-jest/src/__tests__/components/test-suites.test.tsx
@@ -7,6 +7,7 @@ import stylesheet from "../../reporter/stylesheet";
 import { ITestSuite } from "../../reporter/types";
 import { toTestSuites } from "../../reporter/utils";
 import { readJson } from "../utils";
+import { authRedactor } from "../../reporter/options";
 
 const jestResults = readJson("resources/jest-results.json");
 const unmockSnapshots = readJson("resources/unmock-snapshots.json");
@@ -18,7 +19,7 @@ const input = {
 
 const renderTestSuites = () => {
     const testSuites: ITestSuite[] = toTestSuites(input);
-    const [css, TestSuitesComponent] = TestSuites({testSuites });
+    const [css, TestSuitesComponent] = TestSuites({testSuites, redactor: authRedactor });
     const element = ReactDomServer.renderToStaticMarkup(<TestSuitesComponent />);
     // Small hack to include stylesheets in the DOM
     const html = `<!DOCTYPE html><html><head><style>${stylesheet}</style><style>${css}</style></head><body>${element}</body></html>`;

--- a/packages/unmock-jest/src/__tests__/create-report.test.ts
+++ b/packages/unmock-jest/src/__tests__/create-report.test.ts
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/extend-expect";
 import { JSDOM } from "jsdom";
 import * as path from "path";
 import createReport from "../reporter/create-report";
+import { authRedactor } from "../reporter/options";
 import { writeToDirectory } from "../reporter/write-report";
 import { exampleInput } from "./fake-data";
 import { readJson } from "./utils";
@@ -10,7 +11,7 @@ const jestResults = readJson("resources/jest-results.json");
 const unmockSnapshots = readJson("resources/unmock-snapshots.json");
 
 describe("Report creator for given data", () => {
-  const report = createReport(exampleInput);
+  const report = createReport(exampleInput, authRedactor);
   expect(report).toBeDefined();
   const dom = new JSDOM(report);
   it("should have header", () => {
@@ -25,10 +26,13 @@ describe("Report creator for given data", () => {
 });
 
 describe("Report creator for real test data", () => {
-  const report = createReport({
-    jestData: { aggregatedResult: jestResults },
-    snapshots: unmockSnapshots,
-  });
+  const report = createReport(
+    {
+      jestData: { aggregatedResult: jestResults },
+      snapshots: unmockSnapshots,
+    },
+    authRedactor,
+  );
   const dom = new JSDOM(report);
 
   it("should have header", () => {
@@ -49,6 +53,7 @@ describe("Report creator for real test data", () => {
     writeToDirectory(report, {
       outputDirectory: targetDirectory,
       outputFilename: "report.html",
+      redactor: authRedactor,
     });
   });
 });

--- a/packages/unmock-jest/src/__tests__/redactor.test.ts
+++ b/packages/unmock-jest/src/__tests__/redactor.test.ts
@@ -1,4 +1,3 @@
-import { UnmockRequest } from "unmock";
 import { authRedactor } from "../reporter/options";
 import { testRequest } from "./fake-data";
 test("auth redactor redacts authentication tokens", () => {

--- a/packages/unmock-jest/src/__tests__/redactor.test.ts
+++ b/packages/unmock-jest/src/__tests__/redactor.test.ts
@@ -1,0 +1,25 @@
+import { UnmockRequest } from "unmock";
+import { authRedactor } from "../reporter/options";
+import { testRequest } from "./fake-data";
+test("auth redactor redacts authentication tokens", () => {
+  expect(
+    authRedactor({
+      ...testRequest,
+      headers: {
+        authorization: "foo",
+        Authorization: "bar",
+        hello: "world",
+      },
+    }),
+  ).toEqual({
+    req: {
+      ...testRequest,
+      headers: {
+        hello: "world",
+        authorization: "-- redacted --",
+        Authorization: "-- redacted --",
+      },
+    },
+    res: undefined,
+  });
+});

--- a/packages/unmock-jest/src/__tests__/write-report.test.ts
+++ b/packages/unmock-jest/src/__tests__/write-report.test.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import writeReport, { writeToDirectory } from "../reporter/write-report";
 import { aggregatedResult, snapshots } from "./fake-data";
+import { authRedactor } from "../reporter/options";
 
 const RANDOM_STRING = Math.random()
   .toString(36)
@@ -28,6 +29,7 @@ describe("Report writer", () => {
       {
         outputDirectory: OUTPUT_FOLDER,
         outputFilename: TEST_FILE_NAME,
+        redactor: authRedactor,
       },
     );
 
@@ -39,6 +41,7 @@ describe("Report writer", () => {
     writeToDirectory(RANDOM_STRING, {
       outputDirectory: OUTPUT_FOLDER,
       outputFilename: TEST_FILE_NAME,
+      redactor: authRedactor,
     });
 
     const contents = fs.readFileSync(TEST_FILE_PATH, { encoding: "utf-8" });

--- a/packages/unmock-jest/src/reporter/components/call.tsx
+++ b/packages/unmock-jest/src/reporter/components/call.tsx
@@ -50,7 +50,7 @@ const Call = ({ snapshot, redactor }: { snapshot: ISnapshot, redactor: Redactor 
   const redacted = redactor(snapshot.data.req, snapshot.data.res);
   return (<div className={"call"}>
     <Request request={redacted.req} />
-    { snapshot.data.res ? <Response response={redacted.res} /> : <div>No response</div>}
+    { redacted.res ? <Response response={redacted.res} /> : <div>No response</div>}
     </div>);
 };
 

--- a/packages/unmock-jest/src/reporter/components/call.tsx
+++ b/packages/unmock-jest/src/reporter/components/call.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { ISnapshot, UnmockRequest, UnmockResponse } from "unmock";
+import { Redactor } from "../types";
 
-const Request = ({ request }: { request: UnmockRequest}) => {
+const Request = ({ request, }: { request: UnmockRequest}) => {
   const operation = `${request.method.toUpperCase()} ${request.protocol}://${request.host}${request.path}`;
   return (<div className={"call__request"}>
     <div className={"call__request-title"}>Request</div>
@@ -45,10 +46,11 @@ const Response = ({ response }: { response: UnmockResponse }) => {
   </div>)
 }
 
-const Call = ({ snapshot }: { snapshot: ISnapshot }) => {
+const Call = ({ snapshot, redactor }: { snapshot: ISnapshot, redactor: Redactor }) => {
+  const redacted = redactor(snapshot.data.req, snapshot.data.res);
   return (<div className={"call"}>
-    <Request request={snapshot.data.req} />
-    { snapshot.data.res ? <Response response={snapshot.data.res} /> : <div>No response</div>}
+    <Request request={redacted.req} />
+    { snapshot.data.res ? <Response response={redacted.res} /> : <div>No response</div>}
     </div>);
 };
 

--- a/packages/unmock-jest/src/reporter/components/calls.tsx
+++ b/packages/unmock-jest/src/reporter/components/calls.tsx
@@ -1,14 +1,16 @@
 import * as React from "react";
 import { ISnapshot } from "unmock";
+import { Redactor } from "../types";
 import Call from "./call";
 
-const Calls = ({ snapshots }:
+const Calls = ({ snapshots, redactor }:
   { assertionResult: jest.AssertionResult,
+    redactor: Redactor,
   snapshots: ISnapshot[] },
 ) => {
   return (<div className={"calls"}>
     <div className={"calls__title"}>{`${snapshots.length} HTTP request(s)`}</div>
-    {snapshots.map((snapshot, i) => (<Call snapshot={snapshot} key={i}/>))}
+    {snapshots.map((snapshot, i) => (<Call snapshot={snapshot} redactor={redactor} key={i}/>))}
   </div>);
 };
 

--- a/packages/unmock-jest/src/reporter/components/test-suite.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suite.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ITestSuite } from "../types";
+import { ITestSuite, Redactor } from "../types";
 import Test from "./test";
 
 const Summary = ({ testSuite }: { testSuite: ITestSuite }) => {
@@ -16,14 +16,14 @@ const Summary = ({ testSuite }: { testSuite: ITestSuite }) => {
     </div>)
 };
 
-const TestSuite = ({ testSuite }: { testSuite: ITestSuite }) => {
+const TestSuite = ({ testSuite, redactor }: { testSuite: ITestSuite, redactor: Redactor }) => {
 
     const testElements = testSuite.suiteResults.testResults.map(
         (assertionResult: jest.AssertionResult) => {
             const snapshotsForTest = testSuite.snapshots.filter(
                 snapshot => snapshot.currentTestName === assertionResult.fullName,
             );
-            return <Test assertionResult={assertionResult} snapshots={snapshotsForTest} key={assertionResult.fullName}/>
+            return <Test assertionResult={assertionResult} snapshots={snapshotsForTest} key={assertionResult.fullName} redactor={redactor}/>
         },
   );
 

--- a/packages/unmock-jest/src/reporter/components/test-suites.tsx
+++ b/packages/unmock-jest/src/reporter/components/test-suites.tsx
@@ -1,6 +1,6 @@
 import * as os from "os";
 import * as React from "react";
-import { ITestSuite } from "../types";
+import { ITestSuite, Redactor } from "../types";
 import TestSuite from "./test-suite";
 
 // Replace file path separator chars with a dash
@@ -10,7 +10,7 @@ export const testFileToId = (file: string) => file.replace(/(\/|\\(\\)?|:|\.)/g,
  * Not actually a React component but something that returns dynamically generated CSS and a React component
  * @returns Tuple where the first element is CSS string, second is a React component for rendering the test results.
  */
-const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () => React.ReactElement] => {
+const TestResults = ({ testSuites, redactor }: { testSuites: ITestSuite[], redactor: Redactor }): [string, () => React.ReactElement] => {
 
     const elementsAndCss = testSuites.map((testSuite, index) => {
         const id = testFileToId(testSuite.shortFilePath);
@@ -36,7 +36,7 @@ const TestResults = ({ testSuites }: { testSuites: ITestSuite[] }): [string, () 
                 <span className="test-suite-label__filename">{testSuite.shortFilePath}</span>
                 <span className="test-suite-label__summary">{`Passing: ${numPassingTests}, failing: ${numFailingTests}, HTTP calls: ${nSnapshots}`}</span>
             </label>,
-            testSuite: <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} /></div>,
+            testSuite: <div className={`test-suite test-suite-${id}`} key={`div-${id}`}><TestSuite testSuite={testSuite} redactor={redactor} /></div>,
             css: elementCss
         };
     });

--- a/packages/unmock-jest/src/reporter/components/test.tsx
+++ b/packages/unmock-jest/src/reporter/components/test.tsx
@@ -41,7 +41,7 @@ const Test = ({ assertionResult, snapshots, redactor }: { assertionResult: jest.
             { failureMessages.length > 0 ?
                 <FailureMessage messages={failureMessages} />
                 : null }
-            <Calls assertionResult={assertionResult} redactor={Redactor} snapshots={snapshots}/>
+            <Calls assertionResult={assertionResult} redactor={redactor} snapshots={snapshots}/>
         </div>);
 };
 

--- a/packages/unmock-jest/src/reporter/components/test.tsx
+++ b/packages/unmock-jest/src/reporter/components/test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import stripAnsi from "strip-ansi";
 import { ISnapshot } from "unmock";
+import { Redactor } from "../types";
 import Calls from "./calls";
 
 const buildTestTitle = (assertionResult: jest.AssertionResult) =>
@@ -25,7 +26,7 @@ const FailureMessage = ({ messages }: { messages: string[] }) => {
  * @param assertionResult Jest results for the test
  * @param snapshots All unmock snapshots for **this test**
  */
-const Test = ({ assertionResult, snapshots }: { assertionResult: jest.AssertionResult, snapshots: ISnapshot[]}) => {
+const Test = ({ assertionResult, snapshots, redactor }: { assertionResult: jest.AssertionResult, snapshots: ISnapshot[], redactor: Redactor}) => {
 
     const failureMessages = assertionResult.failureMessages;
 
@@ -40,7 +41,7 @@ const Test = ({ assertionResult, snapshots }: { assertionResult: jest.AssertionR
             { failureMessages.length > 0 ?
                 <FailureMessage messages={failureMessages} />
                 : null }
-            <Calls assertionResult={assertionResult}  snapshots={snapshots}/>
+            <Calls assertionResult={assertionResult} redactor={Redactor} snapshots={snapshots}/>
         </div>);
 };
 

--- a/packages/unmock-jest/src/reporter/create-report.tsx
+++ b/packages/unmock-jest/src/reporter/create-report.tsx
@@ -3,7 +3,7 @@ import * as ReactDomServer from "react-dom/server";
 import xmlBuilder = require("xmlbuilder");
 import TestSuites from "./components/test-suites";
 import stylesheet from "./stylesheet";
-import { IReportInput, ITestSuite } from "./types";
+import { IReportInput, ITestSuite, Redactor } from "./types";
 import { sortTestSuites, toTestSuites } from "./utils";
 
 const createHtml = ({ css, body } : { css: string, body: string }) => {
@@ -56,7 +56,7 @@ const buildHeaderDiv = (input: IReportInput): xmlBuilder.XMLDocument => {
 };
 
 
-const buildBodyDiv = (input: IReportInput): [xmlBuilder.XMLDocument, string] => {
+const buildBodyDiv = (input: IReportInput, redactor: Redactor): [xmlBuilder.XMLDocument, string] => {
   const reportBody = xmlBuilder.begin().element("div", { class: "report" });
 
   // Header
@@ -64,15 +64,15 @@ const buildBodyDiv = (input: IReportInput): [xmlBuilder.XMLDocument, string] => 
 
   const testSuites: ITestSuite[] = sortTestSuites(toTestSuites(input));
 
-  const [css, TestSuitesComponent ] = TestSuites({testSuites });
+  const [css, TestSuitesComponent ] = TestSuites({testSuites, redactor });
 
   reportBody.raw(renderReact(<TestSuitesComponent />));
 
   return [reportBody, css];
 };
 
-export const createReport = (input: IReportInput) => {
-  const [body, css] = buildBodyDiv(input);
+export const createReport = (input: IReportInput, redactor: Redactor) => {
+  const [body, css] = buildBodyDiv(input, redactor);
   const htmlOutput = createHtml({ css, body: body.end() });
   return htmlOutput;
 };

--- a/packages/unmock-jest/src/reporter/options.ts
+++ b/packages/unmock-jest/src/reporter/options.ts
@@ -18,9 +18,9 @@ const authRedactor: Redactor = (req, res) => ({
   req: {
     ...req,
     headers: {
-      ...res.headers,
-      ...(res.headers.Authorization ? { Authorization: "-- redacted --" } : {}),
-      ...(res.headers.authorization ? { authorization: "-- redacted --" } : {}),
+      ...req.headers,
+      ...(req.headers.Authorization ? { Authorization: "-- redacted --" } : {}),
+      ...(req.headers.authorization ? { authorization: "-- redacted --" } : {}),
     },
   },
   res,

--- a/packages/unmock-jest/src/reporter/options.ts
+++ b/packages/unmock-jest/src/reporter/options.ts
@@ -14,7 +14,7 @@ export interface IReporterOptions {
   redactor: Redactor;
 }
 
-export const authRedactor: Redactor = (req, res) => ({
+export const authRedactor: Redactor = (req, res?) => ({
   req: {
     ...req,
     headers: {

--- a/packages/unmock-jest/src/reporter/options.ts
+++ b/packages/unmock-jest/src/reporter/options.ts
@@ -14,7 +14,7 @@ export interface IReporterOptions {
   redactor: Redactor;
 }
 
-const authRedactor: Redactor = (req, res) => ({
+export const authRedactor: Redactor = (req, res) => ({
   req: {
     ...req,
     headers: {

--- a/packages/unmock-jest/src/reporter/options.ts
+++ b/packages/unmock-jest/src/reporter/options.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { Redactor } from "./types";
 
 export const DEFAULT_OUTPUT_DIRECTORY = path.resolve(
   process.cwd(),
@@ -10,11 +11,25 @@ export const DEFAULT_OUTPUT_FILENAME = "unmock-report.html";
 export interface IReporterOptions {
   outputDirectory: string;
   outputFilename: string;
+  redactor: Redactor;
 }
+
+const authRedactor: Redactor = (req, res) => ({
+  req: {
+    ...req,
+    headers: {
+      ...res.headers,
+      ...(res.headers.Authorization ? { Authorization: "-- redacted --" } : {}),
+      ...(res.headers.authorization ? { authorization: "-- redacted --" } : {}),
+    },
+  },
+  res,
+});
 
 const DEFAULT_OPTIONS: IReporterOptions = {
   outputDirectory: DEFAULT_OUTPUT_DIRECTORY,
   outputFilename: DEFAULT_OUTPUT_FILENAME,
+  redactor: authRedactor,
 };
 
 export const resolveOptions = (reporterOptions: Partial<IReporterOptions>) => ({

--- a/packages/unmock-jest/src/reporter/types.ts
+++ b/packages/unmock-jest/src/reporter/types.ts
@@ -1,4 +1,12 @@
-import { ISnapshot } from "unmock";
+import { ISnapshot, UnmockRequest, UnmockResponse } from "unmock";
+
+export type Redactor = (
+  req: UnmockRequest,
+  res: UnmockResponse,
+) => {
+  req: UnmockRequest;
+  res: UnmockResponse;
+};
 
 export interface IJestData {
   aggregatedResult: jest.AggregatedResult;

--- a/packages/unmock-jest/src/reporter/types.ts
+++ b/packages/unmock-jest/src/reporter/types.ts
@@ -2,7 +2,7 @@ import { ISnapshot, UnmockRequest, UnmockResponse } from "unmock";
 
 export type Redactor = (
   req: UnmockRequest,
-  res: UnmockResponse | undefined,
+  res?: UnmockResponse,
 ) => {
   req: UnmockRequest;
   res?: UnmockResponse;

--- a/packages/unmock-jest/src/reporter/types.ts
+++ b/packages/unmock-jest/src/reporter/types.ts
@@ -2,10 +2,10 @@ import { ISnapshot, UnmockRequest, UnmockResponse } from "unmock";
 
 export type Redactor = (
   req: UnmockRequest,
-  res: UnmockResponse,
+  res: UnmockResponse | undefined,
 ) => {
   req: UnmockRequest;
-  res: UnmockResponse;
+  res?: UnmockResponse;
 };
 
 export interface IJestData {

--- a/packages/unmock-jest/src/reporter/write-report.ts
+++ b/packages/unmock-jest/src/reporter/write-report.ts
@@ -44,7 +44,7 @@ export const writeToDirectory = (
  */
 const writeReport = (input: IReportInput, opts: IReporterOptions) => {
   const options = resolveOptions(opts || {});
-  const report: string = createReport(input);
+  const report: string = createReport(input, options.redactor);
   return writeToDirectory(report, options);
 };
 


### PR DESCRIPTION
This is a basic sketch for redactable test reports. Not sure if the interface is the best, and not sure if we want redaction on the snapshot level as well, but IMO this achieves minimal viable redaction in the reporter, which was a common concern in Budapest.