### PR TITLE
Optional api

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ nock("https://zodiac.com", "zodiac")
   .get("/horoscope/{sign}")
   .reply(200, {
     horoscope: u.string(),
+    ascendant: u.opt(u.string())
   })
   .reply(404, { message: "Not authorized" });
 
@@ -77,7 +78,7 @@ describe("getHoroscope", () => {
 });
 ```
 
-This setup says that we will intercept every HTTPS GET request to `https://zodiac.com/horoscope/{sign}`. We instruct it to reply with a status 200, and the body will contain a response in JSON corresponding to the spec - in this case, an object with a horoscope.
+This setup says that we will intercept every HTTPS GET request to `https://zodiac.com/horoscope/{sign}`. We instruct it to reply with a status 200, and the body will contain a response in JSON corresponding to the spec - in this case, an object with a horoscope and optionally any ascendant.
 
 ### Specifying hostname
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ describe("getHoroscope", () => {
 });
 ```
 
-This setup says that we will intercept every HTTPS GET request to `https://zodiac.com/horoscope/{sign}`. We instruct it to reply with a status 200, and the body will contain a response in JSON corresponding to the spec - in this case, an object with a horoscope and optionally any ascendant.
+This setup says that we will intercept every HTTPS GET request to `https://zodiac.com/horoscope/{sign}`. We instruct it to reply with a status 200, and the body will contain a response in JSON corresponding to the spec - in this case, an object with a horoscope of type `string` and optionally an ascendant of type `string`.
 
 ### Specifying hostname
 
@@ -197,12 +197,21 @@ unmock.nock('http://myapp.iriscouch.com')
   .reply(404)
 ```
 
-You can also specify the reply body as valid JSON, JSON schema, or any combination thereof.
+You can also specify the reply body as valid JSON, `json-schema-poet`, or any combination thereof.
 
 ```js
 unmock.nock('http://www.google.com')
   .get('/')
   .reply(200, u.stringEnum(['Hello from Google!', 'Do no evil']))
+```
+
+If you would like to transform any part of a constant reply (ie a fixture recorded from real API traffic) into a variable version of itself, use `u.fuzz`. This command infers the type of its input and produces output following the same schema.
+
+```js
+unmock.nock('http://www.foo.com')
+  .get('/')
+  // produces { firstName: "a random string", lastName: "another random string" }
+  .reply(200, u.fuzz({ firstName: "Bob", lastName: "Smith" }))
 ```
 
 ### Specifying reply headers

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -16,7 +16,6 @@ describe("Tests dynamic path tests", () => {
       .nock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });
-    console.log("HANGING OUT WITH FOO", u.string().dynamic);
     expectNServices(1);
   });
 

--- a/packages/unmock-core/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-core/src/__tests__/dynamicService.test.ts
@@ -16,6 +16,7 @@ describe("Tests dynamic path tests", () => {
       .nock("https://foo.com")
       .get("/foo")
       .reply(200, { foo: u.string() });
+    console.log("HANGING OUT WITH FOO", u.string().dynamic);
     expectNServices(1);
   });
 

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -5,7 +5,7 @@ import NodeBackend from "./backend";
 import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
 import FsSnapshotter, { ISnapshot } from "./loggers/snapshotter";
 import WinstonLogger from "./loggers/winston-logger";
-import { ExtendedJSONSchema, JSONSchemify, nockify } from "./nock";
+import { ExtendedJSONSchema, nockify, vanillaJSONSchemify } from "./nock";
 import internalRunner, { IRunnerOptions } from "./runner";
 import { AllowedHosts, BooleanSetting } from "./settings";
 
@@ -87,7 +87,7 @@ export class UnmockPackage implements IUnmockPackage {
     const requestHeaders =
       typeof nameOrHeaders === "object" && nameOrHeaders.reqheaders
         ? Object.entries(nameOrHeaders.reqheaders).reduce(
-            (a, b) => ({ ...a, [b[0]]: JSONSchemify(b[1]) }),
+            (a, b) => ({ ...a, [b[0]]: vanillaJSONSchemify(b[1]) }),
             {},
           )
         : {};

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -374,7 +374,7 @@ export const JSONSchemify = <T, C extends object>(c: C) => (
     : constantHandler(e as CType);
 
 // Define poet to recognize the new "dynamic type"
-const jspt = extendT<ExtendedJSONSchema, IDynamicJSONValue>({
+const jspt = extendT<RecursiveUnionType, IDynamicJSONValue>({
   dynamic: DynamicJSONSymbol,
 });
 

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -249,6 +249,17 @@ const fuzz: ConstTransformer<RecursiveUnionType, IDynamicJSONValue> = (
     ? jspt.boolean()
     : jspt.nul();
 
+const unfuzz: ConstTransformer<RecursiveUnionType, IDynamicJSONValue> = (
+  e: CType,
+): JSSTAnything<RecursiveUnionType, IDynamicJSONValue> =>
+  typeof e === "string"
+    ? jspt.cnst(e)
+    : typeof e === "number"
+    ? jspt.cnst(e)
+    : typeof e === "boolean"
+    ? jspt.cnst(e)
+    : jspt.cnst(null);
+
 export const JSONSchemify = <T, C extends object>(c: C) => (
   schemaToSchemaTransformer: (schema: any) => JSSTAnything<T, C>,
 ) => (constantHandler: ConstTransformer<T, C>) => (
@@ -372,6 +383,9 @@ export const u = {
   fuzz: JSONSchemify<RecursiveUnionType, IDynamicJSONValue>({
     dynamic: DynamicJSONSymbol,
   })(fuzzNoop)(fuzz),
+  unfuzz: JSONSchemify<RecursiveUnionType, IDynamicJSONValue>({
+    dynamic: DynamicJSONSymbol,
+  })(fuzzNoop)(unfuzz),
   opt: (e: ExtendedJSONSchema): IMaybeJSONValue => ({
     maybe: MaybeJSONSymbol,
     val: e,

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -15,7 +15,6 @@ import {
   JSSTNot,
   JSSTObject,
   JSSTOneOf,
-  JSSTTopLevel,
   JSSTTuple,
 } from "json-schema-strictly-typed";
 import { fromTraversable, Iso, Prism } from "monocle-ts";

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -15,6 +15,7 @@ import {
   JSSTNot,
   JSSTObject,
   JSSTOneOf,
+  JSSTTopLevel,
   JSSTTuple,
 } from "json-schema-strictly-typed";
 import { fromTraversable, Iso, Prism } from "monocle-ts";
@@ -25,6 +26,8 @@ import { identityGetter } from "./generator";
 import { CodeAsInt, HTTPMethod } from "./interfaces";
 import { Schema, ValidEndpointType } from "./service/interfaces";
 import { ServiceStore } from "./service/serviceStore";
+
+const CONS = <T>(t: T, m?: string) => { console.log(JSON.stringify(t), typeof t === "object" ? (t as any).dynamic : "not dynamic", m); return t };
 
 /*************************************************
  * (Extended, Dynamic) JSON Schema defined below *
@@ -203,14 +206,15 @@ const ExtendedArray: io.Type<
   IExtendedArrayType
 > = io.recursion("ExtendedArray", () => io.array(ExtendedValue));
 
-const spreadAndSchemify = (
-  e?: ITameExtendedObjectType,
-  f: (e: ExtendedValueType) => JSSTAnything<EJSEmpty, {}> = JSONSchemify,
+const spreadAndSchemify = <T, C extends object>(
+  e: ITameExtendedObjectType | undefined,
+  f: (e: ExtendedValueType) => JSSTAnything<T, C>,
 ) =>
   e ? Object.entries(e).reduce((a, b) => ({ ...a, [b[0]]: f(b[1]) }), {}) : {};
 
 // hack until we get around to doing full typing :-(
 const removeDynamicSymbol = (schema: any): JSONSchemaObject<EJSEmpty, {}> => {
+  CONS(schema, "checking out this schema")
   if (schema instanceof Array) {
     return (schema as unknown) as JSONSchemaObject<EJSEmpty, {}>;
   }
@@ -224,50 +228,151 @@ const removeDynamicSymbol = (schema: any): JSONSchemaObject<EJSEmpty, {}> => {
   return schema;
 };
 
-export const JSONSchemify = (
-  e: ExtendedValueType,
+const fuzzNoop = (
+  schema: any,
+): JSONSchemaObject<RecursiveUnionType, IDynamicJSONValue> =>
+  (schema as unknown) as JSONSchemaObject<
+    RecursiveUnionType,
+    IDynamicJSONValue
+  >;
+
+type CType =
+  | string
+  | number
+  | boolean
+  | (string & JSSTTopLevel<RecursiveUnionType, IDynamicJSONValue>)
+  | (number & JSSTTopLevel<RecursiveUnionType, IDynamicJSONValue>)
+  | (false & JSSTTopLevel<RecursiveUnionType, IDynamicJSONValue>)
+  | (true & JSSTTopLevel<RecursiveUnionType, IDynamicJSONValue>)
+  | null;
+type ConstTransformer<T, C extends object> = (e: CType) => JSSTAnything<T, C>;
+
+// total hack comes from the conversion from schema to json-schema
+// this works because valAsConst only ever yields valid JSON schema
+// we should mitigate this by makeing a "subset" type
+// common to both OAS & JSON Schema
+const simpleConstantTransformer: ConstTransformer<EJSEmpty, {}> = (
+  e: CType,
 ): JSSTAnything<EJSEmpty, {}> =>
+  valAsConst(cnst_<{}>({})(e).const) as JSSTAnything<EJSEmpty, {}>;
+
+const fuzz: ConstTransformer<RecursiveUnionType, IDynamicJSONValue> = (
+  e: CType,
+): JSSTAnything<RecursiveUnionType, IDynamicJSONValue> =>
+  typeof e === "string"
+    ? jspt.string()
+    : typeof e === "number" && Math.floor(e) === e
+    ? jspt.integer()
+    : typeof e === "number"
+    ? jspt.number()
+    : typeof e === "boolean"
+    ? jspt.boolean()
+    : jspt.nul();
+
+export const JSONSchemify = <T, C extends object>(c: C) => (
+  schemaToSchemaTransformer: (schema: any) => JSSTAnything<T, C>,
+) => (constantHandler: ConstTransformer<T, C>) => (
+  e: ExtendedValueType,
+): JSSTAnything<T, C> =>
   isDynamic(e)
-    ? removeDynamicSymbol(
+    ? schemaToSchemaTransformer(
         // we cover all of the nested cases,
         // followed by un-nested cases
         JSSTAllOf(RecursiveUnion, DynamicJSONValue).is(e)
-          ? { ...e, allOf: e.allOf.map(JSONSchemify) }
+          ? {
+              ...e,
+              allOf: e.allOf.map(
+                JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                  constantHandler,
+                ),
+              ),
+            }
           : JSSTAnyOf(RecursiveUnion, DynamicJSONValue).is(e)
-          ? { ...e, anyOf: e.anyOf.map(JSONSchemify) }
+          ? {
+              ...e,
+              anyOf: e.anyOf.map(
+                JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                  constantHandler,
+                ),
+              ),
+            }
           : JSSTOneOf(RecursiveUnion, DynamicJSONValue).is(e)
-          ? { ...e, oneOf: e.oneOf.map(JSONSchemify) }
+          ? {
+              ...e,
+              oneOf: e.oneOf.map(
+                JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                  constantHandler,
+                ),
+              ),
+            }
           : JSSTNot(RecursiveUnion, DynamicJSONValue).is(e)
-          ? { ...e, not: JSONSchemify(e.not) }
+          ? {
+              ...e,
+              not: JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                constantHandler,
+              )(e.not),
+            }
           : JSSTList(RecursiveUnion, DynamicJSONValue).is(e)
-          ? { ...e, items: JSONSchemify(e.items) }
+          ? {
+              ...e,
+              items: JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                constantHandler,
+              )(e.items),
+            }
           : JSSTTuple(RecursiveUnion, DynamicJSONValue).is(e)
-          ? { ...e, oneOf: e.items.map(JSONSchemify) }
+          ? {
+              ...e,
+              oneOf: e.items.map(
+                JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                  constantHandler,
+                ),
+              ),
+            }
           : JSSTObject(RecursiveUnion, DynamicJSONValue).is(e)
           ? {
               ...e,
               ...(e.additionalProperties
-                ? { additionalProperties: JSONSchemify(e.additionalProperties) }
+                ? {
+                    additionalProperties: JSONSchemify<T, C>(c)(
+                      schemaToSchemaTransformer,
+                    )(constantHandler)(e.additionalProperties),
+                  }
                 : {}),
-              ...spreadAndSchemify(e.patternProperties),
-              ...spreadAndSchemify(e.properties),
+              ...spreadAndSchemify(
+                e.patternProperties,
+                JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                  constantHandler,
+                ),
+              ),
+              ...spreadAndSchemify(
+                e.properties,
+                JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(
+                  constantHandler,
+                ),
+              ),
             }
           : e,
       )
     : ExtendedArray.is(e) || JSONArray.is(e)
-    ? tuple_<EJSEmpty, {}>({})(e.map(JSONSchemify))
+    ? tuple_<T, C>(c)(
+        e.map(
+          JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(constantHandler),
+        ),
+      )
     : ExtendedObject.is(e) || JSONObject.is(e)
-    ? type_<EJSEmpty, {}>({})(
-        spreadAndSchemify(rejectOptionals(e)),
-        spreadAndSchemify(keepOptionals(e)),
+    ? type_<T, C>(c)(
+        spreadAndSchemify(
+          rejectOptionals(CONS(e, "touching extended object")),
+          JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(constantHandler),
+        ),
+        spreadAndSchemify(
+          keepOptionals(e),
+          JSONSchemify<T, C>(c)(schemaToSchemaTransformer)(constantHandler),
+        ),
       )
     : e instanceof RegExp
-    ? { type: "string", pattern: e.source }
-    : // total hack comes from the conversion from schema to json-schema
-      // this works because valAsConst only ever yields valid JSON schema
-      // we should mitigate this by makeing a "subset" type
-      // common to both OAS & JSON Schema
-      (valAsConst(cnst_<{}>({})(e).const) as JSSTAnything<EJSEmpty, {}>);
+    ? { type: "string", pattern: e.source, ...c }
+    : constantHandler(e);
 
 // Define poet to recognize the new "dynamic type"
 const jspt = extendT<ExtendedJSONSchema, IDynamicJSONValue>({
@@ -276,6 +381,9 @@ const jspt = extendT<ExtendedJSONSchema, IDynamicJSONValue>({
 
 export const u = {
   ...jspt,
+  fuzz: JSONSchemify<RecursiveUnionType, IDynamicJSONValue>({
+    dynamic: DynamicJSONSymbol,
+  })(fuzzNoop)(fuzz),
   opt: (e: ExtendedJSONSchema): IMaybeJSONValue => ({
     maybe: MaybeJSONSymbol,
     val: e,
@@ -340,6 +448,10 @@ interface IDynamicServiceSpec {
   ): IFluentDynamicService & IDynamicServiceSpec;
 }
 
+const vanillaJSONSchemify = JSONSchemify<EJSEmpty, {}>({})(removeDynamicSymbol)(
+  simpleConstantTransformer,
+);
+
 export class DynamicServiceSpec implements IDynamicServiceSpec {
   private data: Schema = {};
   private headers: Record<string, Schema> = {};
@@ -364,7 +476,10 @@ export class DynamicServiceSpec implements IDynamicServiceSpec {
       ...this.accumulatedQueries,
       ...(data
         ? Object.entries(data).reduce(
-            (a, b) => ({ ...a, [b[0]]: JSONSchemify(b[1]) }),
+            (a, b) => ({
+              ...a,
+              [b[0]]: vanillaJSONSchemify(b[1]),
+            }),
             {},
           )
         : {}),
@@ -399,7 +514,7 @@ export class DynamicServiceSpec implements IDynamicServiceSpec {
     maybeHeaders?: Record<string, InputToPoet>,
   ): IFluentDynamicService & IDynamicServiceSpec {
     if (maybeData !== undefined) {
-      this.data = JSONSchemify(maybeData) as Schema; // TODO should this be some JSSTX?
+      this.data = vanillaJSONSchemify(maybeData) as Schema; // TODO should this be some JSSTX?
       this.statusCode = maybeStatusCode as CodeAsInt | "default";
     } else if (
       (typeof maybeStatusCode === "number" &&
@@ -410,11 +525,14 @@ export class DynamicServiceSpec implements IDynamicServiceSpec {
       // we assume it's a status code
       this.statusCode = maybeStatusCode as CodeAsInt | "default";
     } else {
-      this.data = JSONSchemify(maybeStatusCode) as Schema;
+      this.data = vanillaJSONSchemify(maybeStatusCode) as Schema;
     }
     this.headers = maybeHeaders
       ? (Object.entries(maybeHeaders).reduce(
-          (a, b) => ({ ...a, [b[0]]: JSONSchemify(b[1]) }),
+          (a, b) => ({
+            ...a,
+            [b[0]]: vanillaJSONSchemify(b[1]),
+          }),
           {},
         ) as Record<string, Schema>)
       : {};
@@ -491,7 +609,7 @@ const endpointToQs = (endpoint: ValidEndpointType) =>
   ).reduce(
     (a, b) => ({
       ...a,
-      [b[0]]: JSONSchemify(b[1] === undefined ? null : b[1]),
+      [b[0]]: vanillaJSONSchemify(b[1] === undefined ? null : b[1]),
     }),
     {},
   ) || {};
@@ -552,7 +670,7 @@ const buildFluentNock = (
                   endpointToQs(endpoint) || {},
                   requestHeaders as Record<string, Schema>,
                   requestBody !== undefined
-                    ? (JSONSchemify(requestBody) as Schema)
+                    ? (vanillaJSONSchemify(requestBody) as Schema)
                     : undefined,
                   name,
                 ),

--- a/packages/unmock/src/__tests__/end-to-end/complex-service.test.ts
+++ b/packages/unmock/src/__tests__/end-to-end/complex-service.test.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+import unmock, { Arr, transform, u } from "../../";
+import { IService } from "unmock-core/dist/service/interfaces";
+const { responseBody } = transform;
+
+unmock
+  .nock("https://api.foo.com/v1", "foo")
+  .get("/users")
+  .reply(200, {
+    hello: {
+      bar: { a: 1, b: u.opt(2) },
+      foo: u.type({ a: "b", c: u.string() }, {}),
+      world: "5",
+      z: [1, u.fuzz(2), u.array(u.fuzz({ b: "hello", c: u.cnst("world") }))],
+    },
+  });
+
+beforeAll(() => {
+  unmock.on();
+});
+afterAll(() => unmock.off());
+describe("Complex service test", () => {
+  it("Should conform to the service description", async () => {
+    const { data } = await axios("https://api.foo.com/v1/users");
+    expect(data.hello.bar.a).toBe(1);
+    // very, very small chance that this will be 2...
+    expect(data.hello.z[1]).not.toBe(2);
+  });
+});

--- a/packages/unmock/src/__tests__/end-to-end/complex-service.test.ts
+++ b/packages/unmock/src/__tests__/end-to-end/complex-service.test.ts
@@ -1,7 +1,5 @@
 import axios from "axios";
-import unmock, { Arr, transform, u } from "../../";
-import { IService } from "unmock-core/dist/service/interfaces";
-const { responseBody } = transform;
+import unmock, { u } from "../../";
 
 unmock
   .nock("https://api.foo.com/v1", "foo")

--- a/packages/unmock/src/__tests__/end-to-end/readme/introductory-example.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/introductory-example.test.js
@@ -6,7 +6,7 @@ nock("https://zodiac.com", "zodiac")
   .get("/horoscope/{sign}")
   .reply(200, {
     horoscope: u.string(),
-    ascendant: u.opt()
+    ascendant: u.opt(u.string()),
   })
   .reply(404, { message: "Not authorized" });
 

--- a/packages/unmock/src/__tests__/end-to-end/readme/introductory-example.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/introductory-example.test.js
@@ -6,6 +6,7 @@ nock("https://zodiac.com", "zodiac")
   .get("/horoscope/{sign}")
   .reply(200, {
     horoscope: u.string(),
+    ascendant: u.opt()
   })
   .reply(404, { message: "Not authorized" });
 

--- a/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-reply.test.js
+++ b/packages/unmock/src/__tests__/end-to-end/readme/specifying-the-reply.test.js
@@ -1,0 +1,37 @@
+const unmock = require("unmock");
+const { nock, runner, transform, u } = unmock;
+const { withCodes } = transform;
+
+unmock
+  .nock("http://www.foo.com")
+  .get("/")
+  // produces { firstName: "a random string", lastName: "another random string" }
+  .reply(200, u.fuzz({ firstName: "Bob", lastName: "Smith" }));
+
+async function getName(sign) {
+  // use unmock.fetch, request, fetch, axios or any similar library
+  const result = await unmock.fetch("http://www.foo.com");
+  const json = await result.json();
+  return json;
+}
+
+beforeAll(() => {
+  zodiac = unmock.default.on();
+});
+afterAll(() => unmock.default.off());
+
+describe("getName", () => {
+  it(
+    "gets fuzzed version of the name",
+    runner(async () => {
+      const res = await getName();
+      expect(typeof res.firstName).toBe("string");
+      expect(typeof res.lastName).toBe("string");
+      // there is a very, very slight chance this test
+      // will fail if the random string generator
+      // generates Bob or Smith
+      expect(res.firstName).not.toBe("Bob");
+      expect(res.lastName).not.toBe("Smith");
+    }),
+  );
+});


### PR DESCRIPTION
This adds the following three members to the `u` API:
- `u.opt`, which makes an element of an object optional
- `u.fuzz`, which takes an object and converts any constants to fuzzable values (ie `"bob"` becomes `u.string()`). in the `fuzz` context, constants are represented with `u.const()`
- `u.unfuzz`. this reverts the `fuzz` context.