### PR TITLE
Include headers in report, add test for redactor.

### DIFF
--- a/packages/unmock-jest/src/__tests__/create-report.test.ts
+++ b/packages/unmock-jest/src/__tests__/create-report.test.ts
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/extend-expect";
 import { JSDOM } from "jsdom";
 import * as path from "path";
 import createReport from "../reporter/create-report";
+import { REDACTED } from "../reporter/utils";
 import { writeToDirectory } from "../reporter/write-report";
 import { exampleInput } from "./fake-data";
 import { readJson } from "./utils";
@@ -50,5 +51,29 @@ describe("Report creator for real test data", () => {
       outputDirectory: targetDirectory,
       outputFilename: "report.html",
     });
+  });
+});
+
+describe("Report creator auth redaction", () => {
+  it("should redact auth from header", () => {
+    const snapshot = unmockSnapshots[0];
+    const testSnapshot = {
+      ...snapshot,
+      data: {
+        ...snapshot.data,
+        req: {
+          ...snapshot.data.req,
+          headers: {
+            Authorization: "Bearer foo",
+          },
+        },
+      },
+    };
+    const testInput = {
+      jestData: { aggregatedResult: jestResults },
+      snapshots: [testSnapshot],
+    };
+    const report = createReport(testInput);
+    expect(report).toContain(REDACTED);
   });
 });

--- a/packages/unmock-jest/src/__tests__/create-report.test.ts
+++ b/packages/unmock-jest/src/__tests__/create-report.test.ts
@@ -55,6 +55,14 @@ describe("Report creator for real test data", () => {
 });
 
 describe("Report creator auth redaction", () => {
+  it("should not redact anything from test snapshots", () => {
+    const testInput = {
+      jestData: { aggregatedResult: jestResults },
+      snapshots: unmockSnapshots,
+    };
+    const report = createReport(testInput);
+    expect(report).not.toContain(REDACTED);
+  });
   it("should redact auth from header", () => {
     const snapshot = unmockSnapshots[0];
     const testSnapshot = {

--- a/packages/unmock-jest/src/reporter/components/call.tsx
+++ b/packages/unmock-jest/src/reporter/components/call.tsx
@@ -1,5 +1,15 @@
 import * as React from "react";
 import { ISnapshot, UnmockRequest, UnmockResponse } from "unmock";
+import { IIncomingHeaders } from "unmock-core/dist/interfaces";
+
+const Headers = ({ headers }: { headers: IIncomingHeaders }) => {
+  return <div className={"call__request-headers"}>
+        {`Headers`}
+        <ul className={"call__request-headers-list"}>
+          {Object.keys(headers).map(key => (<li key={key}>{key}: {headers[key]}</li>))}
+        </ul>
+    </div>
+};
 
 const Request = ({ request }: { request: UnmockRequest}) => {
   const operation = `${request.method.toUpperCase()} ${request.protocol}://${request.host}${request.path}`;
@@ -17,6 +27,7 @@ const Request = ({ request }: { request: UnmockRequest}) => {
     <p>
         {`Protocol: ${request.protocol}`}
     </p>
+    <Headers headers={request.headers} />
     { request.body? (<p>
       {`Body:`}
       <div className={"call__request-body"}>

--- a/packages/unmock-jest/src/reporter/stylesheet.ts
+++ b/packages/unmock-jest/src/reporter/stylesheet.ts
@@ -131,15 +131,22 @@ body {
 .call__request {
   flex: 1 1 0px;
   padding: 1rem;
+  font-size: 0.8em;
 }
 
 .call__response {
   flex: 1 1 0px;
   padding: 1rem;
+  font-size: 0.8em;
 }
 
 .call__request-title {
   font-size: 2rem;
+}
+
+.call__request-headers-list {
+  margin-left: 2rem;
+  font-size: 0.9em;
 }
 
 .call__response-title {

--- a/packages/unmock-jest/src/reporter/utils.ts
+++ b/packages/unmock-jest/src/reporter/utils.ts
@@ -38,6 +38,8 @@ export const largestCommonArray = <T>(arrays: T[][]): T[] => {
   return arrays.reduce((acc, val) => largestCommonArray2(acc, val));
 };
 
+export const REDACTED = "-- redacted --";
+
 export const authRedactor: Redactor = (snapshot: ISnapshot): ISnapshot => {
   const req = snapshot.data.req;
 
@@ -45,8 +47,8 @@ export const authRedactor: Redactor = (snapshot: ISnapshot): ISnapshot => {
     ...req,
     headers: {
       ...req.headers,
-      ...(req.headers.Authorization ? { Authorization: "-- redacted --" } : {}),
-      ...(req.headers.authorization ? { authorization: "-- redacted --" } : {}),
+      ...(req.headers.Authorization ? { Authorization: REDACTED } : {}),
+      ...(req.headers.authorization ? { authorization: REDACTED } : {}),
     },
   };
 


### PR DESCRIPTION
It wasn't possible to add a smoke test for the redactor as the headers are not included in the report, so added those + a test that create report does redaction.

NOTE: This is a PR to `redactor-2` branch as the redaction is effectively no-op unless headers are included in the report