### PR TITLE
Remove the header used internally from request.

### DIFF
--- a/packages/unmock-core/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/index.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { removeCodes } from "openapi-refinements";
 import * as path from "path";
-import { Service, sinon, UnmockPackage } from "../../";
+import { Service, sinon, transform, UnmockPackage } from "../../";
 import NodeBackend from "../../backend";
 import { UNMOCK_INTERNAL_HTTP_HEADER } from "../../backend/client-request-tracker";
 
@@ -138,6 +138,7 @@ describe("Unmock node package", () => {
     });
     beforeEach(() => {
       petstore.reset();
+      petstore.state(transform.withCodes(201));
     });
     afterAll(() => {
       unmock.off();

--- a/packages/unmock-core/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-core/src/__tests__/backend/index.test.ts
@@ -3,6 +3,7 @@ import { removeCodes } from "openapi-refinements";
 import * as path from "path";
 import { Service, sinon, UnmockPackage } from "../../";
 import NodeBackend from "../../backend";
+import { UNMOCK_INTERNAL_HTTP_HEADER } from "../../backend/client-request-tracker";
 
 const servicesDirectory = path.join(__dirname, "..", "__unmock__");
 
@@ -128,6 +129,23 @@ describe("Unmock node package", () => {
       await axios.post("http://petstore.swagger.io/v1/pets", {});
       petstore.reset();
       sinon.assert.notCalled(petstore.spy);
+    });
+  });
+  describe("call tracking", () => {
+    let petstore: Service;
+    beforeAll(() => {
+      petstore = unmock.on().services.petstore;
+    });
+    beforeEach(() => {
+      petstore.reset();
+    });
+    afterAll(() => {
+      unmock.off();
+    });
+    test("should not leave internally used tracking ID in request header", async () => {
+      await axios.post("http://petstore.swagger.io/v1/pets", {});
+      const requestHeaders = petstore.spy.postRequestHeaders();
+      expect(requestHeaders).not.toHaveProperty(UNMOCK_INTERNAL_HTTP_HEADER);
     });
   });
 });

--- a/packages/unmock-core/src/backend/client-request-tracker.ts
+++ b/packages/unmock-core/src/backend/client-request-tracker.ts
@@ -48,7 +48,8 @@ export default abstract class ClientRequestTracker {
   /**
    * Extract the `ClientRequest` corresponding to the given `IncomingMessage`.
    * Deletes the corresponding instance from the map of tracked requests.
-   * @param incomingMessage Incoming message ("server" side)
+   * NOTE: Modifies input message by deleting the internally used header!
+   * @param incomingMessage Incoming message ("server" side). The header used internal tracking is deleted!
    */
   public static pop(incomingMessage: IncomingMessage): ClientRequest {
     const { [UNMOCK_INTERNAL_HTTP_HEADER]: reqId } = incomingMessage.headers;
@@ -61,13 +62,14 @@ export default abstract class ClientRequestTracker {
         `Expected to find a string request ID in request header, got type: ${typeof reqId}`,
       );
     }
+    delete incomingMessage.headers[UNMOCK_INTERNAL_HTTP_HEADER];
+
     const clientRequest = ClientRequestTracker.clientRequests[reqId];
     if (clientRequest === undefined) {
       throw Error(`Expected to find a client request for request ID ${reqId}`);
     }
 
     delete ClientRequestTracker.clientRequests[reqId];
-
     return clientRequest;
   }
 

--- a/packages/unmock-core/src/backend/client-request-tracker.ts
+++ b/packages/unmock-core/src/backend/client-request-tracker.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 
 const debugLog = debug("unmock:client-request-tracker");
 
-const UNMOCK_INTERNAL_HTTP_HEADER = "x-unmock-req-id";
+export const UNMOCK_INTERNAL_HTTP_HEADER = "x-unmock-req-id";
 
 /**
  * "Static" class for tracking client requests.


### PR DESCRIPTION
- `UnmockRequest` contained the `x-unmock-req-id` header that is used internally fir mapping between `IncomingMessage` and `ClientRequest`, it should be removed when not used anymore