### PR TITLE
Get rid of node.js url in unmock-core.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2697,8 +2697,7 @@
     "@types/node": {
       "version": "8.10.54",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
-      "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
-      "dev": true
+      "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg=="
     },
     "@types/node-fetch": {
       "version": "2.5.2",
@@ -2778,6 +2777,14 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
       "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
       "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
       "requires": {
         "@types/node": "*"
       }
@@ -9226,8 +9233,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -12775,7 +12781,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -13102,6 +13107,7 @@
       "version": "file:packages/unmock-core",
       "requires": {
         "@types/sinon": "^7.0.13",
+        "@types/whatwg-url": "^6.4.0",
         "ajv": "^6.10.0",
         "axios": "^0.18.0",
         "boxen": "3.2.0",
@@ -13127,6 +13133,7 @@
         "seedrandom": "^3.0.3",
         "sinon": "^7.4.1",
         "swagger2openapi": "^5.3.0",
+        "whatwg-url": "^7.0.0",
         "winston": "^3.2.1"
       },
       "dependencies": {
@@ -13160,6 +13167,16 @@
             "fp-ts": "^2.0.5",
             "io-ts": "^2.0.1",
             "json-schema-strictly-typed": "^0.0.14"
+          }
+        },
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
           }
         }
       }
@@ -13525,8 +13542,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@types/sinon": "^7.0.13",
+    "@types/whatwg-url": "^6.4.0",
     "ajv": "^6.10.0",
     "axios": "^0.18.0",
     "boxen": "3.2.0",
@@ -39,6 +40,7 @@
     "seedrandom": "^3.0.3",
     "sinon": "^7.4.1",
     "swagger2openapi": "^5.3.0",
+    "whatwg-url": "^7.0.0",
     "winston": "^3.2.1"
   }
 }

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "@types/query-string": "^6.3.0",
     "@types/sinon": "^7.0.13",
     "@types/whatwg-url": "^6.4.0",
     "ajv": "^6.10.0",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
+    "@types/query-string": "^6.3.0",
     "@types/sinon": "^7.0.13",
     "@types/whatwg-url": "^6.4.0",
     "ajv": "^6.10.0",

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -38,7 +38,7 @@ import {
   valueLens,
 } from "openapi-refinements";
 import * as seedrandom from "seedrandom";
-import * as url from "url";
+import * as url from "whatwg-url";
 import {
   CreateResponse,
   IListener,

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -1,4 +1,4 @@
-import * as url from "url";
+import * as url from "whatwg-url";
 import { IObjectToService, IServiceCore, OpenAPIObject } from "./interfaces";
 import { Service } from "./service";
 import { ServiceCore } from "./serviceCore";
@@ -26,7 +26,7 @@ export class ServiceStore {
 
   public updateOrAdd(input: IObjectToService): ServiceStore {
     // TODO: Tighly coupled with OpenAPI at the moment... resolve this at a later time
-    const hostName = url.parse(input.baseUrl).hostname || input.baseUrl;
+    const hostName = new url.URL(input.baseUrl).hostname || input.baseUrl;
     const serviceName = input.name || hostName || input.baseUrl;
     const baseSchema: OpenAPIObject =
       serviceName !== undefined && this.cores[serviceName] !== undefined

--- a/packages/unmock-node/src/serialize/index.ts
+++ b/packages/unmock-node/src/serialize/index.ts
@@ -2,6 +2,7 @@ import * as http from "http";
 // @types/readable-stream not compatible with @types/node@8?
 // @ts-ignore
 const readable = require("readable-stream"); // tslint:disable-line:no-var-requires
+import queryString = require("query-string");
 import { isRESTMethod } from "unmock-core";
 import {
   HTTPMethod,
@@ -9,7 +10,7 @@ import {
   IIncomingQuery,
   ISerializedRequest,
 } from "unmock-core";
-import * as url from "url";
+import * as url from "whatwg-url";
 
 class BodySerializer extends readable.Transform {
   public static async fromIncoming(incomingMessage: http.IncomingMessage) {
@@ -36,8 +37,12 @@ function extractVars(
   host: string;
   path: string;
   pathname: string;
+  protocol: "https" | "http";
   query: IIncomingQuery;
 } {
+  const isEncrypted = (interceptedRequest.connection as any).encrypted;
+  const protocol = isEncrypted ? "https" : "http";
+
   const headers = interceptedRequest.headers;
 
   const hostWithPort = headers.host;
@@ -56,7 +61,18 @@ function extractVars(
     throw new Error("Missing method");
   }
 
-  const { path, pathname, query } = url.parse(requestUrl, true);
+  const baseURL = `${protocol}://${hostWithPort}`;
+
+  const parsedUrl = new url.URL(requestUrl, baseURL);
+
+  if (!parsedUrl) {
+    throw Error(`Could not parse URL: ${requestUrl}`);
+  }
+  const { pathname, search } = parsedUrl;
+
+  const path = `${pathname}${search}`;
+
+  const { query } = queryString.parseUrl(search);
 
   if (!path) {
     throw new Error("Could not parse path");
@@ -79,6 +95,7 @@ function extractVars(
     method,
     path,
     pathname,
+    protocol,
     query,
   };
 }
@@ -101,12 +118,15 @@ const jsonOrBust = (s: string | undefined) => {
 export const serializeRequest = async (
   interceptedRequest: http.IncomingMessage,
 ): Promise<ISerializedRequest> => {
-  const { headers, host, method, path, pathname, query } = extractVars(
-    interceptedRequest,
-  );
-
-  const isEncrypted = (interceptedRequest.connection as any).encrypted;
-  const protocol = isEncrypted ? "https" : "http";
+  const {
+    headers,
+    host,
+    method,
+    path,
+    pathname,
+    protocol,
+    query,
+  } = extractVars(interceptedRequest);
 
   const body = await BodySerializer.fromIncoming(interceptedRequest);
   const bodyAsJson = jsonOrBust(body);

--- a/packages/unmock-node/src/serialize/index.ts
+++ b/packages/unmock-node/src/serialize/index.ts
@@ -1,14 +1,15 @@
 import * as http from "http";
+import { mapValues } from "lodash";
 // @types/readable-stream not compatible with @types/node@8?
 // @ts-ignore
 const readable = require("readable-stream"); // tslint:disable-line:no-var-requires
 import queryString = require("query-string");
-import { isRESTMethod } from "unmock-core";
 import {
   HTTPMethod,
   IIncomingHeaders,
   IIncomingQuery,
   ISerializedRequest,
+  isRESTMethod,
 } from "unmock-core";
 import * as url from "whatwg-url";
 
@@ -74,6 +75,10 @@ function extractVars(
 
   const { query } = queryString.parseUrl(search);
 
+  const queryWithoutNull = mapValues(query, value =>
+    value === null ? undefined : value,
+  );
+
   if (!path) {
     throw new Error("Could not parse path");
   }
@@ -96,7 +101,7 @@ function extractVars(
     path,
     pathname,
     protocol,
-    query,
+    query: queryWithoutNull,
   };
 }
 

--- a/packages/unmock-node/src/serialize/index.ts
+++ b/packages/unmock-node/src/serialize/index.ts
@@ -73,7 +73,7 @@ function extractVars(
 
   const path = `${pathname}${search}`;
 
-  const { query } = queryString.parseUrl(search);
+  const query = queryString.parse(search);
 
   const queryWithoutNull = mapValues(query, value =>
     value === null ? undefined : value,


### PR DESCRIPTION
To fix issues where `require("url")` fails because running outside of Node.js. We want `unmock-core` to be "isomorphic" in that it can run in Node, browser, React Native, etc.