### PR TITLE
Refactor: Make Backend concrete, expose algorithm.

### DIFF
--- a/packages/unmock-core/src/__tests__/utils.ts
+++ b/packages/unmock-core/src/__tests__/utils.ts
@@ -18,9 +18,6 @@ export class TestBackend extends Backend {
   public constructor() {
     super({ interceptorFactory: TestInterceptor() });
   }
-  public loadServices() {
-    this.updateServiceDefs([]);
-  }
 }
 
 export const PetStoreSpecLocation = path.join(

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -69,6 +69,7 @@ export const buildRequestHandler = (
 export abstract class Backend {
   public serviceStore: ServiceStore = new ServiceStore([]);
   public readonly interceptorFactory: IInterceptorFactory;
+  public handleRequest?: OnSerializedRequest;
   protected readonly requestResponseListeners: IListener[];
   private interceptor?: IInterceptor;
 
@@ -108,8 +109,10 @@ export abstract class Backend {
       store: this.serviceStore,
     });
 
+    this.handleRequest = buildRequestHandler(createResponse);
+
     this.interceptor = this.interceptorFactory({
-      onSerializedRequest: buildRequestHandler(createResponse),
+      onSerializedRequest: this.handleRequest,
       shouldBypassHost: options.isWhitelisted,
     });
   }
@@ -119,6 +122,7 @@ export abstract class Backend {
       this.interceptor.disable();
       this.interceptor = undefined;
     }
+    this.handleRequest = undefined;
     if (this.serviceStore) {
       // TODO - this is quite ugly :shrug:
       Object.values(this.serviceStore.services).forEach(service =>

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -19,7 +19,7 @@ export class UnmockPackage implements IUnmockPackage {
   public allowedHosts: AllowedHosts;
   public flaky: BooleanSetting;
   public useInProduction: BooleanSetting;
-  protected readonly backend: Backend;
+  public readonly backend: Backend;
   private logger: ILogger = { log: () => undefined }; // Default logger does nothing
   constructor(
     backend: Backend,

--- a/packages/unmock-node/src/__tests__/dynamicService.test.ts
+++ b/packages/unmock-node/src/__tests__/dynamicService.test.ts
@@ -2,8 +2,7 @@ import axios from "axios";
 import { u } from "unmock-core";
 import unmock from "..";
 
-const expectNServices = (expectedLength: number) =>
-  expect(Object.keys(unmock.services).length).toEqual(expectedLength);
+const nServices = () => Object.keys(unmock.services).length;
 
 // @ts-ignore // we access private fields in this test for simplicity; it would probably be cleaner to have some of these as E2E tests
 const getPrivateSchema = (name: string) => unmock.services[name].core.oasSchema;
@@ -12,12 +11,12 @@ describe("Tests dynamic path tests", () => {
   beforeEach(() => unmock.reloadServices());
   describe("Paths can be defined using arrays and regexs", () => {
     it("Also handles multiple parameters", async () => {
-      expectNServices(0);
+      expect(nServices()).toEqual(0);
       unmock
         .nock("https://www.foo.com", "foo")
         .get(["foo", ["baz", /\W+/], "bar", /\d+/, ["spam", /eggs/]])
         .reply(200);
-      expectNServices(1);
+      expect(nServices()).toEqual(1);
       const schema = getPrivateSchema("foo");
       expect(Object.keys(schema.paths).length).toEqual(1);
       const path = Object.keys(schema.paths)[0];

--- a/packages/unmock-node/src/backend.ts
+++ b/packages/unmock-node/src/backend.ts
@@ -1,4 +1,4 @@
-import { Backend, IServiceDef } from "unmock-core";
+import { Backend } from "unmock-core";
 import { IInterceptorOptions } from "unmock-core/src/interceptor";
 import createFsServiceDefLoader from "./fs-service-def-loader";
 import NodeInterceptor from "./interceptor/node-interceptor";
@@ -14,7 +14,6 @@ export interface INodeBackendOptions {
  * filesystem at construction.
  */
 export default class NodeBackend extends Backend {
-  private readonly servicesDirectory?: string;
   public constructor(config?: INodeBackendOptions) {
     const servicesDirectory = config && config.servicesDirectory;
     const listeners = [
@@ -23,18 +22,12 @@ export default class NodeBackend extends Backend {
       }),
       FSSnapshotter.getOrUpdateSnapshotter({}),
     ];
+    const serviceDefLoader = createFsServiceDefLoader(servicesDirectory);
     super({
       interceptorFactory: (options: IInterceptorOptions) =>
         new NodeInterceptor(options),
       listeners,
+      serviceDefLoader,
     });
-    this.servicesDirectory = config && config.servicesDirectory;
-    this.loadServices();
-  }
-
-  public loadServices() {
-    const serviceDefLoader = createFsServiceDefLoader(this.servicesDirectory);
-    const serviceDefs: IServiceDef[] = serviceDefLoader.loadSync();
-    this.updateServiceDefs(serviceDefs);
   }
 }


### PR DESCRIPTION
- Make `Backend` a concrete class by adding `serviceDefLoader` as dependency
  - Gets rid of inheritance 🎉 
  - Puts all "backend" logic into one place
  - Classes like `NodeBackend` are then just wrappers calling `super`
- Expose `backend` and `backend.handleRequest` from `unmock` object. 
  - Users of `UnmockPackage` can then access the algorithm without hacking the interceptor, like in #318 