### PR TITLE
CLI improvement #303

### DIFF
--- a/packages/unmock-cli/README.md
+++ b/packages/unmock-cli/README.md
@@ -10,3 +10,18 @@
 [coverage]: https://coveralls.io/github/unmock/unmock-js
 
 This package contains the base functions needed to build or extend the [unmock](../unmock/README.md) CLI.  It also contains the cli itself for testing purposes.
+
+## Usage: unmock `<command>`
+
+### Options:
+  - `-h, --help` output usage information
+
+### Commands:
+  - `init [options] [dirname]` Sets up a new test suite
+    - `--installer [installer]`  Specify Package Manager (yarn/npm)
+    - `--offline` Specify whether to allow install from cache
+    - `--verbose` Specify verbosity of output messages
+
+  - `curl [options] <url>`
+  - `open [options] <hash>`
+  - `list`

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "commander": "^2.20.0",
     "glob": "^7.1.3",
-    "unmock-core": "file:../unmock-core"
+    "unmock-core": "file:../unmock-core",
+    "unmock-node": "file:../unmock-node"
   }
 }

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -16,8 +16,11 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
+    "@types/readline-sync": "^1.4.3",
+    "chalk": "^2.4.2",
     "commander": "^2.20.0",
     "glob": "^7.1.3",
+    "readline-sync": "^1.4.10",
     "unmock-core": "file:../unmock-core",
     "unmock-node": "file:../unmock-node"
   }

--- a/packages/unmock-cli/src/commands/curl.ts
+++ b/packages/unmock-cli/src/commands/curl.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+import { unmock } from "unmock-node";
+
+export const makeHeaders = (headers: string[]) =>
+  headers
+    .map(h => ({
+      [h.substring(0, h.indexOf(":")).trim()]: h
+        .substring(h.indexOf(":") + 1)
+        .trim(),
+    }))
+    .reduce((a, b) => ({ ...a, ...b }), {});
+
+export const curlInternal = async (url: string, options: any) => {
+  await unmock({
+    ...(options.signature ? { signature: options.signature } : {}),
+  });
+  const { data } = await axios({
+    ...(options.data ? { data: JSON.parse(options.data) } : {}),
+    ...(options.headers ? { headers: makeHeaders(options.headers) } : {}),
+    method: options.request || "GET",
+    url,
+  });
+  return data;
+};
+
+export const curl = async (url: string, options: any) => {
+  const data = curlInternal(url, options);
+  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+};

--- a/packages/unmock-cli/src/commands/index.ts
+++ b/packages/unmock-cli/src/commands/index.ts
@@ -1,0 +1,3 @@
+export { curl } from "./curl";
+export { open } from "./open";
+export { list } from "./list";

--- a/packages/unmock-cli/src/commands/index.ts
+++ b/packages/unmock-cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+export { init } from "./init";
 export { curl } from "./curl";
 export { open } from "./open";
 export { list } from "./list";

--- a/packages/unmock-cli/src/commands/init.starter.tmp.ts
+++ b/packages/unmock-cli/src/commands/init.starter.tmp.ts
@@ -1,0 +1,56 @@
+export default `\
+/**
+ * Unmock Starter Template
+ *
+ * This is just to get you started, feel free to delete this.
+ * Place your tests in this file.
+ */
+const unmock = require("unmock");
+
+// Some dummy fetching function
+const getUsersForUI = async () => {
+  try {
+    const { data } = await fetch("https://api.example.com/v1/users");
+    return {
+      ...data,
+      users: data.users.map(user => ({ ...user, seen: false })),
+      newlyFetched: true,
+      timestamp: new Date().getTime()
+    };
+  } catch (e) {
+    return {
+      users: [],
+      error: e
+    }
+  }
+};
+
+// Basic unmock test
+const { u } = unmock;
+
+signs = ['Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo', 'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'];
+
+unmock
+  .default
+  .nock("https://api.example.com/v1", "example")
+  .get("/users")
+  .reply(200, {
+    users: u.array({ // an array of arbitrary length
+      id: u.integer(), // an arbitrary integer
+      name: u.string("name.firstName"), // an arbitrary first name
+      zodiac: u.opt({ // an optional arbitrary zodiac
+        sign: u.stringEnum(signs), // an arbitrary zodiac sign
+        ascendant: u.opt(u.string()) // an optional arbitrary string
+      })
+    })
+  });
+
+beforeAll(() => {
+  unmock.default.on();
+});
+
+test("test get users for UI", async () => {
+  const usersForUI = await getUsersForUI();
+  expect(typeof usersForUI.timestamp).toBe("number");
+});
+`;

--- a/packages/unmock-cli/src/commands/init.ts
+++ b/packages/unmock-cli/src/commands/init.ts
@@ -1,0 +1,131 @@
+import * as path from "path";
+import { mkdirSync, rmdirSync, writeFileSync, accessSync, constants } from "fs";
+import { question as prompt } from "readline-sync";
+import chalk from "chalk";
+
+import WinstonLogger from "../utils/logger";
+import NodePkgInstaller, {
+  INodePkgInstallerOpts,
+} from "../utils/NodePkgInstaller";
+import initStarterTmp from "./init.starter.tmp";
+
+const CWD = process.cwd();
+const logger = new WinstonLogger();
+
+export const init = (dirname: string = "__tests__", options: any) => {
+  const pkgJson: any = require(path.join(CWD, "package.json"));
+  const projectName: string = (pkgJson && pkgJson.name) || "";
+  const testSuiteDir: string = path.join(CWD, dirname);
+  const unmockDir: string = path.normalize(
+    `${testSuiteDir}${path.sep}__unmock__`,
+  );
+
+  logger.log(
+    `Creating test suite${(projectName &&
+      " for " + chalk.magenta.bold(projectName)) ||
+      ""}...`,
+  );
+
+  // Try to create directories
+  try {
+    mkdirSync(testSuiteDir);
+    mkdirSync(unmockDir);
+  } catch (error) {
+    const deletePreviousTestsAnwser = prompt(
+      `${chalk.yellow.bold(
+        "unmock",
+      )}: Do you wish to override existing tests?\n        (${chalk.yellow(
+        "Warning: this will result in the loss of previous tests",
+      )})\n        [Y/n]`,
+    );
+    const deletePreviousTests = deletePreviousTestsAnwser == "Y" ? true : false;
+
+    if (deletePreviousTests) {
+      // delete and continue
+      rmdirSync(testSuiteDir);
+    } else {
+      // exit with error
+      logger.error(error);
+      process.exit(0);
+    }
+  }
+
+  // Start dependency installation process
+  logger.log("Installing dependencies...");
+
+  const installer = new NodePkgInstaller(<INodePkgInstallerOpts>{
+    root: CWD,
+    useYarn: options.installer != "npm" ? true : false,
+    usePnp: false,
+    verbose: options.verbose,
+    isOnline: !options.offline,
+    isDev: true,
+  });
+  const dependencies = ["unmock", "jest", "unmock-jest"];
+
+  installer
+    .install(dependencies)
+    .then(() => {
+      // After install
+      // create starter template
+      logger.log("Creating starter template...");
+      writeFileSync(path.join(CWD, dirname, "1.test.js"), initStarterTmp);
+
+      // setup the jest reporter
+      logger.log("Configuring the jest reporter...");
+      setupJestReport(projectName, unmockDir);
+
+      logger.log("Setup complete!");
+
+      // guides...
+      console.info(
+        `\n    Start writing tests in ${chalk.grey(`./${dirname}/`) +
+          chalk.grey.bold("1.test.js")}\n    Enjoy testing APIs with unmock!\n`,
+      );
+    })
+    .catch(() => {
+      logger.error("Unable to install dependencies.");
+      process.exit(0); // be sure to exit
+    });
+};
+
+function setupJestReport(
+  projectName: string = "unmock",
+  outputDirectory: string = "/",
+) {
+  const jestConfigPath = path.join(CWD, "jest.config.js");
+
+  // @TODO handle 'else' case
+  if (!fileExistsSync(jestConfigPath)) {
+    writeFileSync(jestConfigPath, jestConfigTmp(projectName, outputDirectory));
+  }
+}
+
+function jestConfigTmp(projectName: string, outputDirectory: string) {
+  return `\
+// jest.config.js
+{
+  reporters: [
+    "default",
+    [
+      "unmock-jest",
+      {
+        outputDirectory: "${outputDirectory}",
+        outputFilename: "${projectName}-report.html"
+      }
+    ]
+  ];
+}\n`;
+}
+
+function fileExistsSync(path: string) {
+  let result = true;
+
+  try {
+    accessSync(path, constants.F_OK);
+  } catch (e) {
+    result = false;
+  }
+
+  return result;
+}

--- a/packages/unmock-cli/src/commands/init.ts
+++ b/packages/unmock-cli/src/commands/init.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import { mkdirSync, rmdirSync, writeFileSync, accessSync, constants } from "fs";
+import { execSync } from "child_process";
 import { question as prompt } from "readline-sync";
 import chalk from "chalk";
 
@@ -53,15 +54,16 @@ export const init = (dirname: string = "__tests__", options: any) => {
   // Start dependency installation process
   logger.log("Installing dependencies...");
 
+  const dependencies = ["unmock", "jest", "unmock-jest"];
+  const useYarn = yarnExists() && options.installer != "npm" ? true : false;
   const installer = new NodePkgInstaller(<INodePkgInstallerOpts>{
     root: CWD,
-    useYarn: options.installer != "npm" ? true : false,
+    useYarn,
     usePnp: false,
     verbose: options.verbose,
     isOnline: !options.offline,
     isDev: true,
   });
-  const dependencies = ["unmock", "jest", "unmock-jest"];
 
   installer
     .install(dependencies)
@@ -128,4 +130,13 @@ function fileExistsSync(path: string) {
   }
 
   return result;
+}
+
+function yarnExists(): boolean {
+  try {
+    execSync("yarnpkg --version", { stdio: "ignore" });
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/packages/unmock-cli/src/commands/list.ts
+++ b/packages/unmock-cli/src/commands/list.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import * as glob from "glob";
 import * as path from "path";
 import { ILogger } from "unmock-core";
-import WinstonLogger from "../logger";
+import WinstonLogger from "../utils/logger";
 
 const removeTrailingNumber = (s: string) =>
   s

--- a/packages/unmock-cli/src/commands/list.ts
+++ b/packages/unmock-cli/src/commands/list.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "fs";
+import * as glob from "glob";
+import * as path from "path";
+import { ILogger } from "unmock-core";
+import WinstonLogger from "../logger";
+
+const removeTrailingNumber = (s: string) =>
+  s
+    .split(" ")
+    .slice(0, -1)
+    .join(" ");
+
+const SNAP_SUFFIX = ".snap";
+const DEFAULT_SNAPSHOTS_FOLDER = ".snapshots";
+interface IStringMap {
+  [key: string]: string[];
+}
+
+export const listInternal = (logger: ILogger): Promise<undefined> => {
+  return new Promise((resolve, reject) => {
+    logger.log("Fetching mocks and relevant tests...");
+    glob(
+      `${process.cwd()}/**/${DEFAULT_SNAPSHOTS_FOLDER}/**/*${SNAP_SUFFIX}`,
+      { dot: true },
+      (e, matches) => {
+        if (e) {
+          reject(e);
+          return;
+        }
+        matches.forEach(match => {
+          logger.log(path.basename(match, SNAP_SUFFIX));
+          const snapshots = JSON.parse(readFileSync(match, "utf8"));
+          const tests: IStringMap = Object.keys(snapshots).reduce(
+            (obj: IStringMap, name) => {
+              const key = removeTrailingNumber(name);
+              (obj[key] = obj[key] || []).push(name);
+              return obj;
+            },
+            {},
+          );
+          Object.keys(tests).forEach(test => {
+            logger.log(`  ${test}`);
+            tests[test].forEach(call => {
+              logger.log(`    hash: ${snapshots[call].hash}`);
+              logger.log(`      method: ${snapshots[call].method}`);
+              logger.log(`      host: ${snapshots[call].host}`);
+              logger.log(`      path: ${snapshots[call].path}`);
+            });
+          });
+        });
+        resolve();
+      },
+    );
+  });
+};
+
+export const list = async () => {
+  await listInternal(new WinstonLogger());
+};

--- a/packages/unmock-cli/src/commands/open.ts
+++ b/packages/unmock-cli/src/commands/open.ts
@@ -1,0 +1,29 @@
+import * as child_process from "child_process";
+import * as glob from "glob";
+import WinstonLogger from "../logger";
+
+export const open = (hash: string, options: any) => {
+  const logger = new WinstonLogger();
+  const editor = options.editor || process.env.EDITOR || "vi";
+  glob(
+    `${process.cwd()}/**/${hash}/response.json`,
+    { dot: true, nosort: true },
+    (e, matches) => {
+      if (e || matches.length !== 1) {
+        logger.log(
+          e || matches.length === 0
+            ? `Could not find ${hash}`
+            : `Too many matches: ${matches}`,
+        );
+        return;
+      }
+      const path = matches[0];
+      const child = child_process.spawn(editor, [path], {
+        stdio: "inherit",
+      });
+      child.on("exit", () => {
+        logger.log(`Done editing ${hash}.`);
+      });
+    },
+  );
+};

--- a/packages/unmock-cli/src/commands/open.ts
+++ b/packages/unmock-cli/src/commands/open.ts
@@ -1,6 +1,6 @@
 import * as child_process from "child_process";
 import * as glob from "glob";
-import WinstonLogger from "../logger";
+import WinstonLogger from "../utils/logger";
 
 export const open = (hash: string, options: any) => {
   const logger = new WinstonLogger();

--- a/packages/unmock-cli/src/index.ts
+++ b/packages/unmock-cli/src/index.ts
@@ -1,5 +1,5 @@
 import * as program from "commander";
-import { curl, list, open } from "./commands/";
+import { init, curl, list, open } from "./commands/";
 
 export default () => {
   const collect = (val: string, memo: string[]) => {
@@ -8,6 +8,13 @@ export default () => {
   };
 
   program.usage("unmock <command>");
+
+  program
+    .command("init [dirname]")
+    .option("--installer [installer]", "Specify Package Manager (yarn/npm)")
+    .option("--offline", "Specify whether to allow install from cache")
+    .option("--verbose", "Specify verbosity of output messages")
+    .action(init);
 
   program
     .command("curl <url>")

--- a/packages/unmock-cli/src/index.ts
+++ b/packages/unmock-cli/src/index.ts
@@ -1,7 +1,40 @@
 import * as program from "commander";
+import { curl, list, open } from "./commands/";
 
 export default () => {
+  const collect = (val: string, memo: string[]) => {
+    memo.push(val);
+    return memo;
+  };
+
   program.usage("unmock <command>");
-  program.command("init");
+
+  program
+    .command("curl <url>")
+    .option("-d, --data [data]", "HTTP POST data")
+    .option(
+      "-H, --header [header]",
+      "Pass custom header(s) to server",
+      collect,
+      [],
+    )
+    .option("-X", "--request [command]", "Specify request command to use")
+    .option(
+      "-S",
+      "--signature [signature]",
+      "Specify a signature for a request in tokenless mode",
+    )
+    .action(curl);
+
+  program
+    .command("open <hash>")
+    .option(
+      "-e, --editor [editor]",
+      "editor (defaults to the EDITOR env variable or, in the absence of this, vi)",
+    )
+    .action(open);
+
+  program.command("list").action(list);
+
   program.parse(process.argv);
 };

--- a/packages/unmock-cli/src/logger.ts
+++ b/packages/unmock-cli/src/logger.ts
@@ -1,0 +1,27 @@
+import { ILogger } from "unmock-core";
+import * as winston from "winston";
+
+const logger = winston.createLogger({
+  levels: { unmock: 2 },
+  transports: [
+    new winston.transports.Console({
+      format: winston.format.combine(
+        winston.format.colorize(),
+        winston.format.simple(),
+      ),
+      level: "unmock",
+      stderrLevels: ["unmock"],
+    }),
+  ],
+});
+
+winston.addColors({ unmock: "cyan bold" });
+
+export default class WinstonLogger implements ILogger {
+  public log(message: string) {
+    logger.log({
+      level: "unmock",
+      message,
+    });
+  }
+}

--- a/packages/unmock-cli/src/utils/NodePkgInstaller.ts
+++ b/packages/unmock-cli/src/utils/NodePkgInstaller.ts
@@ -1,0 +1,78 @@
+import { spawn } from "child_process";
+import chalk from "chalk";
+
+/**
+ * NodePkgInstaller
+ *
+ * inspired by create-react-app's internal package installer
+ */
+export default class NodePkgInstaller {
+  constructor(public options: INodePkgInstallerOpts) {}
+
+  public install(dependencies: string[]) {
+    return new Promise((resolve, reject) => {
+      const { root, useYarn, usePnp, verbose, isOnline, isDev } = this.options;
+
+      let command: string;
+      let args: string[];
+
+      if (useYarn) {
+        command = "yarnpkg";
+        args = ["add", "--exact"];
+
+        if (!isOnline) args.push("--offline");
+        if (usePnp) args.push("--enable-pnp");
+        if (isDev) args.push("-D");
+
+        args = args.concat(dependencies);
+
+        args.push("--cwd");
+        args.push(root);
+
+        if (!isOnline) {
+          console.log(chalk.yellow("You appear to be offline."));
+          console.log(
+            chalk.yellow("Falling back to the local Yarn cache.") + "\n",
+          );
+        }
+      } else {
+        command = "npm";
+        args = ["install", "--save", "--save-exact", "--loglevel", "error"];
+
+        if (isDev) args.push("--save-dev");
+
+        args = args.concat(dependencies);
+
+        if (usePnp) {
+          console.log(chalk.yellow("NPM doesn't support PnP."));
+          console.log(
+            chalk.yellow("Falling back to the regular installs.") + "\n",
+          );
+        }
+      }
+
+      if (verbose) args.push("--verbose");
+
+      const child = spawn(command, args, { stdio: "inherit" });
+
+      child.on("close", code => {
+        if (code !== 0) {
+          reject({
+            command: `${command} ${args.join(" ")}`,
+          });
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+export interface INodePkgInstallerOpts {
+  root: string;
+  useYarn: boolean;
+  usePnp: boolean;
+  verbose: boolean;
+  isOnline: boolean;
+  isDev: boolean;
+}

--- a/packages/unmock-cli/src/utils/logger.ts
+++ b/packages/unmock-cli/src/utils/logger.ts
@@ -2,7 +2,7 @@ import { ILogger } from "unmock-core";
 import * as winston from "winston";
 
 const logger = winston.createLogger({
-  levels: { unmock: 2 },
+  levels: { unmock: 2, unmockError: 0 },
   transports: [
     new winston.transports.Console({
       format: winston.format.combine(
@@ -15,12 +15,19 @@ const logger = winston.createLogger({
   ],
 });
 
-winston.addColors({ unmock: "cyan bold" });
+winston.addColors({ unmock: "cyan bold", unmockError: "red bold" });
 
 export default class WinstonLogger implements ILogger {
   public log(message: string) {
     logger.log({
       level: "unmock",
+      message,
+    });
+  }
+
+  public error(message: string) {
+    logger.log({
+      level: "unmockError",
       message,
     });
   }

--- a/packages/unmock-cli/tsconfig.json
+++ b/packages/unmock-cli/tsconfig.json
@@ -6,7 +6,5 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__"],
-  "references": [
-    { "path": "../unmock-core" }
-  ]
+  "references": [{ "path": "../unmock-core" }, { "path": "../unmock-node" }]
 }


### PR DESCRIPTION
This update adds the `init` command to the CLI. But, it pretty much does plenty useful things so far:
  - creates test suite structure
  - installs dependencies
  - creates starter template
  - sets up the jest reporter

More features could definitely be added. But I'd like to do that gradually.

It could be used as follows: `unmock init`.

`init [options] [dirname]` Sets up a new test suite
  - `--installer [installer]`  Specify Package Manager (yarn/npm)
  - `--offline` Specify whether to allow install from cache
  - `--verbose` Specify verbosity of output messages

[Read more](https://github.com/bukharim96/unmock-js/tree/dev/packages/unmock-cli#unmock-cli).