### PR TITLE
Simplify fetch interface.

### DIFF
--- a/packages/unmock-fetch/README.md
+++ b/packages/unmock-fetch/README.md
@@ -20,34 +20,23 @@ yarn add unmock-fetch -D
 
 ```ts
 import { buildFetch } from "unmock-fetch";
-import { ISerializedRequest, ISerializedResponse, OnSerializedRequest } from "unmock-core";
+import { CreateResponse, ISerializedRequest, ISerializedResponse, OnSerializedRequest } from "unmock-core";
 
 // Define what to do with the intercepted request
-const requestCb: OnSerializedRequest = (
-  req: ISerializedRequest,
-  sendResponse: (res: ISerializedResponse) => void,
-  emitError: (e: Error) => void,
-) => {
-  try {
-    // Use `req` to determine how to respond
-    // and create an `ISerializedResponse`
-    const res: ISerializedResponse = {
-      headers: {},
-      statusCode: 200,
-      body: JSON.stringify({
-        ok: true,
-      }),
-    };
-    // Send response with `sendResponse`
-    sendResponse(res);
-  } catch (err) {
-    // If things go wrong, emit an error from the call with `emitError`  
-    emitError(err);
-  }
+const responseCreator: CreateResponse = (
+  req: ISerializedRequest
+): ISerializedResponse => {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: JSON.stringify({
+      ok: true,
+    }),
+  };
 };
 
 // Build `fetch` with your callback
-const fetch = buildFetch(requestCb);
+const fetch = buildFetch(responseCreator);
 
 // Make API calls!
 const response = await fetch("https://example.com");
@@ -65,7 +54,7 @@ To override `global.fetch` or `window.fetch`, use the default import:
 import FetchInterceptor from "unmock-fetch";
 
 // What to do with serialized request
-const requestCb: OnSerializedRequest = /* as above */
+const requestCb: CreateResponse = /* as above */
 
 // Intercept `global.fetch` or `window.fetch`
 FetchInterceptor.on(requestCb);

--- a/packages/unmock-fetch/src/__tests__/index.test.ts
+++ b/packages/unmock-fetch/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import {
   ISerializedResponse,
   OnSerializedRequest,
 } from "unmock-core/dist/interfaces";
-import UnmockFetch, { buildFetch, CreateResponse } from "../";
+import UnmockFetch, { buildFetch } from "../";
 
 const testUrl = "http://example.com";
 

--- a/packages/unmock-fetch/src/__tests__/index.test.ts
+++ b/packages/unmock-fetch/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import {
   ISerializedResponse,
   OnSerializedRequest,
 } from "unmock-core/dist/interfaces";
-import UnmockFetch, { buildFetch } from "../";
+import UnmockFetch, { buildFetch, CreateResponse } from "../";
 
 const testUrl = "http://example.com";
 
@@ -32,11 +32,29 @@ const respondOk: OnSerializedRequest = (
   }
 };
 
+const okResponseCreator: CreateResponse = (
+  _: ISerializedRequest,
+): ISerializedResponse => {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: JSON.stringify({
+      ok: true,
+    }),
+  };
+};
+
 const fetch = buildFetch(respondOk);
+const fetchFromResponseCreator = buildFetch(okResponseCreator);
 
 describe("Built fetch", () => {
-  it("should respond as expected", async () => {
+  it("should respond as expected when used with callback", async () => {
     const response = await fetch(testUrl);
+    expect(response.ok).toBe(true);
+  });
+
+  it("should respond as expected when used with response creator", async () => {
+    const response = await fetchFromResponseCreator(testUrl);
     expect(response.ok).toBe(true);
   });
 });

--- a/packages/unmock-fetch/src/__tests__/index.test.ts
+++ b/packages/unmock-fetch/src/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  CreateResponse,
   ISerializedRequest,
   ISerializedResponse,
   OnSerializedRequest,

--- a/packages/unmock-fetch/src/fetch.ts
+++ b/packages/unmock-fetch/src/fetch.ts
@@ -12,7 +12,7 @@ const debugLog = debug("unmock:fetch-mitm");
 
 const isCreateResponse = (
   cb: CreateResponse | OnSerializedRequest,
-): cb is CreateResponse => cb.length === 1;
+): cb is CreateResponse => cb.length === 1; // Check the number of function arguments
 
 export const buildFetch = (cb: CreateResponse | OnSerializedRequest): Fetch =>
   function fetch(url: RequestInfo, init?: RequestInit): Promise<Response> {

--- a/packages/unmock-fetch/src/fetch.ts
+++ b/packages/unmock-fetch/src/fetch.ts
@@ -21,7 +21,7 @@ export const buildFetch = (cb: CreateResponse | OnSerializedRequest): Fetch =>
 
     return new Promise((resolve, reject) => {
       const sendResponse = (res: ISerializedResponse): void => {
-        const responseInit: ResponseInit = { status: res.statusCode };
+        const responseInit: ResponseInit = { status: res.statusCode }; // TODO Headers
         resolve(new Response(res.body, responseInit));
       };
 

--- a/packages/unmock-fetch/src/fetch.ts
+++ b/packages/unmock-fetch/src/fetch.ts
@@ -32,10 +32,9 @@ export const buildFetch = (cb: CreateResponse | OnSerializedRequest): Fetch =>
           try {
             const res = cb(req);
             if (typeof res === "undefined") {
-              reject("Empty response");
-            } else {
-              sendResponse(res);
+              return reject("Empty response");
             }
+            sendResponse(res);
           } catch (err) {
             reject(err);
           }

--- a/packages/unmock-fetch/src/index.ts
+++ b/packages/unmock-fetch/src/index.ts
@@ -1,10 +1,13 @@
 import {
+  CreateResponse,
   ISerializedRequest,
   ISerializedResponse,
   OnSerializedRequest,
 } from "unmock-core/dist/interfaces";
 import buildFetch from "./fetch";
 export { buildFetch };
+
+// export type CreateResponse = (req: ISerializedRequest) => ISerializedResponse;
 
 export type Listener = (
   req: ISerializedRequest,
@@ -31,7 +34,7 @@ let fetchInterceptor: FetchInterceptor | undefined;
 export class FetchInterceptor {
   public readonly fetch: Fetch;
   private originalFetch?: { where: any; fetch: any };
-  constructor(onSerializedRequest: OnSerializedRequest) {
+  constructor(onSerializedRequest: CreateResponse | OnSerializedRequest) {
     this.fetch = buildFetch(onSerializedRequest);
     if (typeof global !== "undefined") {
       this.originalFetch = {
@@ -59,7 +62,7 @@ export default {
    * global.fetch and/or window.fetch.
    * @param onSerializedRequest Optional "algorithm" for determining the fake response
    */
-  on(onSerializedRequest: OnSerializedRequest) {
+  on(onSerializedRequest: CreateResponse | OnSerializedRequest) {
     this.off();
     fetchInterceptor = new FetchInterceptor(onSerializedRequest);
     return fetchInterceptor;

--- a/packages/unmock-fetch/src/index.ts
+++ b/packages/unmock-fetch/src/index.ts
@@ -7,8 +7,6 @@ import {
 import buildFetch from "./fetch";
 export { buildFetch };
 
-// export type CreateResponse = (req: ISerializedRequest) => ISerializedResponse;
-
 export type Listener = (
   req: ISerializedRequest,
   respond: (res: ISerializedResponse) => void,


### PR DESCRIPTION
- Simplify the fetch interface: allow passing in a function of type `CreateResponse: (req: ISerializedRequest) => ISerializedResponse | undefined`, not unlike in the Python version
- It would be nicer if `CreateResponse` was typed so that the response is `ISerializedResponse` and never `undefined`. This goes back to the old discussion of whether the algorithm should return `undefined` or just throw an exception when no match is found. I'm maybe starting to change my mind, not finding a matcher should just be an exception. Maybe an exception of specific instance still so that the core knows to handle it differently than unexpected errors, if needed.