### PR TITLE
Add setting for randomization.

### DIFF
--- a/packages/unmock-core/src/__tests__/index.test.ts
+++ b/packages/unmock-core/src/__tests__/index.test.ts
@@ -1,0 +1,66 @@
+import { buildFetch, Fetch } from "unmock-fetch";
+import { IService, IServiceDefLoader, u, UnmockPackage } from "../";
+import { Backend } from "../backend";
+import { IInterceptorOptions } from "../interceptor";
+
+let fetch: Fetch;
+
+const interceptorFactory = (opts: IInterceptorOptions) => {
+  fetch = buildFetch(opts.onSerializedRequest);
+  return {
+    disable() {
+      // @ts-ignore
+      fetch = undefined;
+    },
+  };
+};
+
+const serviceDefLoader: IServiceDefLoader = {
+  loadSync() {
+    return [];
+  },
+};
+
+const backend = new Backend({
+  interceptorFactory,
+  serviceDefLoader,
+});
+
+const unmock = new UnmockPackage(backend);
+
+let foo: IService;
+beforeAll(() => {
+  unmock
+    .nock("https://www.foo.com", "foo")
+    .get("/hello")
+    .reply(200, { foo: u.string() });
+  foo = unmock.on().services.foo;
+});
+beforeEach(() => foo.reset());
+afterAll(() => unmock.off());
+
+describe("Unmock with fetch", () => {
+  it("returns expected body", async () => {
+    const response = await fetch("https://www.foo.com/hello");
+    expect(response.ok).toBe(true);
+    const body = await response.json();
+    expect(body).toHaveProperty("foo");
+  });
+  describe("randomize", () => {
+    afterAll(() => {
+      unmock.randomize.off();
+    });
+    it("should return the same body when not randomized", async () => {
+      unmock.randomize.off();
+      const body1 = await (await fetch("https://www.foo.com/hello")).json();
+      const body2 = await (await fetch("https://www.foo.com/hello")).json();
+      expect(body1).toEqual(body2);
+    });
+    it("should not return the same body when randomized", async () => {
+      unmock.randomize.on();
+      const body1 = await (await fetch("https://www.foo.com/hello")).json();
+      const body2 = await (await fetch("https://www.foo.com/hello")).json();
+      expect(body1).not.toEqual(body2);
+    });
+  });
+});

--- a/packages/unmock-core/src/__tests__/index.test.ts
+++ b/packages/unmock-core/src/__tests__/index.test.ts
@@ -39,24 +39,24 @@ beforeAll(() => {
 beforeEach(() => foo.reset());
 afterAll(() => unmock.off());
 
-describe("Unmock with fetch", () => {
-  it("returns expected body", async () => {
+describe("Unmock", () => {
+  it("returns body with expected property", async () => {
     const response = await fetch("https://www.foo.com/hello");
     expect(response.ok).toBe(true);
     const body = await response.json();
     expect(body).toHaveProperty("foo");
   });
-  describe("randomize", () => {
+  describe("randomize setting", () => {
     afterAll(() => {
       unmock.randomize.off();
     });
-    it("should return the same body when not randomized", async () => {
+    it("should return the same body for the same request when not randomized", async () => {
       unmock.randomize.off();
       const body1 = await (await fetch("https://www.foo.com/hello")).json();
       const body2 = await (await fetch("https://www.foo.com/hello")).json();
       expect(body1).toEqual(body2);
     });
-    it("should not return the same body when randomized", async () => {
+    it("should not return the same body for the same request when randomized", async () => {
       unmock.randomize.on();
       const body1 = await (await fetch("https://www.foo.com/hello")).json();
       const body2 = await (await fetch("https://www.foo.com/hello")).json();

--- a/packages/unmock-core/src/__tests__/random-number-generator.test.ts
+++ b/packages/unmock-core/src/__tests__/random-number-generator.test.ts
@@ -1,0 +1,18 @@
+import { randomNumberGenerator } from "../random-number-generator";
+
+describe("Random number generator", () => {
+  it("should create stream of numbers", () => {
+    const rng = randomNumberGenerator({});
+    const n1 = rng.get();
+    expect(typeof n1).toBe("number");
+    const n2 = rng.get();
+    expect(n1).not.toEqual(n2);
+  });
+  it("should create the same number after setting seed", () => {
+    const rng = randomNumberGenerator({ seed: 0 });
+    const n1 = rng.get();
+    rng.setSeed(0);
+    const n2 = rng.get();
+    expect(n1).toEqual(n2);
+  });
+});

--- a/packages/unmock-core/src/__tests__/random-number-generator.test.ts
+++ b/packages/unmock-core/src/__tests__/random-number-generator.test.ts
@@ -15,4 +15,11 @@ describe("Random number generator", () => {
     const n2 = rng.get();
     expect(n1).toEqual(n2);
   });
+  it("should create the same number after restoring", () => {
+    const rng = randomNumberGenerator({ seed: 5 });
+    const n1 = rng.get();
+    rng.restore();
+    const n2 = rng.get();
+    expect(n1).toEqual(n2);
+  });
 });

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -105,7 +105,7 @@ export class Backend {
    * @returns `states` object, with which one can modify states of various services.
    */
   public initialize(options: IUnmockOptions, rngOpt?: IRandomNumberGenerator) {
-    const rng = rngOpt || randomNumberGenerator({ frozen: false });
+    const rng = rngOpt || randomNumberGenerator({ frozen: true, seed: 0 });
     if (process.env.NODE_ENV === "production" && !options.useInProduction()) {
       throw new Error("Are you trying to run unmock in production?");
     }

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -95,7 +95,7 @@ export class Backend {
     this.interceptorFactory = interceptorFactory;
     this.requestResponseListeners = listeners || [];
     this.serviceDefLoader = serviceDefLoader || NoopServiceDefLoader;
-    this.randomNumberGenerator = rng || randomNumberGenerator({ seed: 0 });
+    this.randomNumberGenerator = rng || randomNumberGenerator({});
     this.loadServices();
   }
 

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -105,7 +105,7 @@ export class Backend {
    * @returns `states` object, with which one can modify states of various services.
    */
   public initialize(options: IUnmockOptions, rngOpt?: IRandomNumberGenerator) {
-    const rng = rngOpt || randomNumberGenerator({ frozen: true, seed: 0 });
+    const rng = rngOpt || randomNumberGenerator({ seed: 0 });
     if (process.env.NODE_ENV === "production" && !options.useInProduction()) {
       throw new Error("Are you trying to run unmock in production?");
     }

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -14,6 +14,10 @@ import {
   ServiceStoreType,
 } from "../interfaces";
 import { ServiceParser } from "../parser";
+import {
+  IRandomNumberGenerator,
+  randomNumberGenerator,
+} from "../random-number-generator";
 import { IServiceCore } from "../service/interfaces";
 import { ServiceStore } from "../service/serviceStore";
 
@@ -100,7 +104,8 @@ export class Backend {
    * @param options
    * @returns `states` object, with which one can modify states of various services.
    */
-  public initialize(options: IUnmockOptions) {
+  public initialize(options: IUnmockOptions, rngOpt?: IRandomNumberGenerator) {
+    const rng = rngOpt || randomNumberGenerator({ frozen: false });
     if (process.env.NODE_ENV === "production" && !options.useInProduction()) {
       throw new Error("Are you trying to run unmock in production?");
     }
@@ -113,6 +118,7 @@ export class Backend {
     const createResponse = responseCreatorFactory({
       listeners: this.requestResponseListeners,
       options,
+      rng,
       store: this.serviceStore,
     });
 

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -61,9 +61,11 @@ import {
 import { ServiceStore } from "./service/serviceStore";
 
 export const runnerConfiguration = {
+  defaultSeed: 0,
   optionalsProbability: 1.0,
   minItems: 0,
   reset() {
+    this.defaultSeed = 0;
     this.minItems = 0;
     this.optionalsProbability = 1.0;
   },
@@ -787,6 +789,7 @@ const bodyFromResponse = (
 
 export function responseCreatorFactory({
   listeners = [],
+  options,
   rng,
   store,
 }: {
@@ -843,6 +846,13 @@ export function responseCreatorFactory({
         {},
       ),
     };
+
+    /**
+     * Ensure that every generation starts from the same seed if not randomizing.
+     */
+    if (!options.randomize) {
+      rng.setSeed(runnerConfiguration.defaultSeed);
+    }
 
     const res = generateMockFromTemplate({
       rng,

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -842,17 +842,15 @@ export function responseCreatorFactory({
         {},
       ),
     };
-    const res = generateMockFromTemplate2(
+    const res = generateMockFromTemplate({
       statusCode,
-      // headers as an object for generation
-      {
+      headerSchema: {
         definitions,
         type: "object",
         properties: headerProperties,
         required: Object.keys(headerProperties),
       },
-      // body as an object for generation
-      isNone(bodySchema)
+      bodySchema: isNone(bodySchema)
         ? undefined
         : {
             definitions,
@@ -860,7 +858,7 @@ export function responseCreatorFactory({
               ? changeRef(bodySchema.value)
               : changeRefs(bodySchema.value)),
           },
-    );
+    });
     // Notify call tracker
     const serviceName = toSchemas
       .composeLens(keyLens())
@@ -875,11 +873,15 @@ export function responseCreatorFactory({
   };
 }
 
-const generateMockFromTemplate2 = (
-  statusCode: number,
-  headerSchema?: any,
-  bodySchema?: any,
-): ISerializedResponse => {
+const generateMockFromTemplate = ({
+  statusCode,
+  headerSchema,
+  bodySchema,
+}: {
+  statusCode: number;
+  headerSchema?: any;
+  bodySchema?: any;
+}): ISerializedResponse => {
   jsf.extend("faker", () => require("faker"));
   jsf.option("optionalsProbability", runnerConfiguration.optionalsProbability);
   // When optionalsProbability is set to 100%, generate exactly 100% of all optionals.

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -45,10 +45,7 @@ import {
   ISerializedResponse,
   IUnmockOptions,
 } from "./interfaces";
-import {
-  DEFAULT_SEED,
-  IRandomNumberGenerator,
-} from "./random-number-generator";
+import { IRandomNumberGenerator } from "./random-number-generator";
 import {
   Header,
   isReference,
@@ -852,7 +849,7 @@ export function responseCreatorFactory({
      * Ensure that every generation starts from the same seed if not randomizing.
      */
     if (!options.randomize()) {
-      rng.setSeed(DEFAULT_SEED);
+      rng.restore();
     }
 
     const res = generateMockFromTemplate({

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -45,7 +45,10 @@ import {
   ISerializedResponse,
   IUnmockOptions,
 } from "./interfaces";
-import { IRandomNumberGenerator } from "./random-number-generator";
+import {
+  DEFAULT_SEED,
+  IRandomNumberGenerator,
+} from "./random-number-generator";
 import {
   Header,
   isReference,
@@ -61,11 +64,9 @@ import {
 import { ServiceStore } from "./service/serviceStore";
 
 export const runnerConfiguration = {
-  defaultSeed: 0,
   optionalsProbability: 1.0,
   minItems: 0,
   reset() {
-    this.defaultSeed = 0;
     this.minItems = 0;
     this.optionalsProbability = 1.0;
   },
@@ -851,7 +852,7 @@ export function responseCreatorFactory({
      * Ensure that every generation starts from the same seed if not randomizing.
      */
     if (!options.randomize()) {
-      rng.setSeed(runnerConfiguration.defaultSeed);
+      rng.setSeed(DEFAULT_SEED);
     }
 
     const res = generateMockFromTemplate({

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -787,7 +787,7 @@ const bodyFromResponse = (
 
 export function responseCreatorFactory({
   listeners = [],
-  rng: seedGenerator,
+  rng,
   store,
 }: {
   listeners?: IListener[];
@@ -845,7 +845,7 @@ export function responseCreatorFactory({
     };
 
     const res = generateMockFromTemplate({
-      seedGenerator,
+      rng,
       statusCode,
       headerSchema: {
         definitions,
@@ -878,12 +878,12 @@ export function responseCreatorFactory({
 }
 
 const generateMockFromTemplate = ({
-  seedGenerator,
+  rng,
   statusCode,
   headerSchema,
   bodySchema,
 }: {
-  seedGenerator: IRandomNumberGenerator;
+  rng: IRandomNumberGenerator;
   statusCode: number;
   headerSchema?: any;
   bodySchema?: any;
@@ -900,7 +900,7 @@ const generateMockFromTemplate = ({
   // jsf.option("minItems", runnerConfiguration.minItems);
   // jsf.option("minLength", runnerConfiguration.minItems);
   jsf.option("useDefaultValue", false);
-  jsf.option("random", seedGenerator);
+  jsf.option("random", () => rng.get());
   const bodyAsJson = bodySchema ? jsf.generate(bodySchema) : undefined;
   const body = bodyAsJson ? JSON.stringify(bodyAsJson) : undefined;
   jsf.option("useDefaultValue", true);

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -855,7 +855,7 @@ export function responseCreatorFactory({
     }
 
     const res = generateMockFromTemplate({
-      rng,
+      rng: () => rng.get(),
       statusCode,
       headerSchema: {
         definitions,
@@ -893,7 +893,7 @@ const generateMockFromTemplate = ({
   headerSchema,
   bodySchema,
 }: {
-  rng: IRandomNumberGenerator;
+  rng: () => number;
   statusCode: number;
   headerSchema?: any;
   bodySchema?: any;
@@ -910,7 +910,7 @@ const generateMockFromTemplate = ({
   // jsf.option("minItems", runnerConfiguration.minItems);
   // jsf.option("minLength", runnerConfiguration.minItems);
   jsf.option("useDefaultValue", false);
-  jsf.option("random", () => rng.get());
+  jsf.option("random", rng);
   const bodyAsJson = bodySchema ? jsf.generate(bodySchema) : undefined;
   const body = bodyAsJson ? JSON.stringify(bodyAsJson) : undefined;
   jsf.option("useDefaultValue", true);

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -850,7 +850,7 @@ export function responseCreatorFactory({
     /**
      * Ensure that every generation starts from the same seed if not randomizing.
      */
-    if (!options.randomize) {
+    if (!options.randomize()) {
       rng.setSeed(runnerConfiguration.defaultSeed);
     }
 

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -58,7 +58,7 @@ export class UnmockPackage implements IUnmockPackage {
     this.allowedHosts = new AllowedHosts();
     this.useInProduction = new BooleanSetting();
 
-    const rng = randomNumberGenerator({ frozen: true, seed: 0 });
+    const rng = randomNumberGenerator({ frozen: false, seed: 0 });
     this.randomNumberGenerator = rng;
     this.randomize = randomizeSetting(rng);
   }

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -19,6 +19,10 @@ export class UnmockPackage implements IUnmockPackage {
   public allowedHosts: AllowedHosts;
   public flaky: BooleanSetting;
   public useInProduction: BooleanSetting;
+  /**
+   * Always return a new randomized response instead of using a fixed seed.
+   */
+  public randomize: BooleanSetting;
   public readonly backend: Backend;
   private logger: ILogger = { log: () => undefined }; // Default logger does nothing
   constructor(
@@ -33,6 +37,7 @@ export class UnmockPackage implements IUnmockPackage {
     this.allowedHosts = new AllowedHosts();
     this.flaky = new BooleanSetting();
     this.useInProduction = new BooleanSetting();
+    this.randomize = new BooleanSetting(false);
   }
 
   public on() {
@@ -41,6 +46,7 @@ export class UnmockPackage implements IUnmockPackage {
       isWhitelisted: (url: string) => this.allowedHosts.isWhitelisted(url),
       log: (message: string) => this.logger.log(message),
       flaky: () => this.flaky.get(),
+      randomize: () => this.randomize.get(),
     };
     this.backend.initialize(opts);
     return this;

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -19,23 +19,6 @@ export { IService } from "./service/interfaces";
 export { ServiceCore } from "./service/serviceCore";
 export { Backend, buildRequestHandler };
 
-const randomizeSetting = (rng: IRandomNumberGenerator): IBooleanSetting => {
-  let value = false;
-  return {
-    get() {
-      return value;
-    },
-    on() {
-      value = true;
-      rng.unfreeze();
-    },
-    off() {
-      value = false;
-      rng.freeze();
-    },
-  };
-};
-
 export class UnmockPackage implements IUnmockPackage {
   public allowedHosts: AllowedHosts;
   public useInProduction: BooleanSetting;
@@ -58,9 +41,9 @@ export class UnmockPackage implements IUnmockPackage {
     this.allowedHosts = new AllowedHosts();
     this.useInProduction = new BooleanSetting();
 
-    const rng = randomNumberGenerator({ frozen: false, seed: 0 });
+    const rng = randomNumberGenerator({ seed: 0 });
     this.randomNumberGenerator = rng;
-    this.randomize = randomizeSetting(rng);
+    this.randomize = new BooleanSetting();
   }
 
   public on() {

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -39,11 +39,11 @@ export class UnmockPackage implements IUnmockPackage {
     this.logger = (options && options.logger) || this.logger;
 
     this.allowedHosts = new AllowedHosts();
-    this.useInProduction = new BooleanSetting();
+    this.useInProduction = new BooleanSetting(false);
 
     const rng = randomNumberGenerator({ seed: 0 });
     this.randomNumberGenerator = rng;
-    this.randomize = new BooleanSetting();
+    this.randomize = new BooleanSetting(false);
   }
 
   public on() {

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -38,7 +38,6 @@ const randomizeSetting = (rng: IRandomNumberGenerator): IBooleanSetting => {
 
 export class UnmockPackage implements IUnmockPackage {
   public allowedHosts: AllowedHosts;
-  public flaky: BooleanSetting;
   public useInProduction: BooleanSetting;
   public randomNumberGenerator: IRandomNumberGenerator;
   /**
@@ -57,7 +56,6 @@ export class UnmockPackage implements IUnmockPackage {
     this.logger = (options && options.logger) || this.logger;
 
     this.allowedHosts = new AllowedHosts();
-    this.flaky = new BooleanSetting();
     this.useInProduction = new BooleanSetting();
 
     const rng = randomNumberGenerator({ frozen: true, seed: 0 });
@@ -70,7 +68,6 @@ export class UnmockPackage implements IUnmockPackage {
       useInProduction: () => this.useInProduction.get(),
       isWhitelisted: (url: string) => this.allowedHosts.isWhitelisted(url),
       log: (message: string) => this.logger.log(message),
-      flaky: () => this.flaky.get(),
       randomize: () => this.randomize.get(),
     };
     this.backend.initialize(opts, this.randomNumberGenerator);

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -35,7 +35,6 @@ export class UnmockPackage implements IUnmockPackage {
 
     this.allowedHosts = new AllowedHosts();
     this.useInProduction = new BooleanSetting(false);
-
     this.randomize = new BooleanSetting(false);
   }
 

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -560,7 +560,6 @@ export interface IListener {
 export interface IUnmockOptions extends ILogger {
   useInProduction(): boolean;
   isWhitelisted(url: string): boolean;
-  flaky(): boolean;
   /**
    * Randomize responses instead of using a fixed seed.
    */

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -561,6 +561,10 @@ export interface IUnmockOptions extends ILogger {
   useInProduction(): boolean;
   isWhitelisted(url: string): boolean;
   flaky(): boolean;
+  /**
+   * Randomize responses instead of using a fixed seed.
+   */
+  randomize(): boolean;
 }
 
 export interface IUnmockPackage {

--- a/packages/unmock-core/src/random-number-generator.ts
+++ b/packages/unmock-core/src/random-number-generator.ts
@@ -16,7 +16,7 @@ export interface IRandomNumberGenerator {
 }
 
 const createSeedRandom = (seed?: number): seedrandom.prng => {
-  return seedRandom((seed && seed.toString()) || "0", { state: true });
+  return seedRandom((seed && seed.toString()) || "0");
 };
 
 /**

--- a/packages/unmock-core/src/random-number-generator.ts
+++ b/packages/unmock-core/src/random-number-generator.ts
@@ -1,0 +1,65 @@
+import * as seedRandom from "seedrandom";
+
+/**
+ * Representation for random number generator with mutable state.
+ */
+export interface IRandomNumberGenerator {
+  /**
+   * Generate a new number, increment state
+   */
+  get(): number;
+  /**
+   * Set new state.
+   * @param seed New seed
+   */
+  setSeed(seed: number): void;
+  /**
+   * Freeze generator. Always returns the same result.
+   */
+  freeze(): void;
+  /**
+   * Unfreeze generator.
+   */
+  unfreeze(): void;
+}
+
+const createSeedRandom = (seed?: number): seedrandom.prng => {
+  return seedRandom((seed && seed.toString()) || "0", { state: true });
+};
+
+/**
+ * Create an RNG using `seedrandom`.
+ * @param seed Optional seed
+ */
+export const randomNumberGenerator = ({
+  frozen,
+  seed,
+}: {
+  frozen: boolean;
+  seed?: number;
+}): IRandomNumberGenerator => {
+  let isFrozen = frozen;
+  let rng = createSeedRandom(seed);
+
+  return {
+    get() {
+      if (!isFrozen) {
+        return rng();
+      }
+      const state = rng.state();
+      const newNumber = rng();
+      rng = seedRandom("", { state });
+      return newNumber;
+    },
+    setSeed(newSeed: number) {
+      rng = createSeedRandom(newSeed);
+      return this;
+    },
+    freeze() {
+      isFrozen = true;
+    },
+    unfreeze() {
+      isFrozen = false;
+    },
+  };
+};

--- a/packages/unmock-core/src/random-number-generator.ts
+++ b/packages/unmock-core/src/random-number-generator.ts
@@ -1,5 +1,5 @@
 import * as seedRandom from "seedrandom";
-export const DEFAULT_SEED = 0;
+const DEFAULT_SEED = 0;
 
 /**
  * Representation for random number generator with mutable state.
@@ -14,6 +14,10 @@ export interface IRandomNumberGenerator {
    * @param seed New seed
    */
   setSeed(seed: number): void;
+  /**
+   * Restore original seed (default seed if none was given).
+   */
+  restore(): void;
 }
 
 const createSeedRandom = (seed?: number): seedrandom.prng => {
@@ -37,6 +41,10 @@ export const randomNumberGenerator = ({
     },
     setSeed(newSeed: number) {
       rng = createSeedRandom(newSeed);
+      return this;
+    },
+    restore() {
+      rng = createSeedRandom(seed);
       return this;
     },
   };

--- a/packages/unmock-core/src/random-number-generator.ts
+++ b/packages/unmock-core/src/random-number-generator.ts
@@ -1,4 +1,5 @@
 import * as seedRandom from "seedrandom";
+export const DEFAULT_SEED = 0;
 
 /**
  * Representation for random number generator with mutable state.
@@ -16,7 +17,7 @@ export interface IRandomNumberGenerator {
 }
 
 const createSeedRandom = (seed?: number): seedrandom.prng => {
-  return seedRandom((seed && seed.toString()) || "0");
+  return seedRandom((seed && seed.toString()) || DEFAULT_SEED.toString());
 };
 
 /**

--- a/packages/unmock-core/src/random-number-generator.ts
+++ b/packages/unmock-core/src/random-number-generator.ts
@@ -13,14 +13,6 @@ export interface IRandomNumberGenerator {
    * @param seed New seed
    */
   setSeed(seed: number): void;
-  /**
-   * Freeze generator. Always returns the same result.
-   */
-  freeze(): void;
-  /**
-   * Unfreeze generator.
-   */
-  unfreeze(): void;
 }
 
 const createSeedRandom = (seed?: number): seedrandom.prng => {
@@ -32,34 +24,19 @@ const createSeedRandom = (seed?: number): seedrandom.prng => {
  * @param seed Optional seed
  */
 export const randomNumberGenerator = ({
-  frozen,
   seed,
 }: {
-  frozen: boolean;
   seed?: number;
 }): IRandomNumberGenerator => {
-  let isFrozen = frozen;
   let rng = createSeedRandom(seed);
 
   return {
     get() {
-      if (!isFrozen) {
-        return rng();
-      }
-      const state = rng.state();
-      const newNumber = rng();
-      rng = seedRandom("", { state });
-      return newNumber;
+      return rng();
     },
     setSeed(newSeed: number) {
       rng = createSeedRandom(newSeed);
       return this;
-    },
-    freeze() {
-      isFrozen = true;
-    },
-    unfreeze() {
-      isFrozen = false;
     },
   };
 };

--- a/packages/unmock-core/src/runner/index.ts
+++ b/packages/unmock-core/src/runner/index.ts
@@ -1,6 +1,6 @@
 import Backend from "../backend";
 import { runnerConfiguration } from "../generator";
-import { IRandomNumberGenerator } from "../random-number-generator";
+
 export interface IRunnerOptions {
   maxLoop: number;
 }
@@ -40,7 +40,7 @@ const errorHandler = (
   }
 };
 
-export default (backend: Backend, rng: IRandomNumberGenerator) => (
+export default (backend: Backend) => (
   fn?: jest.ProvidesCallback,
   options?: Partial<IRunnerOptions>,
 ) => async (cb?: jest.DoneCallback) => {
@@ -58,7 +58,7 @@ export default (backend: Backend, rng: IRandomNumberGenerator) => (
   const errors: Error[] = [];
   const res = [];
   for (let i = 0; i < realOptions.maxLoop; i++) {
-    rng.setSeed(i);
+    backend.randomNumberGenerator.setSeed(i);
     runnerConfiguration.optionalsProbability = Math.random();
     runnerConfiguration.minItems = Math.floor(Math.random() * 2 ** (i % 5)); // 2^5 seems enough for min items/length
     try {

--- a/packages/unmock-core/src/runner/index.ts
+++ b/packages/unmock-core/src/runner/index.ts
@@ -1,5 +1,6 @@
 import Backend from "../backend";
 import { runnerConfiguration } from "../generator";
+import { IRandomNumberGenerator } from "../random-number-generator";
 export interface IRunnerOptions {
   maxLoop: number;
 }
@@ -39,7 +40,7 @@ const errorHandler = (
   }
 };
 
-export default (backend: Backend) => (
+export default (backend: Backend, rng: IRandomNumberGenerator) => (
   fn?: jest.ProvidesCallback,
   options?: Partial<IRunnerOptions>,
 ) => async (cb?: jest.DoneCallback) => {
@@ -57,7 +58,7 @@ export default (backend: Backend) => (
   const errors: Error[] = [];
   const res = [];
   for (let i = 0; i < realOptions.maxLoop; i++) {
-    runnerConfiguration.seed = i;
+    rng.setSeed(i);
     runnerConfiguration.optionalsProbability = Math.random();
     runnerConfiguration.minItems = Math.floor(Math.random() * 2 ** (i % 5)); // 2^5 seems enough for min items/length
     try {

--- a/packages/unmock-core/src/settings/boolean.ts
+++ b/packages/unmock-core/src/settings/boolean.ts
@@ -1,4 +1,13 @@
-export class BooleanSetting {
+/**
+ * Boolean setting. Used to maintain on-off state.
+ */
+export interface IBooleanSetting {
+  on(): void;
+  off(): void;
+  get(): boolean;
+}
+
+export class BooleanSetting implements IBooleanSetting {
   constructor(private value = false) {}
   public on() {
     this.value = true;

--- a/packages/unmock-core/src/settings/index.ts
+++ b/packages/unmock-core/src/settings/index.ts
@@ -1,2 +1,2 @@
 export { AllowedHosts } from "./allowedHosts";
-export { BooleanSetting } from "./boolean";
+export { BooleanSetting, IBooleanSetting } from "./boolean";

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -28,6 +28,7 @@ describe("Node.js interceptor", () => {
         flaky: () => false,
         isWhitelisted: (_: string) => false,
         log: (_: string) => undefined,
+        randomize: () => false,
         useInProduction: () => false,
       });
       const petstore = nodeInterceptor.services.petstore;

--- a/packages/unmock-node/src/__tests__/backend/index.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/index.test.ts
@@ -25,7 +25,6 @@ describe("Node.js interceptor", () => {
     beforeAll(() => {
       nodeInterceptor = new NodeBackend({ servicesDirectory });
       nodeInterceptor.initialize({
-        flaky: () => false,
         isWhitelisted: (_: string) => false,
         log: (_: string) => undefined,
         randomize: () => false,

--- a/packages/unmock-node/src/__tests__/backend/state.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/state.test.ts
@@ -25,8 +25,8 @@ const servicesDirectory = path.join(__dirname, "..", "__unmock__");
 
 describe("Node.js interceptor", () => {
   describe("with state requests in place", () => {
-    const nodeInterceptor = new NodeBackend({ servicesDirectory });
-    const unmock = new UnmockPackage(nodeInterceptor);
+    const nodeBackend = new NodeBackend({ servicesDirectory });
+    const unmock = new UnmockPackage(nodeBackend);
     let petstore: Service;
     let filestackApi: Service;
     let slack: Service;
@@ -188,7 +188,7 @@ describe("Node.js interceptor", () => {
       }
     });
 
-    test("updates times correctly", async () => {
+    test.skip("updates times correctly", async () => {
       const text = "foo";
       const postMessage = () =>
         axios.post("https://slack.com/api/chat.postMessage", {
@@ -214,7 +214,7 @@ describe("Node.js interceptor", () => {
       expect(resp.data.message.text).not.toEqual(text);
     });
 
-    test("updates times after n", async () => {
+    test.skip("updates times after n", async () => {
       const text = "foo";
       const postMessage = () =>
         axios.post("https://slack.com/api/chat.postMessage", {

--- a/packages/unmock-node/src/__tests__/backend/state.test.ts
+++ b/packages/unmock-node/src/__tests__/backend/state.test.ts
@@ -188,7 +188,7 @@ describe("Node.js interceptor", () => {
       }
     });
 
-    test.skip("updates times correctly", async () => {
+    test("updates times correctly", async () => {
       const text = "foo";
       const postMessage = () =>
         axios.post("https://slack.com/api/chat.postMessage", {
@@ -214,7 +214,7 @@ describe("Node.js interceptor", () => {
       expect(resp.data.message.text).not.toEqual(text);
     });
 
-    test.skip("updates times after n", async () => {
+    test("updates times after n", async () => {
       const text = "foo";
       const postMessage = () =>
         axios.post("https://slack.com/api/chat.postMessage", {

--- a/packages/unmock/src/__tests__/end-to-end/simple-service-with-runner.test.ts
+++ b/packages/unmock/src/__tests__/end-to-end/simple-service-with-runner.test.ts
@@ -29,6 +29,9 @@ beforeAll(() => {
   foo = unmock.on().services.foo;
 });
 afterAll(() => unmock.off());
+
+jest.setTimeout(10000);
+
 describe("Simple service test with runner", () => {
   it(
     "Should reset spies correctly",

--- a/packages/unmock/src/__tests__/end-to-end/simple-service-with-runner.test.ts
+++ b/packages/unmock/src/__tests__/end-to-end/simple-service-with-runner.test.ts
@@ -30,8 +30,6 @@ beforeAll(() => {
 });
 afterAll(() => unmock.off());
 
-jest.setTimeout(10000);
-
 describe("Simple service test with runner", () => {
   it(
     "Should reset spies correctly",


### PR DESCRIPTION
- Currently Unmock always sets the seed to a fixed value when generating a mock. For proper pseudo-random behaviour, add a `randomize` setting to not set the seed everytime.
- Switching randomization on: `unmock.randomize.on()`
- Disable: `unmock.randomize.off()`

TODO:
- [x]  Tests
- [ ]  Completely based on mutable state: having RNG based on functional immutable state (á la [fp-ts/lib/state.ts](https://github.com/gcanti/fp-ts/blob/master/src/State.ts)) would be awesome but I don't really see that fitting to the current architecture at the moment: We would need to change `CreateResponse` to return the modified state.