### PR TITLE
unmock-fetch: Implement serialization of request headers.

### DIFF
--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -5,6 +5,7 @@ import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
 import { ExtendedJSONSchema, nockify, vanillaJSONSchemify } from "./nock";
 import internalRunner, { IRunnerOptions } from "./runner";
 import { AllowedHosts, BooleanSetting, IBooleanSetting } from "./settings";
+import * as typeUtils from "./utils";
 
 export * from "./interfaces";
 export * from "./types";
@@ -14,6 +15,7 @@ export { transform, Addl, Arr } from "./generator-utils";
 export { IService } from "./service/interfaces";
 export { ServiceCore } from "./service/serviceCore";
 export { Backend, buildRequestHandler };
+export { typeUtils };
 
 export class UnmockPackage implements IUnmockPackage {
   public allowedHosts: AllowedHosts;

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -624,7 +624,7 @@ export interface IUnmockPackage {
 
 /**
  * Analogous to `IncomingHttpHeaders` in @types/node.
- * Header names are expected to be _lowercased_.
+ * Header keys are expected to be _lowercased_.
  */
 export interface IIncomingHeaders {
   [header: string]: string | string[] | undefined;

--- a/packages/unmock-core/src/utils.ts
+++ b/packages/unmock-core/src/utils.ts
@@ -1,0 +1,23 @@
+import { HTTPMethod, IProtocol } from "./interfaces";
+
+/**
+ * Normalize header key, expected for `IIncomingHeaders`.
+ * @param key
+ */
+export const normalizeHeaderKey = (key: string) => key.toLowerCase();
+
+export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
+  [
+    "get",
+    "head",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "options",
+    "trace",
+  ].includes(maybeMethod);
+
+export const isKnownProtocol = (
+  maybeProtocol: string,
+): maybeProtocol is IProtocol => /^https?$/.test(maybeProtocol);

--- a/packages/unmock-fetch/README.md
+++ b/packages/unmock-fetch/README.md
@@ -20,10 +20,10 @@ yarn add unmock-fetch -D
 
 ```ts
 import { buildFetch } from "unmock-fetch";
-import { CreateResponse, ISerializedRequest, ISerializedResponse, OnSerializedRequest } from "unmock-core";
+import { ISerializedRequest, ISerializedResponse, OnSerializedRequest } from "unmock-core";
 
 // Define what to do with the intercepted request
-const responseCreator: CreateResponse = (
+const responseCreator = (
   req: ISerializedRequest
 ): ISerializedResponse => {
   return {
@@ -54,7 +54,9 @@ To override `global.fetch` or `window.fetch`, use the default import:
 import FetchInterceptor from "unmock-fetch";
 
 // What to do with serialized request
-const requestCb: CreateResponse = /* as above */
+const requestCb: (
+  req: ISerializedRequest
+) => ISerializedResponse  = /* as above */
 
 // Intercept `global.fetch` or `window.fetch`
 FetchInterceptor.on(requestCb);

--- a/packages/unmock-fetch/src/__tests__/serialize.test.ts
+++ b/packages/unmock-fetch/src/__tests__/serialize.test.ts
@@ -1,5 +1,6 @@
 import { ISerializedRequest } from "unmock-core";
 import serialize from "../serialize";
+import { Headers } from "../types";
 
 describe("Fetch request serializer", () => {
   it("should serialize method correctly", () => {
@@ -21,13 +22,38 @@ describe("Fetch request serializer", () => {
     });
   });
 
-  it("should serialize a request with headers", () => {
-    const headers = { "x-accept": "anything " };
-    const req: ISerializedRequest = serialize("https://example.com", {
-      headers,
+  describe("header serialization", () => {
+    it("should serialize a request with headers dictionary", () => {
+      const headers = { "x-accept": "anything" };
+      const req: ISerializedRequest = serialize("https://example.com", {
+        headers,
+      });
+      expect(req).toMatchObject({
+        headers,
+      });
     });
-    expect(req).toMatchObject({
-      headers,
+    it("should normalize headers keys", () => {
+      const headers = { "X-ACCEPT": "anything" };
+      const req: ISerializedRequest = serialize("https://example.com", {
+        headers,
+      });
+      expect(req).toMatchObject({
+        headers: {
+          "x-accept": "anything",
+        },
+      });
+    });
+    it("should serialize a request with headers object", () => {
+      const headers = new Headers();
+      headers.append("x-accept", "anything");
+      const req: ISerializedRequest = serialize("https://example.com", {
+        headers,
+      });
+      expect(req).toMatchObject({
+        headers: {
+          "x-accept": "anything",
+        },
+      });
     });
   });
 });

--- a/packages/unmock-fetch/src/__tests__/serialize.test.ts
+++ b/packages/unmock-fetch/src/__tests__/serialize.test.ts
@@ -55,5 +55,16 @@ describe("Fetch request serializer", () => {
         },
       });
     });
+    it("should serialize a request with headers given as array", () => {
+      const headers = [["x-accept", "anything"]];
+      const req: ISerializedRequest = serialize("https://example.com", {
+        headers,
+      });
+      expect(req).toMatchObject({
+        headers: {
+          "x-accept": ["anything"],
+        },
+      });
+    });
   });
 });

--- a/packages/unmock-fetch/src/__tests__/serialize.test.ts
+++ b/packages/unmock-fetch/src/__tests__/serialize.test.ts
@@ -21,7 +21,7 @@ describe("Fetch request serializer", () => {
     });
   });
 
-  it.skip("should serialize a request with headers", () => {
+  it("should serialize a request with headers", () => {
     const headers = { "x-accept": "anything " };
     const req: ISerializedRequest = serialize("https://example.com", {
       headers,

--- a/packages/unmock-fetch/src/serialize.ts
+++ b/packages/unmock-fetch/src/serialize.ts
@@ -1,6 +1,7 @@
 import debug from "debug";
 import {
   HTTPMethod,
+  IIncomingHeaders,
   IProtocol,
   ISerializedRequest,
 } from "unmock-core/dist/interfaces";
@@ -25,6 +26,46 @@ export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
 
 const debugLog = debug("unmock:fetch-mitm");
 
+const isRequest = (url: RequestInfo): url is Request => {
+  return false;
+};
+
+export const parseHeaders = (
+  url: RequestInfo,
+  init?: RequestInit,
+): IIncomingHeaders => {
+  const parseInternalHeaders = (headers: Headers): IIncomingHeaders => {
+    return {};
+  };
+
+  if (isRequest(url)) {
+    return parseInternalHeaders(url.headers);
+  } else if (typeof init !== "undefined") {
+    const headers = init.headers;
+    if (typeof headers === "undefined") {
+      return {};
+    }
+
+    if (Array.isArray(headers)) {
+      // TODO
+      return {};
+    }
+
+    if (headers instanceof Headers) {
+      // TODO
+      const heads: Record<string, string> = {};
+      headers.forEach((value, key) => {
+        heads[key] = value;
+      });
+      return heads;
+    }
+
+    return headers;
+  }
+
+  return {};
+};
+
 export default (url: RequestInfo, init?: RequestInit): ISerializedRequest => {
   if (typeof url !== "string") {
     throw new Error(`Request instance not yet supported`);
@@ -46,11 +87,13 @@ export default (url: RequestInfo, init?: RequestInit): ISerializedRequest => {
     throw new Error(`Unknown protocol: ${protocolWithoutColon}`);
   }
 
+  const headers = parseHeaders(url, init);
+
   const req: ISerializedRequest = {
     body: undefined, // TODO
     bodyAsJson: undefined, // TODO
     method,
-    headers: {}, // TODO
+    headers,
     host: parsedUrl.host,
     path: parsedUrl.pathname, // TODO
     pathname: parsedUrl.pathname,


### PR DESCRIPTION
- Implement parsing of request headers in `unmock-fetch` (https://github.com/unmock/unmock-js/issues/331)
- Export some helpers from unmock-core