### PR TITLE
Do not use setImmediate in unmock-fetch.

### DIFF
--- a/packages/unmock-fetch/src/fetch.ts
+++ b/packages/unmock-fetch/src/fetch.ts
@@ -27,7 +27,7 @@ export const buildFetch = (cb: CreateResponse | OnSerializedRequest): Fetch =>
 
       const emitError = (e: Error) => reject(e);
 
-      setImmediate(() => {
+      setTimeout(() => {
         if (isCreateResponse(cb)) {
           try {
             const res = cb(req);
@@ -38,7 +38,7 @@ export const buildFetch = (cb: CreateResponse | OnSerializedRequest): Fetch =>
         } else {
           cb(req, sendResponse, emitError);
         }
-      });
+      }, 0);
     });
   };
 


### PR DESCRIPTION
[setImmediate](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate) is non-standard in browsers so use [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout) instead to delay the mock generation to next tick.