### PR TITLE
Disable type-checking in ts-jest.

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -30,7 +30,8 @@ module.exports = {
     "ts-jest": {
       tsConfig: "<rootDir>/src/__tests__/tsconfig.json",
       babelConfig: true,
-      diagnostics: false
+      diagnostics: false,
+      isolatedModules: true
     }
   }
 };


### PR DESCRIPTION
Tests fail quite randomly with the following kind of output:
```
FAIL  packages/unmock/src/__tests__/end-to-end/simple-service.test.ts
  ● Test suite failed to run

    TypeError: Unable to require `.d.ts` file.
    This is usually the result of a faulty configuration or import. Make sure there is a `.js`, `.json` or another executable extension available alongside `interfaces.ts`.
```

In this [thread](https://github.com/kulshekhar/ts-jest/issues/805), the given solution is to disable type-checking in `ts-jest` by setting [isolatedModules](https://kulshekhar.github.io/ts-jest/user/config/isolatedModules) parameter to `true`. This should be fine in our case as we run separate type-checking in the build pipeline.