### PR TITLE
Remove abspath.

### DIFF
--- a/packages/unmock-core/src/parser.ts
+++ b/packages/unmock-core/src/parser.ts
@@ -58,7 +58,6 @@ export abstract class ServiceParser {
     const name = serviceDef.directoryName;
 
     return new ServiceCore({
-      absPath: serviceDef.absolutePath,
       name,
       schema: schema.right,
     });

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -65,7 +65,7 @@ export interface IServiceCore {
   /**
    * Holds the absolute path where the service specification resides.
    */
-  readonly absPath: string;
+  readonly absPath?: string;
 
   /**
    * Spy keeping track of request response pairs

--- a/packages/unmock-core/src/service/interfaces.ts
+++ b/packages/unmock-core/src/service/interfaces.ts
@@ -63,11 +63,6 @@ export interface IServiceCore {
   readonly schema: OpenAPIObject;
 
   /**
-   * Holds the absolute path where the service specification resides.
-   */
-  readonly absPath?: string;
-
-  /**
    * Spy keeping track of request response pairs
    */
   readonly spy: ServiceSpy;

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -1,5 +1,6 @@
 import { defaultsDeep, unionBy } from "lodash";
 import { ISerializedRequest } from "../interfaces";
+import { detectNode } from "../utils";
 import {
   IObjectToService,
   IServiceCore,
@@ -145,7 +146,7 @@ export class ServiceCore implements IServiceCore {
   }
 
   public readonly name: string;
-  public readonly absPath: string;
+  public readonly absPath?: string;
   private hasPaths: boolean = false;
   private readonly oasSchema: OpenAPIObject;
   private readonly callTracker: ICallTracker;
@@ -153,7 +154,7 @@ export class ServiceCore implements IServiceCore {
   constructor(opts: { schema: OpenAPIObject; name: string; absPath?: string }) {
     this.oasSchema = opts.schema;
     this.name = opts.name;
-    this.absPath = opts.absPath || process.cwd();
+    this.absPath = opts.absPath || (detectNode ? process.cwd() : undefined);
     this.hasPaths = // Find this once, as schema is immutable
       this.schema !== undefined &&
       this.schema.paths !== undefined &&

--- a/packages/unmock-core/src/service/serviceCore.ts
+++ b/packages/unmock-core/src/service/serviceCore.ts
@@ -1,6 +1,5 @@
 import { defaultsDeep, unionBy } from "lodash";
 import { ISerializedRequest } from "../interfaces";
-import { detectNode } from "../utils";
 import {
   IObjectToService,
   IServiceCore,
@@ -146,15 +145,13 @@ export class ServiceCore implements IServiceCore {
   }
 
   public readonly name: string;
-  public readonly absPath?: string;
   private hasPaths: boolean = false;
   private readonly oasSchema: OpenAPIObject;
   private readonly callTracker: ICallTracker;
 
-  constructor(opts: { schema: OpenAPIObject; name: string; absPath?: string }) {
+  constructor(opts: { schema: OpenAPIObject; name: string }) {
     this.oasSchema = opts.schema;
     this.name = opts.name;
-    this.absPath = opts.absPath || (detectNode ? process.cwd() : undefined);
     this.hasPaths = // Find this once, as schema is immutable
       this.schema !== undefined &&
       this.schema.paths !== undefined &&

--- a/packages/unmock-core/src/utils.ts
+++ b/packages/unmock-core/src/utils.ts
@@ -21,9 +21,3 @@ export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
 export const isKnownProtocol = (
   maybeProtocol: string,
 ): maybeProtocol is IProtocol => /^https?$/.test(maybeProtocol);
-
-// https://github.com/iliakan/detect-node/blob/master/index.js
-export const detectNode = (): boolean =>
-  Object.prototype.toString.call(
-    typeof process !== "undefined" ? process : 0,
-  ) === "[object process]";

--- a/packages/unmock-core/src/utils.ts
+++ b/packages/unmock-core/src/utils.ts
@@ -21,3 +21,9 @@ export const isRESTMethod = (maybeMethod: string): maybeMethod is HTTPMethod =>
 export const isKnownProtocol = (
   maybeProtocol: string,
 ): maybeProtocol is IProtocol => /^https?$/.test(maybeProtocol);
+
+// https://github.com/iliakan/detect-node/blob/master/index.js
+export const detectNode = (): boolean =>
+  Object.prototype.toString.call(
+    typeof process !== "undefined" ? process : 0,
+  ) === "[object process]";


### PR DESCRIPTION
- Service core contains a field `absPath` that was probably earlier used for dereferencing references from OpenAPI specs, in the case where those references pointed to file system.
- It's apparently not used anymore so delete it, this also removes a reference to `process.cwd()` that breaks in browser