### PR TITLE
Do not allow Buffer in service def contents as it's not available in browser.

### DIFF
--- a/packages/unmock-core/src/__tests__/utils.ts
+++ b/packages/unmock-core/src/__tests__/utils.ts
@@ -11,7 +11,9 @@ export const testServiceDefLoader: IServiceDefLoader = {
   loadSync() {
     const petstoreDirectory = path.resolve(__dirname, "__unmock__", "petstore");
 
-    const spec = fs.readFileSync(path.join(petstoreDirectory, "spec.yaml"));
+    const spec = fs
+      .readFileSync(path.join(petstoreDirectory, "spec.yaml"))
+      .toString("utf-8");
 
     const petstoreServiceDef: IServiceDef = {
       absolutePath: petstoreDirectory,

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -689,7 +689,7 @@ export interface IServiceDefFile {
   /**
    * Contents of the service definition file
    */
-  contents: string | Buffer;
+  contents: string;
 }
 
 /**

--- a/packages/unmock-core/src/parser.ts
+++ b/packages/unmock-core/src/parser.ts
@@ -39,10 +39,7 @@ export abstract class ServiceParser {
 
     debugLog(`Parsing service specification ${serviceFile.basename}`);
 
-    const contents: string =
-      serviceFile.contents instanceof Buffer
-        ? serviceFile.contents.toString("utf-8")
-        : serviceFile.contents;
+    const contents = serviceFile.contents;
 
     const schema = loas3(jsYaml.safeLoad(contents));
     if (isLeft(schema)) {


### PR DESCRIPTION
- There wasn't really any reason to allow `Buffer` as the service description (OpenAPI specification) as it's converted to string anyway
- Random note: the service descriptions (as in OpenAPI specification) must be encoded in "utf-8" or otherwise things will break.