### PR TITLE
Extract UnmockFaker from Backend.

### DIFF
--- a/packages/unmock-core/src/__tests__/faker.test.ts
+++ b/packages/unmock-core/src/__tests__/faker.test.ts
@@ -1,0 +1,40 @@
+import { u } from "..";
+import UnmockFaker from "../faker";
+import { ServiceStore } from "../service/serviceStore";
+
+const serviceStore = new ServiceStore([]);
+const faker = new UnmockFaker({ serviceStore });
+
+const expectNServices = (expectedLength: number) =>
+  expect(Object.keys(faker.services).length).toEqual(expectedLength);
+
+describe("UnmockFaker", () => {
+  beforeEach(() => serviceStore.removeAll());
+
+  describe("adding service with nock syntax", () => {
+    it("adds a service", () => {
+      faker
+        .nock("https://foo.com")
+        .get("/foo")
+        .reply(200, { foo: u.string() });
+      expectNServices(1);
+    });
+    it("adds a service and allows faking it", () => {
+      faker
+        .nock("https://foo.com")
+        .get("/foo")
+        .reply(200, { foo: u.string() });
+      const res = faker.fake({
+        host: "foo.com",
+        protocol: "https",
+        method: "get",
+        path: "/foo",
+        pathname: "/foo",
+        headers: {},
+        query: {},
+      });
+      expect(res).toHaveProperty("body");
+      expect(res.body).toBeDefined();
+    });
+  });
+});

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -102,7 +102,7 @@ export class Backend {
   }
 
   public get services(): ServiceStoreType {
-    return (this.serviceStore && this.serviceStore.services) || {};
+    return this.serviceStore.services;
   }
 
   /**
@@ -142,12 +142,7 @@ export class Backend {
       this.interceptor = undefined;
     }
     this.handleRequest = undefined;
-    if (this.serviceStore) {
-      // TODO - this is quite ugly :shrug:
-      Object.values(this.serviceStore.services).forEach(service =>
-        service.reset(),
-      );
-    }
+    this.serviceStore.resetServices();
   }
 
   public loadServices(): void {

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import * as _ from "lodash";
-import { responseCreatorFactory } from "../generator";
+import UnmockFaker from "../faker";
 import { IInterceptor, IInterceptorFactory } from "../interceptor";
 import {
   CreateResponse,
@@ -78,10 +78,11 @@ const NoopServiceDefLoader: IServiceDefLoader = {
 };
 
 export class Backend {
-  public serviceStore: ServiceStore = new ServiceStore([]);
+  public readonly serviceStore: ServiceStore = new ServiceStore([]);
   public readonly interceptorFactory: IInterceptorFactory;
   public readonly serviceDefLoader: IServiceDefLoader;
   public readonly randomNumberGenerator: IRandomNumberGenerator;
+  public faker: UnmockFaker;
   public handleRequest?: OnSerializedRequest;
   protected readonly requestResponseListeners: IListener[];
   private interceptor?: IInterceptor;
@@ -97,6 +98,7 @@ export class Backend {
     this.serviceDefLoader = serviceDefLoader || NoopServiceDefLoader;
     this.randomNumberGenerator = rng || randomNumberGenerator({});
     this.loadServices();
+    this.faker = new UnmockFaker({ serviceStore: this.serviceStore });
   }
 
   public get services(): ServiceStoreType {
@@ -104,9 +106,10 @@ export class Backend {
   }
 
   /**
+   * Start the interceptor.
    *
    * @param options
-   * @returns `states` object, with which one can modify states of various services.
+   *
    */
   public initialize(options: IUnmockOptions) {
     if (process.env.NODE_ENV === "production" && !options.useInProduction()) {
@@ -118,14 +121,14 @@ export class Backend {
       this.interceptor = undefined;
     }
 
-    const createResponse = responseCreatorFactory({
-      listeners: this.requestResponseListeners,
-      options,
-      rng: this.randomNumberGenerator,
-      store: this.serviceStore,
-    });
+    /**
+     * Backward compatibility: Allow setting options at run-time when initializing unmock.
+     */
+    this.faker.setOptions(options);
 
-    this.handleRequest = buildRequestHandler(createResponse);
+    this.handleRequest = buildRequestHandler(
+      this.faker.createResponse.bind(this.faker),
+    );
 
     this.interceptor = this.interceptorFactory({
       onSerializedRequest: this.handleRequest,
@@ -157,7 +160,7 @@ export class Backend {
       ServiceParser.parse(serviceDef),
     );
 
-    this.serviceStore = new ServiceStore(coreServices);
+    this.serviceStore.update(coreServices);
   }
 }
 

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -8,6 +8,7 @@ import {
   IUnmockOptions,
   ServiceStoreType,
 } from "../interfaces";
+import { ExtendedJSONSchema } from "../nock";
 import {
   IRandomNumberGenerator,
   randomNumberGenerator,
@@ -54,6 +55,16 @@ export default class UnmockFaker {
    */
   public setOptions(options: IUnmockOptions) {
     this.createResponse = this.createResponseCreator(options);
+  }
+
+  public nock(
+    baseUrl: string,
+    nameOrHeaders?:
+      | string
+      | { reqheaders?: Record<string, ExtendedJSONSchema> },
+    name?: string,
+  ) {
+    return this.serviceStore.nock(baseUrl, nameOrHeaders, name);
   }
 
   /**

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -29,12 +29,17 @@ const DEFAULT_OPTIONS: IUnmockOptions = {
 
 export default class UnmockFaker {
   public createResponse: CreateResponse;
+  /**
+   * Add a new service to the faker using `nock` syntax.
+   */
   public readonly nock: NockAPI;
   private readonly serviceStore: ServiceStore;
   private readonly randomNumberGenerator: IRandomNumberGenerator;
   private readonly listeners: IListener[];
   /**
-   * Unmock faker.
+   * Unmock faker. Creates fake responses to fake requests, using
+   * the services contained in `serviceStore`.
+   * Add new services with the `faker.nock` method.
    * @param options Options for creating the object.
    */
   public constructor({

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -8,12 +8,11 @@ import {
   IUnmockOptions,
   ServiceStoreType,
 } from "../interfaces";
-import { ExtendedJSONSchema } from "../nock";
 import {
   IRandomNumberGenerator,
   randomNumberGenerator,
 } from "../random-number-generator";
-import { ServiceStore } from "../service/serviceStore";
+import { addFromNock, NockAPI, ServiceStore } from "../service/serviceStore";
 
 export interface IFakerOptions {
   listeners?: IListener[];
@@ -30,10 +29,10 @@ const DEFAULT_OPTIONS: IUnmockOptions = {
 
 export default class UnmockFaker {
   public createResponse: CreateResponse;
+  public readonly nock: NockAPI;
   private readonly serviceStore: ServiceStore;
   private readonly randomNumberGenerator: IRandomNumberGenerator;
   private readonly listeners: IListener[];
-
   /**
    * Unmock faker.
    * @param options Options for creating the object.
@@ -47,6 +46,7 @@ export default class UnmockFaker {
     this.randomNumberGenerator = rng || randomNumberGenerator({});
     this.serviceStore = serviceStore;
     this.createResponse = this.createResponseCreator();
+    this.nock = addFromNock(this.serviceStore);
   }
 
   /**
@@ -55,16 +55,6 @@ export default class UnmockFaker {
    */
   public setOptions(options: IUnmockOptions) {
     this.createResponse = this.createResponseCreator(options);
-  }
-
-  public nock(
-    baseUrl: string,
-    nameOrHeaders?:
-      | string
-      | { reqheaders?: Record<string, ExtendedJSONSchema> },
-    name?: string,
-  ) {
-    return this.serviceStore.nock(baseUrl, nameOrHeaders, name);
   }
 
   /**

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -1,4 +1,3 @@
-// import debug from "debug";
 import * as _ from "lodash";
 import { responseCreatorFactory } from "../generator";
 import {
@@ -14,8 +13,6 @@ import {
   randomNumberGenerator,
 } from "../random-number-generator";
 import { ServiceStore } from "../service/serviceStore";
-
-// const debugLog = debug("unmock:faker");
 
 export interface IFakerOptions {
   listeners?: IListener[];
@@ -36,6 +33,10 @@ export default class UnmockFaker {
   private readonly randomNumberGenerator: IRandomNumberGenerator;
   private readonly listeners: IListener[];
 
+  /**
+   * Unmock faker.
+   * @param options Options for creating the object.
+   */
   public constructor({
     listeners,
     randomNumberGenerator: rng,
@@ -47,25 +48,36 @@ export default class UnmockFaker {
     this.createResponse = this.createResponseCreator();
   }
 
+  /**
+   * Create a new faker function from the given options.
+   * @param options Options for faking responses.
+   */
   public setOptions(options: IUnmockOptions) {
     this.createResponse = this.createResponseCreator(options);
   }
 
+  /**
+   * Fake a response to a request.
+   * @param request Serialized request.
+   * @throws Error if no matcher was found for the request.
+   * @returns Serialized response.
+   */
   public fake(request: ISerializedRequest): ISerializedResponse {
     return this.createResponse(request);
   }
 
+  /**
+   * Services dictionary mapping service name to `Service` object.
+   */
   public get services(): ServiceStoreType {
     return (this.serviceStore && this.serviceStore.services) || {};
   }
 
+  /**
+   * Reset the states of all services.
+   */
   public reset() {
-    if (this.serviceStore) {
-      // TODO - this is quite ugly :shrug:
-      Object.values(this.serviceStore.services).forEach(service =>
-        service.reset(),
-      );
-    }
+    this.serviceStore.resetServices();
   }
 
   private createResponseCreator(options?: IUnmockOptions): CreateResponse {

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -1,0 +1,79 @@
+// import debug from "debug";
+import * as _ from "lodash";
+import { responseCreatorFactory } from "../generator";
+import {
+  CreateResponse,
+  IListener,
+  ISerializedRequest,
+  ISerializedResponse,
+  IUnmockOptions,
+  ServiceStoreType,
+} from "../interfaces";
+import {
+  IRandomNumberGenerator,
+  randomNumberGenerator,
+} from "../random-number-generator";
+import { ServiceStore } from "../service/serviceStore";
+
+// const debugLog = debug("unmock:faker");
+
+export interface IFakerOptions {
+  listeners?: IListener[];
+  serviceStore: ServiceStore;
+  randomNumberGenerator?: IRandomNumberGenerator;
+}
+
+const DEFAULT_OPTIONS: IUnmockOptions = {
+  useInProduction: () => true,
+  isWhitelisted: (__: string) => false,
+  randomize: () => true,
+  log: (__: string) => {}, // tslint:disable-line:no-empty
+};
+
+export default class UnmockFaker {
+  public createResponse: CreateResponse;
+  private readonly serviceStore: ServiceStore;
+  private readonly randomNumberGenerator: IRandomNumberGenerator;
+  private readonly listeners: IListener[];
+
+  public constructor({
+    listeners,
+    randomNumberGenerator: rng,
+    serviceStore,
+  }: IFakerOptions) {
+    this.listeners = listeners ? listeners : [];
+    this.randomNumberGenerator = rng || randomNumberGenerator({});
+    this.serviceStore = serviceStore;
+    this.createResponse = this.createResponseCreator();
+  }
+
+  public setOptions(options: IUnmockOptions) {
+    this.createResponse = this.createResponseCreator(options);
+  }
+
+  public fake(request: ISerializedRequest): ISerializedResponse {
+    return this.createResponse(request);
+  }
+
+  public get services(): ServiceStoreType {
+    return (this.serviceStore && this.serviceStore.services) || {};
+  }
+
+  public reset() {
+    if (this.serviceStore) {
+      // TODO - this is quite ugly :shrug:
+      Object.values(this.serviceStore.services).forEach(service =>
+        service.reset(),
+      );
+    }
+  }
+
+  private createResponseCreator(options?: IUnmockOptions): CreateResponse {
+    return responseCreatorFactory({
+      listeners: this.listeners,
+      options: options || DEFAULT_OPTIONS,
+      rng: this.randomNumberGenerator,
+      store: this.serviceStore,
+    });
+  }
+}

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -3,7 +3,7 @@ import * as sinon from "sinon";
 import Backend, { buildRequestHandler } from "./backend";
 import UnmockFaker from "./faker";
 import { ILogger, IUnmockOptions, IUnmockPackage } from "./interfaces";
-import { ExtendedJSONSchema, nockify, vanillaJSONSchemify } from "./nock";
+import { ExtendedJSONSchema } from "./nock";
 import internalRunner, { IRunnerOptions } from "./runner";
 import { ServiceStore } from "./service/serviceStore";
 import { AllowedHosts, BooleanSetting, IBooleanSetting } from "./settings";
@@ -86,25 +86,7 @@ export class UnmockPackage implements IUnmockPackage {
       | { reqheaders?: Record<string, ExtendedJSONSchema> },
     name?: string,
   ) {
-    const internalName =
-      typeof nameOrHeaders === "string"
-        ? nameOrHeaders
-        : typeof name === "string"
-        ? name
-        : undefined;
-    const requestHeaders =
-      typeof nameOrHeaders === "object" && nameOrHeaders.reqheaders
-        ? Object.entries(nameOrHeaders.reqheaders).reduce(
-            (a, b) => ({ ...a, [b[0]]: vanillaJSONSchemify(b[1]) }),
-            {},
-          )
-        : {};
-    return nockify({
-      serviceStore: this.backend.serviceStore,
-      baseUrl,
-      requestHeaders,
-      name: internalName,
-    });
+    return this.backend.serviceStore.nock(baseUrl, nameOrHeaders, name);
   }
 
   public associate(url: string, name: string) {

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -100,7 +100,7 @@ export class UnmockPackage implements IUnmockPackage {
           )
         : {};
     return nockify({
-      backend: this.backend,
+      serviceStore: this.backend.serviceStore,
       baseUrl,
       requestHeaders,
       name: internalName,

--- a/packages/unmock-core/src/nock.ts
+++ b/packages/unmock-core/src/nock.ts
@@ -20,7 +20,6 @@ import {
 import { fromTraversable, Iso, Prism } from "monocle-ts";
 import { valAsConst } from "openapi-refinements";
 import * as querystring from "query-string";
-import Backend from "./backend";
 import { identityGetter } from "./generator";
 import { CodeAsInt, HTTPMethod } from "./interfaces";
 import { Schema, ValidEndpointType } from "./service/interfaces";
@@ -706,13 +705,13 @@ const buildFluentNock = (
   ) as IFluentDynamicService);
 
 export const nockify = ({
-  backend,
+  serviceStore,
   baseUrl,
   requestHeaders,
   name,
 }: {
-  backend: Backend;
+  serviceStore: ServiceStore;
   baseUrl: string;
   requestHeaders: Record<string, JSSTAnything<EJSEmpty, {}>>;
   name?: string;
-}) => buildFluentNock(backend.serviceStore, baseUrl, requestHeaders, name);
+}) => buildFluentNock(serviceStore, baseUrl, requestHeaders, name);

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -7,13 +7,24 @@ export class ServiceStore {
   /**
    * `services` is a wrapper for each `IServiceCore` in `cores`, and is ultimately what's available for the user.
    */
-  public readonly services: Record<string, Service>;
+  public services: Record<string, Service>;
   /**
    * `cores` is an internal mapping, allowing manipulation and extraction of services as needed
    */
-  public readonly cores: Record<string, IServiceCore>;
+  public cores: Record<string, IServiceCore>;
 
   constructor(coreServices: IServiceCore[]) {
+    this.cores = coreServices.reduce(
+      (o, core) => ({ ...o, [core.name]: core }),
+      {},
+    );
+    this.services = coreServices.reduce(
+      (o, core) => ({ ...o, [core.name]: new Service(core) }),
+      {},
+    );
+  }
+
+  public update(coreServices: IServiceCore[]) {
     this.cores = coreServices.reduce(
       (o, core) => ({ ...o, [core.name]: core }),
       {},
@@ -36,7 +47,10 @@ export class ServiceStore {
         : {
             /* new service - some template schema */
             openapi: "3.0.0",
-            info: { title: "Internally built by unmock", version: "0.0.0" },
+            info: {
+              title: "Internally built by unmock",
+              version: "0.0.0",
+            },
             paths: {},
           };
     const newServiceCore = ServiceCore.from(baseSchema, {

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -4,6 +4,17 @@ import { Service } from "./service";
 import { ServiceCore } from "./serviceCore";
 
 export class ServiceStore {
+  private static extractCoresAndServices(coreServices: IServiceCore[]) {
+    const cores = coreServices.reduce(
+      (o, core) => ({ ...o, [core.name]: core }),
+      {},
+    );
+    const services = coreServices.reduce(
+      (o, core) => ({ ...o, [core.name]: new Service(core) }),
+      {},
+    );
+    return { cores, services };
+  }
   /**
    * `services` is a wrapper for each `IServiceCore` in `cores`, and is ultimately what's available for the user.
    */
@@ -14,25 +25,19 @@ export class ServiceStore {
   public cores: Record<string, IServiceCore>;
 
   constructor(coreServices: IServiceCore[]) {
-    this.cores = coreServices.reduce(
-      (o, core) => ({ ...o, [core.name]: core }),
-      {},
+    const { cores, services } = ServiceStore.extractCoresAndServices(
+      coreServices,
     );
-    this.services = coreServices.reduce(
-      (o, core) => ({ ...o, [core.name]: new Service(core) }),
-      {},
-    );
+    this.cores = cores;
+    this.services = services;
   }
 
   public update(coreServices: IServiceCore[]) {
-    this.cores = coreServices.reduce(
-      (o, core) => ({ ...o, [core.name]: core }),
-      {},
+    const { cores, services } = ServiceStore.extractCoresAndServices(
+      coreServices,
     );
-    this.services = coreServices.reduce(
-      (o, core) => ({ ...o, [core.name]: new Service(core) }),
-      {},
-    );
+    this.cores = cores;
+    this.services = services;
   }
 
   public updateOrAdd(input: IObjectToService): ServiceStore {

--- a/packages/unmock-core/src/service/serviceStore.ts
+++ b/packages/unmock-core/src/service/serviceStore.ts
@@ -17,11 +17,11 @@ export class ServiceStore {
     return { cores, services };
   }
   /**
-   * `services` is a wrapper for each `IServiceCore` in `cores`, and is ultimately what's available for the user.
+   * Internal map from the service name to `Service` object.
    */
   public services: Record<string, Service>;
   /**
-   * `cores` is an internal mapping, allowing manipulation and extraction of services as needed
+   * Internal map from the service name to `ServiceCore` object.
    */
   public cores: Record<string, IServiceCore>;
 
@@ -33,6 +33,10 @@ export class ServiceStore {
     this.services = services;
   }
 
+  /**
+   * Replace all services with the given array of services.
+   * @param coreServices List of service cores.
+   */
   public update(coreServices: IServiceCore[]) {
     const { cores, services } = ServiceStore.extractCoresAndServices(
       coreServices,
@@ -109,5 +113,19 @@ export class ServiceStore {
     this.services[serviceName] = new Service(newServiceCore);
 
     return this;
+  }
+
+  /**
+   * Remove all services from the store.
+   */
+  public removeAll() {
+    this.update([]);
+  }
+
+  /**
+   * Reset the states of all services in store.
+   */
+  public resetServices() {
+    Object.values(this.services).forEach(service => service.reset());
   }
 }


### PR DESCRIPTION
- Extract `UnmockFaker` class responsible for faking responses to serialized requests, lifting that responsibility from `Backend` class.
- Refactor `unmock.nock` so that the same API can be used also from `UnmockFaker` to add services
- Add helper methods to `ServiceStore`: `update`, `removeAll`, `resetServices`

The purpose of all this is that one can separate the mock generation logic from the interceptor logic: one can create mock responses via `UnmockFaker` without starting the interceptor and add new services and modify their states. And it's nice that one can create multiple independent fakers, as the big bad global interceptor is separate from the faking logic.