### PR TITLE
Polyfill Buffer when missing from global.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3591,6 +3591,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -3751,6 +3756,15 @@
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
+    },
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -7883,6 +7897,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ienoopen": {
       "version": "1.1.0",
@@ -13520,6 +13539,7 @@
     "unmock-browser": {
       "version": "file:packages/unmock-browser",
       "requires": {
+        "buffer": "^5.4.3",
         "unmock-core": "file:packages/unmock-core",
         "unmock-fetch": "file:packages/unmock-fetch"
       }

--- a/packages/unmock-browser/package.json
+++ b/packages/unmock-browser/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
+    "buffer": "^5.4.3",
     "unmock-core": "file:../unmock-core",
     "unmock-fetch": "file:../unmock-fetch"
   }

--- a/packages/unmock-browser/src/index.ts
+++ b/packages/unmock-browser/src/index.ts
@@ -1,6 +1,14 @@
 import { UnmockPackage } from "unmock-core";
 import RnBackend from "./backend";
 
+/**
+ * Polyfill Buffer if undefined, required by URL operations
+ * https://github.com/unmock/unmock-js/pull/359
+ */
+if (typeof Buffer === "undefined") {
+  global.Buffer = require("buffer").Buffer; // tslint:disable-line:no-var-requires
+}
+
 export const unmock = new UnmockPackage(new RnBackend());
 
 export const nock = unmock.nock.bind(unmock);

--- a/packages/unmock/src/browser/index.ts
+++ b/packages/unmock/src/browser/index.ts
@@ -1,9 +1,3 @@
-/**
- * Polyfill Buffer if undefined, required by URL operations
- */
-if (typeof Buffer === "undefined") {
-  global.Buffer = require("buffer").Buffer; // tslint:disable-line:no-var-requires
-}
 export * from "unmock-core";
 import unmock from "unmock-browser";
 export * from "unmock-browser";

--- a/packages/unmock/src/browser/index.ts
+++ b/packages/unmock/src/browser/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Polyfill Buffer if undefined, required by URL operations
+ */
+if (typeof Buffer === "undefined") {
+  global.Buffer = require("buffer").Buffer; // tslint:disable-line:no-var-requires
+}
 export * from "unmock-core";
 import unmock from "unmock-browser";
 export * from "unmock-browser";


### PR DESCRIPTION
Getting `unmock` run in React Native (https://github.com/unmock/unmock-react-native-example/pull/3) requires polyfilling `Buffer` as we depend on that somewhere via `whatwg-url`. Messing with `global` is not nice at all but I think this is the easiest solution for now to get browser support move forward.