### PR TITLE
Use custom json schema faker.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2363,6 +2363,34 @@
         "write-file-atomic": "^2.3.0"
       }
     },
+    "@meeshkanml/json-schema-faker": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@meeshkanml/json-schema-faker/-/json-schema-faker-0.0.1.tgz",
+      "integrity": "sha512-KFVv4udZITeR97+9SnkWXZLR/7TKV3bS5A6hAc5UUH2WFv+MQDKbib77Le9Btdnkdk7IwbOa9KrBJXIZb/aKSw==",
+      "requires": {
+        "@meeshkanml/json-schema-ref-parser": "0.0.0",
+        "jsonpath-plus": "^1.0.0",
+        "randexp": "^0.5.3"
+      }
+    },
+    "@meeshkanml/json-schema-ref-parser": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@meeshkanml/json-schema-ref-parser/-/json-schema-ref-parser-0.0.0.tgz",
+      "integrity": "sha512-NI+0dbUzllLPHVS5rbF9e7qUp9pbkbHn5uMAHmBy43CvGD5EfkTQTRjBB2wE5lSv5eLXICVNC4sZGPU9vLTt5g==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1",
+        "ono": "^5.1.0",
+        "url": "^0.11.0"
+      },
+      "dependencies": {
+        "ono": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
+          "integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
+        }
+      }
+    },
     "@meeshkanml/jsonschema": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@meeshkanml/jsonschema/-/jsonschema-0.0.1.tgz",
@@ -6239,11 +6267,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
-    },
     "formidable": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
@@ -9338,26 +9361,6 @@
         "valid-url": "~1.0.9"
       }
     },
-    "json-schema-faker": {
-      "version": "0.5.0-rc19",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rc19.tgz",
-      "integrity": "sha512-yJLDodgoc/BOONGFmyuKoj3bSRXZ55FWIp1WjN0yC76kfoIz+lI5ttjUtU8NxgNULGFppJzpUM0ydyAWH3qp7A==",
-      "requires": {
-        "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^1.0.0",
-        "randexp": "^0.5.3"
-      }
-    },
-    "json-schema-ref-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.12.1",
-        "ono": "^4.0.11"
-      }
-    },
     "json-schema-strictly-typed": {
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/json-schema-strictly-typed/-/json-schema-strictly-typed-0.0.14.tgz",
@@ -10850,14 +10853,6 @@
         }
       }
     },
-    "ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "requires": {
-        "format-util": "^1.0.3"
-      }
-    },
     "openapi-refinements": {
       "version": "file:packages/openapi-refinements",
       "requires": {
@@ -11502,6 +11497,11 @@
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystringify": {
       "version": "2.1.1",
@@ -13559,6 +13559,7 @@
     "unmock-core": {
       "version": "file:packages/unmock-core",
       "requires": {
+        "@meeshkanml/json-schema-faker": "^0.0.1",
         "@meeshkanml/jsonschema": "^0.0.1",
         "@types/sinon": "^7.0.13",
         "@types/whatwg-url": "^6.4.0",
@@ -13573,7 +13574,6 @@
         "io-ts": "^2.0.1",
         "json-pointer": "^0.6.0",
         "json-schema-deref-sync": "^0.10.1",
-        "json-schema-faker": "^0.5.0-rc17",
         "json-schema-poet": "0.0.9",
         "json-schema-strictly-typed": "0.0.14",
         "loas3": "^0.1.4",
@@ -13863,6 +13863,22 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
     },
     "url-parse": {
       "version": "1.4.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13559,7 +13559,7 @@
     "unmock-core": {
       "version": "file:packages/unmock-core",
       "requires": {
-        "@meeshkanml/json-schema-faker": "^0.0.1",
+        "@meeshkanml/json-schema-faker": "^0.0.2",
         "@meeshkanml/jsonschema": "^0.0.1",
         "@types/sinon": "^7.0.13",
         "@types/whatwg-url": "^6.4.0",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@meeshkanml/jsonschema": "^0.0.1",
-    "@meeshkanml/json-schema-faker": "^0.0.1",
+    "@meeshkanml/json-schema-faker": "^0.0.2",
     "@types/sinon": "^7.0.13",
     "@types/whatwg-url": "^6.4.0",
     "ajv": "^6.10.0",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@meeshkanml/jsonschema": "^0.0.1",
+    "@meeshkanml/json-schema-faker": "^0.0.1",
     "@types/sinon": "^7.0.13",
     "@types/whatwg-url": "^6.4.0",
     "ajv": "^6.10.0",
@@ -27,7 +28,6 @@
     "io-ts": "^2.0.1",
     "json-pointer": "^0.6.0",
     "json-schema-deref-sync": "^0.10.1",
-    "json-schema-faker": "^0.5.0-rc17",
     "json-schema-poet": "0.0.9",
     "json-schema-strictly-typed": "0.0.14",
     "loas3": "^0.1.4",

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -1,11 +1,14 @@
 /**
  * Implements the logic for generating a response from a service file
  */
-// @ts-ignore  // No type definitions for json-schema-faker :/
+// No type definitions for json-schema-faker :/
+// @ts-ignore
 import jsfRequire = require("@meeshkanml/json-schema-faker");
 // Use default import if exists. Seems that default is needed in browser but
 // not available in Node.js/React Native.
-const jsf = jsfRequire.hasOwnProperty("default") ? jsfRequire.default : jsfRequire;
+const jsf = jsfRequire.hasOwnProperty("default")
+  ? jsfRequire.default
+  : jsfRequire;
 import * as jsonschema from "@meeshkanml/jsonschema";
 import { array } from "fp-ts/lib/Array";
 import { fold, isNone, none, Option, some } from "fp-ts/lib/Option";

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -2,7 +2,6 @@
  * Implements the logic for generating a response from a service file
  */
 import * as jsonschema from "@meeshkanml/jsonschema";
-// Try fixing broken imports in Node <= 8 by using require instead of default import
 const jsf = require("@meeshkanml/json-schema-faker"); // tslint:disable-line:no-var-requires
 import { array } from "fp-ts/lib/Array";
 import { fold, isNone, none, Option, some } from "fp-ts/lib/Option";

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -1,8 +1,12 @@
 /**
  * Implements the logic for generating a response from a service file
  */
+// @ts-ignore  // No type definitions for json-schema-faker :/
+import jsfRequire = require("@meeshkanml/json-schema-faker");
+// Use default import if exists. Seems that default is needed in browser but
+// not available in Node.js/React Native.
+const jsf = jsfRequire.hasOwnProperty("default") ? jsfRequire.default : jsfRequire;
 import * as jsonschema from "@meeshkanml/jsonschema";
-const jsf = require("@meeshkanml/json-schema-faker"); // tslint:disable-line:no-var-requires
 import { array } from "fp-ts/lib/Array";
 import { fold, isNone, none, Option, some } from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/pipeable";

--- a/packages/unmock-core/src/generator.ts
+++ b/packages/unmock-core/src/generator.ts
@@ -3,7 +3,7 @@
  */
 import * as jsonschema from "@meeshkanml/jsonschema";
 // Try fixing broken imports in Node <= 8 by using require instead of default import
-const jsf = require("json-schema-faker"); // tslint:disable-line:no-var-requires
+const jsf = require("@meeshkanml/json-schema-faker"); // tslint:disable-line:no-var-requires
 import { array } from "fp-ts/lib/Array";
 import { fold, isNone, none, Option, some } from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/pipeable";


### PR DESCRIPTION
- Allows using unmock in React Native (https://github.com/unmock/unmock-react-native-example/pull/3)
- Use [@meeshkanml/json-schema-faker](https://www.npmjs.com/package/@meeshkanml/json-schema-faker) from the [unmock branch of json-schema-faker fork](https://github.com/unmock/json-schema-faker/tree/unmock)
- The custom fork adds (1) `react-native` field pointing to `dist/index.js` instead of the browser build and (2) custom `json-schema-ref-parser` [excluding](https://github.com/unmock/json-schema-ref-parser/pull/1) `http` and `https` in the browser build
- Update the import of json-schema-faker to use the `default` if available. This approach seems to be the only way to get `jsf` is of correct type in Node.js, browser, and React Native. There could be something wrong with the json-schema-faker builds but I'd rather not start hacking those now.