### PR TITLE
Rename faker.fake() to faker.generate(), add IFaker interface.

### DIFF
--- a/packages/unmock-core/src/__tests__/faker.test.ts
+++ b/packages/unmock-core/src/__tests__/faker.test.ts
@@ -24,7 +24,7 @@ describe("UnmockFaker", () => {
         .nock("https://foo.com")
         .get("/foo")
         .reply(200, { foo: u.string() });
-      const res = faker.fake({
+      const res = faker.generate({
         host: "foo.com",
         protocol: "https",
         method: "get",

--- a/packages/unmock-core/src/backend/index.ts
+++ b/packages/unmock-core/src/backend/index.ts
@@ -126,8 +126,8 @@ export class Backend {
      */
     this.faker.setOptions(options);
 
-    this.handleRequest = buildRequestHandler(
-      this.faker.createResponse.bind(this.faker),
+    this.handleRequest = buildRequestHandler((req: ISerializedRequest) =>
+      this.faker.createResponse(req),
     );
 
     this.interceptor = this.interceptorFactory({

--- a/packages/unmock-core/src/faker/index.ts
+++ b/packages/unmock-core/src/faker/index.ts
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 import { responseCreatorFactory } from "../generator";
 import {
   CreateResponse,
+  IFaker,
   IListener,
   ISerializedRequest,
   ISerializedResponse,
@@ -27,7 +28,7 @@ const DEFAULT_OPTIONS: IUnmockOptions = {
   log: (__: string) => {}, // tslint:disable-line:no-empty
 };
 
-export default class UnmockFaker {
+export default class UnmockFaker implements IFaker {
   public createResponse: CreateResponse;
   /**
    * Add a new service to the faker using `nock` syntax.
@@ -63,12 +64,12 @@ export default class UnmockFaker {
   }
 
   /**
-   * Fake a response to a request.
+   * Generate a fake response to a request.
    * @param request Serialized request.
    * @throws Error if no matcher was found for the request.
    * @returns Serialized response.
    */
-  public fake(request: ISerializedRequest): ISerializedResponse {
+  public generate(request: ISerializedRequest): ISerializedResponse {
     return this.createResponse(request);
   }
 

--- a/packages/unmock-core/src/interfaces.ts
+++ b/packages/unmock-core/src/interfaces.ts
@@ -1,6 +1,10 @@
 import { OpenAPIObject, ServiceStoreType } from "./service/interfaces";
 import { AllowedHosts } from "./settings/allowedHosts";
 
+export interface IFaker {
+  generate: CreateResponse;
+}
+
 export interface IServiceDefLoader {
   loadSync(): IServiceDef[];
 }


### PR DESCRIPTION
- It feels silly to write `faker.fake(req)`, `generate()` seems easier to understand
- Add `IFaker` interface, I think for example `unmock-fetch` could be changed to also consume an `IFaker` instead of accepting `CreateResponse`.