### PR TITLE
Rename faker creation, export UnmockFaker.

### DIFF
--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -17,6 +17,7 @@ export { IService } from "./service/interfaces";
 export { ServiceCore } from "./service/serviceCore";
 export { Backend, buildRequestHandler };
 export { typeUtils };
+export { UnmockFaker };
 
 export class UnmockPackage implements IUnmockPackage {
   public allowedHosts: AllowedHosts;
@@ -50,7 +51,7 @@ export class UnmockPackage implements IUnmockPackage {
     this.nock = addFromNock(this.backend.serviceStore);
   }
 
-  public newFaker(): UnmockFaker {
+  public faker(): UnmockFaker {
     return new UnmockFaker({ serviceStore: new ServiceStore([]) });
   }
 

--- a/packages/unmock-core/src/index.ts
+++ b/packages/unmock-core/src/index.ts
@@ -51,6 +51,26 @@ export class UnmockPackage implements IUnmockPackage {
     this.nock = addFromNock(this.backend.serviceStore);
   }
 
+  /**
+   * Create a new `UnmockFaker` with empty `ServiceStore`.
+   *
+   * @example
+   *
+   * const faker = unmock.faker();
+   * faker
+   *  .nock('https://api.github.com', 'github')
+   *  .get('/v1/users')
+   *  .reply({ id: '1' });
+   * const req: ISerializedRequest = {
+   *  host: "api.github.com",
+   *  path: '/v1/users',
+   *  protocol: 'https',
+   *  ...
+   * };
+   * const res = faker.generate(request);
+   *
+   * @returns UnmockFaker instance
+   */
   public faker(): UnmockFaker {
     return new UnmockFaker({ serviceStore: new ServiceStore([]) });
   }


### PR DESCRIPTION
- `unmock.newFaker()` is too long, `unmock.faker()` says the same
- The class should also be exported so one can do, for example 
```ts
import unmock, { UnmockFaker } from "unmock";
const faker: UnmockFaker = unmock.faker()
```