### PR TITLE
Release v0.3.11

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,24 @@
 # CHANGELOG.md
 
+## 0.3.11 (2019-12-19)
+
+Breaking changes:
+
+  - Rename `fake()` to `generate()`
+  - Rename `unmock.newFaker()` to `unmock.faker()`
+
+Features:
+
+  - Add CLI to `unmock-server`
+  - Add `unmock-browser` package, which runs `unmock-js` in browser and React Native
+  - Implement parsing of request headers in `unmock-fetch`
+  - Add `unmock-types` package
+  - Extract `UnmockFaker` class from `Backend` class
+
+Fixes:
+
+  - Remove `concurrently` dependency
+
 ## 0.3.10 (2019-11-4)
 
 Features:

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,6 @@
 
 ## 0.3.11 (2019-12-19)
 
-Breaking changes:
-
-  - Rename `fake()` to `generate()`
-  - Rename `unmock.newFaker()` to `unmock.faker()`
-
 Features:
 
   - Add CLI to `unmock-server`
@@ -14,6 +9,7 @@ Features:
   - Implement parsing of request headers in `unmock-fetch`
   - Add `unmock-types` package
   - Extract `UnmockFaker` class from `Backend` class
+  - Rename `unmock.newFaker()` to `unmock.faker()`
 
 Fixes:
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/**"
   ],
-  "version": "0.3.10"
+  "version": "0.3.11"
 }

--- a/packages/openapi-refinements/package.json
+++ b/packages/openapi-refinements/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "openapi-refinements",
   "displayName": "openapi-refinements",
   "main": "dist/index.js",

--- a/packages/unmock-browser/package.json
+++ b/packages/unmock-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unmock-browser",
-  "version": "0.3.8",
+  "version": "0.3.11",
   "description": "Unmock for browser and React Native",
   "keywords": [
     "unmock",

--- a/packages/unmock-cli/package.json
+++ b/packages/unmock-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock-cli",
   "displayName": "unmock-cli",
   "license": "MIT",

--- a/packages/unmock-core/package.json
+++ b/packages/unmock-core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock-core",
   "displayName": "unmock-core",
   "main": "dist/index.js",
@@ -13,8 +13,8 @@
     "url": "https://github.com/unmock/unmock-js/issues"
   },
   "dependencies": {
-    "@meeshkanml/jsonschema": "^0.0.1",
     "@meeshkanml/json-schema-faker": "^0.0.2",
+    "@meeshkanml/jsonschema": "^0.0.1",
     "@types/sinon": "^7.0.13",
     "@types/whatwg-url": "^6.4.0",
     "ajv": "^6.10.0",

--- a/packages/unmock-fetch/package.json
+++ b/packages/unmock-fetch/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock-fetch",
   "displayName": "unmock-fetch",
   "main": "dist/index.js",

--- a/packages/unmock-jest/package.json
+++ b/packages/unmock-jest/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock-jest",
   "displayName": "unmock-jest",
   "main": "dist/index.js",

--- a/packages/unmock-node/package.json
+++ b/packages/unmock-node/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock-node",
   "displayName": "unmock-node",
   "main": "dist/index.js",

--- a/packages/unmock-server/package.json
+++ b/packages/unmock-server/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock-server",
   "displayName": "unmock-server",
   "main": "dist/index.js",

--- a/packages/unmock-types/package.json
+++ b/packages/unmock-types/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock-types",
   "displayName": "unmock-types",
   "main": "dist/index.js",

--- a/packages/unmock/package.json
+++ b/packages/unmock/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "name": "unmock",
   "displayName": "unmock",
   "license": "MIT",


### PR DESCRIPTION
Features:

  - Add CLI to `unmock-server`
  - Add `unmock-browser` package, which runs `unmock-js` in browser and React Native
  - Implement parsing of request headers in `unmock-fetch`
  - Add `unmock-types` package
  - Extract `UnmockFaker` class from `Backend` class
  - Rename `unmock.newFaker()` to `unmock.faker()`

Fixes:

  - Remove `concurrently` dependency