### PR TITLE
Add stop command to unmock-server.

### DIFF
--- a/packages/unmock-server/package.json
+++ b/packages/unmock-server/package.json
@@ -31,6 +31,7 @@
     "express": "^4.17.1",
     "helmet": "^3.21.1",
     "http-proxy": "^1.18.0",
+    "mkdirp": "^0.5.1",
     "node-forge": "^0.9.1",
     "unmock-core": "file:../unmock-core",
     "unmock-node": "file:../unmock-node"

--- a/packages/unmock-server/src/__tests__/pid.test.ts
+++ b/packages/unmock-server/src/__tests__/pid.test.ts
@@ -1,15 +1,15 @@
 import * as path from "path";
 import { deletePidFile, readPidIfExists, writePid } from "../pid";
 
-const localConfigDirectory = path.resolve(__dirname, ".unmock");
+const LOCAL_CONFIG_DIRECTORY = path.resolve(__dirname, ".unmock");
 
 afterEach(() => {
-  deletePidFile();
+  deletePidFile(LOCAL_CONFIG_DIRECTORY);
 });
 
 it("should write process PID to given file and read it", () => {
   const pid = process.pid;
-  writePid(localConfigDirectory);
-  const writtenPid = readPidIfExists(localConfigDirectory);
+  writePid(LOCAL_CONFIG_DIRECTORY);
+  const writtenPid = readPidIfExists(LOCAL_CONFIG_DIRECTORY);
   expect(writtenPid).toBe(pid);
 });

--- a/packages/unmock-server/src/__tests__/pid.test.ts
+++ b/packages/unmock-server/src/__tests__/pid.test.ts
@@ -4,12 +4,12 @@ import { deletePidFile, readPidIfExists, writePid } from "../pid";
 const localConfigDirectory = path.resolve(__dirname, ".unmock");
 
 afterEach(() => {
-    deletePidFile();
+  deletePidFile();
 });
 
 it("should write process PID to given file and read it", () => {
-    const pid = process.pid;
-    writePid(localConfigDirectory);
-    const writtenPid = readPidIfExists(localConfigDirectory);
-    expect(writtenPid).toBe(pid);
+  const pid = process.pid;
+  writePid(localConfigDirectory);
+  const writtenPid = readPidIfExists(localConfigDirectory);
+  expect(writtenPid).toBe(pid);
 });

--- a/packages/unmock-server/src/__tests__/pid.test.ts
+++ b/packages/unmock-server/src/__tests__/pid.test.ts
@@ -1,0 +1,15 @@
+import * as path from "path";
+import { deletePidFile, readPidIfExists, writePid } from "../pid";
+
+const localConfigDirectory = path.resolve(__dirname, ".unmock");
+
+afterEach(() => {
+    deletePidFile();
+});
+
+it("should write process PID to given file and read it", () => {
+    const pid = process.pid;
+    writePid(localConfigDirectory);
+    const writtenPid = readPidIfExists(localConfigDirectory);
+    expect(writtenPid).toBe(pid);
+});

--- a/packages/unmock-server/src/commands/start.ts
+++ b/packages/unmock-server/src/commands/start.ts
@@ -1,6 +1,10 @@
 import { Command, flags } from "@oclif/command";
+import debug from "debug";
+import { writePid } from "../pid";
 import { startProxy } from "../proxy";
 import { buildApp, startServer } from "../server";
+
+const debugLog = debug("unmock-server:start");
 
 export default class Start extends Command {
   public static description = "Start unmock server and proxy";
@@ -17,10 +21,23 @@ export default class Start extends Command {
   public static args = [];
 
   public async run() {
+    debugLog('Starting.');
     const run = () => {
       const { app } = buildApp();
-      startServer(app);
-      startProxy();
+      const [httpServer, httpsServer] = startServer(app);
+      const proxyServer = startProxy();
+
+      const sigTermHandler = () => {
+        debugLog('Received SIGTERM. Stopping servers.');
+        httpServer.close();
+        httpsServer.close();
+        proxyServer.close();
+        debugLog('Servers closed.');
+      }
+
+      process.on('SIGTERM', sigTermHandler);
+      debugLog("Writing PID to file for closing...");
+      writePid();
     };
     run();
   }

--- a/packages/unmock-server/src/commands/start.ts
+++ b/packages/unmock-server/src/commands/start.ts
@@ -21,21 +21,21 @@ export default class Start extends Command {
   public static args = [];
 
   public async run() {
-    debugLog('Starting.');
+    debugLog("Starting.");
     const run = () => {
       const { app } = buildApp();
       const [httpServer, httpsServer] = startServer(app);
       const proxyServer = startProxy();
 
       const sigTermHandler = () => {
-        debugLog('Received SIGTERM. Stopping servers.');
+        debugLog("Received SIGTERM. Stopping servers.");
         httpServer.close();
         httpsServer.close();
         proxyServer.close();
-        debugLog('Servers closed.');
-      }
+        debugLog("Servers closed.");
+      };
 
-      process.on('SIGTERM', sigTermHandler);
+      process.on("SIGTERM", sigTermHandler);
       debugLog("Writing PID to file for closing...");
       writePid();
     };

--- a/packages/unmock-server/src/commands/start.ts
+++ b/packages/unmock-server/src/commands/start.ts
@@ -11,15 +11,12 @@ const log = (...args: any[]) => console.log(...args); // tslint:disable-line
 const addCleanUp = (callback: () => void) => {
   process.on("exit", callback);
 
-  process.on("SIGINT", () => {
-    process.exit(2);
-  });
-
   process.on("uncaughtException", e => {
     log("Uncaught exception: %s", e.stack);
     process.exit(99);
   });
 
+  process.on("SIGINT", () => process.exit(2));
   process.on("SIGTERM", () => process.exit(2));
 };
 

--- a/packages/unmock-server/src/commands/stop.ts
+++ b/packages/unmock-server/src/commands/stop.ts
@@ -26,15 +26,15 @@ export default class Stop extends Command {
     const pidOrNull = readPidIfExists();
 
     if (pidOrNull === null) {
-        log("Server not running.")
-        return;
+      log("Server not running.");
+      return;
     }
 
     try {
-        process.kill(pidOrNull, 0);
+      process.kill(pidOrNull, 0);
     } catch (ex) {
-        log("Server not running.");
-        return;
+      log("Server not running.");
+      return;
     }
 
     debugLog("Sending %s to PID %d", TERM_SIGNAL, pidOrNull);

--- a/packages/unmock-server/src/commands/stop.ts
+++ b/packages/unmock-server/src/commands/stop.ts
@@ -1,6 +1,6 @@
 import { Command, flags } from "@oclif/command";
 import debug from "debug";
-import { deletePidFile, readPidIfExists, TERM_SIGNAL } from "../pid";
+import { readPidIfExists, TERM_SIGNAL } from "../pid";
 
 const debugLog = debug("unmock-server:stop");
 const log = (...args: any[]) => console.log(...args); // tslint:disable-line
@@ -40,7 +40,5 @@ export default class Stop extends Command {
     debugLog("Sending %s to PID %d", TERM_SIGNAL, pidOrNull);
     process.kill(pidOrNull, TERM_SIGNAL);
     log("Server stopped.");
-
-    deletePidFile();
   }
 }

--- a/packages/unmock-server/src/commands/stop.ts
+++ b/packages/unmock-server/src/commands/stop.ts
@@ -1,0 +1,46 @@
+import { Command, flags } from "@oclif/command";
+import debug from "debug";
+import { deletePidFile, readPidIfExists, TERM_SIGNAL } from "../pid";
+
+const debugLog = debug("unmock-server:stop");
+const log = (...args: any[]) => console.log(...args); // tslint:disable-line
+
+export default class Stop extends Command {
+  public static description = "Stop unmock server and proxy.";
+
+  public static examples = [
+    `$ unmock-server stop
+`,
+  ];
+
+  public static flags = {
+    help: flags.help({ char: "h" }),
+  };
+
+  public static args = [];
+
+  /**
+   * Server process is stopped by sending a SIGTERM to the process PID written to the file-system.
+   */
+  public async run() {
+    const pidOrNull = readPidIfExists();
+
+    if (pidOrNull === null) {
+        log("Server not running.")
+        return;
+    }
+
+    try {
+        process.kill(pidOrNull, 0);
+    } catch (ex) {
+        log("Server not running.");
+        return;
+    }
+
+    debugLog("Sending %s to PID %d", TERM_SIGNAL, pidOrNull);
+    process.kill(pidOrNull, TERM_SIGNAL);
+    log("Server stopped.");
+
+    deletePidFile();
+  }
+}

--- a/packages/unmock-server/src/pid.ts
+++ b/packages/unmock-server/src/pid.ts
@@ -1,0 +1,65 @@
+/* Code for saving process PID into local file system.*/
+import debug from "debug";
+import * as fs from "fs";
+import * as mkdirp from "mkdirp";
+import * as os from "os";
+import * as path from "path";
+
+const debugLog = debug("unmock-server:pid");
+
+export const DEFAULT_CONFIG_DIRECTORY = path.resolve(
+    os.homedir(),
+    ".unmock"
+);
+
+// Signal used for terminating process
+export const TERM_SIGNAL = "SIGTERM";
+
+export const PID_FILENAME = 'server.pid';
+
+const ensureDirExists = (directory: string) => {
+    if (!fs.existsSync(directory)) {
+      debugLog(`Creating directory: ${directory}`);
+      return mkdirp.sync(directory);
+    }
+
+    if (!fs.lstatSync(directory).isDirectory()) {
+      throw Error(`Destination exists but is not directory: ${directory}`);
+    }
+
+    debugLog(`Directory exists: ${directory}`);
+
+    return;
+};
+
+export const writePid = (directory = DEFAULT_CONFIG_DIRECTORY) => {
+    const pid = process.pid;
+
+    ensureDirExists(directory);
+
+    const pidFile = path.join(directory, PID_FILENAME);
+    debugLog("Writing pid (%d) to %s", pid, pidFile)
+    fs.writeFileSync(pidFile, pid);
+};
+
+export const readPidIfExists = (directory = DEFAULT_CONFIG_DIRECTORY): number | null => {
+    const pidFile = path.join(directory, PID_FILENAME);
+    if (!fs.existsSync(pidFile)) {
+        debugLog("File not found: %s", pidFile);
+        return null;
+    }
+
+    const contents = fs.readFileSync(pidFile).toString();
+
+    return parseInt(contents, 10);
+}
+
+export const deletePidFile = (directory = DEFAULT_CONFIG_DIRECTORY): void => {
+    const pidFile = path.join(directory, PID_FILENAME);
+    if (!fs.existsSync(pidFile)) {
+        debugLog("File not found: %s", pidFile);
+        return;
+    }
+    debugLog("Deleting file %s.", pidFile);
+    fs.unlinkSync(pidFile);
+}

--- a/packages/unmock-server/src/pid.ts
+++ b/packages/unmock-server/src/pid.ts
@@ -7,59 +7,58 @@ import * as path from "path";
 
 const debugLog = debug("unmock-server:pid");
 
-export const DEFAULT_CONFIG_DIRECTORY = path.resolve(
-    os.homedir(),
-    ".unmock"
-);
+export const DEFAULT_CONFIG_DIRECTORY = path.resolve(os.homedir(), ".unmock");
 
 // Signal used for terminating process
 export const TERM_SIGNAL = "SIGTERM";
 
-export const PID_FILENAME = 'server.pid';
+export const PID_FILENAME = "server.pid";
 
 const ensureDirExists = (directory: string) => {
-    if (!fs.existsSync(directory)) {
-      debugLog(`Creating directory: ${directory}`);
-      return mkdirp.sync(directory);
-    }
+  if (!fs.existsSync(directory)) {
+    debugLog(`Creating directory: ${directory}`);
+    return mkdirp.sync(directory);
+  }
 
-    if (!fs.lstatSync(directory).isDirectory()) {
-      throw Error(`Destination exists but is not directory: ${directory}`);
-    }
+  if (!fs.lstatSync(directory).isDirectory()) {
+    throw Error(`Destination exists but is not directory: ${directory}`);
+  }
 
-    debugLog(`Directory exists: ${directory}`);
+  debugLog(`Directory exists: ${directory}`);
 
-    return;
+  return;
 };
 
 export const writePid = (directory = DEFAULT_CONFIG_DIRECTORY) => {
-    const pid = process.pid;
+  const pid = process.pid;
 
-    ensureDirExists(directory);
+  ensureDirExists(directory);
 
-    const pidFile = path.join(directory, PID_FILENAME);
-    debugLog("Writing pid (%d) to %s", pid, pidFile)
-    fs.writeFileSync(pidFile, pid);
+  const pidFile = path.join(directory, PID_FILENAME);
+  debugLog("Writing pid (%d) to %s", pid, pidFile);
+  fs.writeFileSync(pidFile, pid);
 };
 
-export const readPidIfExists = (directory = DEFAULT_CONFIG_DIRECTORY): number | null => {
-    const pidFile = path.join(directory, PID_FILENAME);
-    if (!fs.existsSync(pidFile)) {
-        debugLog("File not found: %s", pidFile);
-        return null;
-    }
+export const readPidIfExists = (
+  directory = DEFAULT_CONFIG_DIRECTORY,
+): number | null => {
+  const pidFile = path.join(directory, PID_FILENAME);
+  if (!fs.existsSync(pidFile)) {
+    debugLog("File not found: %s", pidFile);
+    return null;
+  }
 
-    const contents = fs.readFileSync(pidFile).toString();
+  const contents = fs.readFileSync(pidFile).toString();
 
-    return parseInt(contents, 10);
-}
+  return parseInt(contents, 10);
+};
 
 export const deletePidFile = (directory = DEFAULT_CONFIG_DIRECTORY): void => {
-    const pidFile = path.join(directory, PID_FILENAME);
-    if (!fs.existsSync(pidFile)) {
-        debugLog("File not found: %s", pidFile);
-        return;
-    }
-    debugLog("Deleting file %s.", pidFile);
-    fs.unlinkSync(pidFile);
-}
+  const pidFile = path.join(directory, PID_FILENAME);
+  if (!fs.existsSync(pidFile)) {
+    debugLog("File not found: %s", pidFile);
+    return;
+  }
+  debugLog("Deleting file %s.", pidFile);
+  fs.unlinkSync(pidFile);
+};

--- a/packages/unmock-server/src/server.ts
+++ b/packages/unmock-server/src/server.ts
@@ -147,4 +147,6 @@ export const startServer = (app: express.Express) => {
   httpsServer.listen(httpsPort, () => {
     log("HTTPS server starting on port: " + httpsPort);
   });
+
+  return [httpServer, httpsServer];
 };


### PR DESCRIPTION
- Add `unmock-server stop` command
- Works by writing process PID to `~/.unmock/server.pid` to file when unmock server is started and adding a SIGTERM handler. Stop command then reads the file and sends SIGTERM to the process. 
- Alternative would be to add an endpoint in the servers such as "/stop" but implementing that is not the easiest thing for the proxy server. Or should one add an `/api/stop` endpoint in the mock server and also stop the proxy server there, coupling the two?
- Could something go wrong if the PID in `server.pid` points to the wrong process? This should not happen if `start` command gets to do its clean-up properly (defined in `process.exit` handler)